### PR TITLE
ops/compiler: refactoring OPSCompiler

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,7 +63,7 @@ matrix:
           packages:
             - gcc-7
             - g++-7
-      env: DEVITO_ARCH=gcc-7 DEVITO_OPENMP=0 DEVITO_BACKEND=ops YC_CXX=g++-7 INSTALL_TYPE=conda RUN_EXAMPLES=False MPI_INSTALL=0
+      env: DEVITO_ARCH=gcc-7 DEVITO_OPENMP=0 DEVITO_BACKEND=ops YC_CXX=g++-7 INSTALL_TYPE=conda RUN_EXAMPLES=False MPI_INSTALL=0 OPS_COMPILER=gnu OPS_INSTALL_PATH=$HOME/build/opesci/OPS/ops
 
 addons:
   apt:
@@ -108,6 +108,10 @@ before_script:
       conda install swig; cd ../;
       git clone https://github.com/opesci/yask.git;
       cd yask; make compiler-api; pip install -e .; cd ../devito;
+    elif [[ $DEVITO_BACKEND == 'ops' ]]; then
+      cd ../;
+      git clone https://github.com/opesci/OPS.git;
+      cd OPS/ops/c; make; cd ../../../devito;
     fi
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,7 +63,7 @@ matrix:
           packages:
             - gcc-7
             - g++-7
-      env: DEVITO_ARCH=gcc-7 DEVITO_OPENMP=0 DEVITO_BACKEND=ops INSTALL_TYPE=conda RUN_EXAMPLES=False MPI_INSTALL=0 OPS_COMPILER=gnu OPS_INSTALL_PATH=$HOME/build/opesci/OPS/ops
+      env: DEVITO_ARCH=gcc-7 DEVITO_OPENMP=0 DEVITO_BACKEND=ops INSTALL_TYPE=conda RUN_EXAMPLES=False MPI_INSTALL=0 OPS_COMPILER=gnu OPS_INSTALL_PATH=$HOME/opesci/OPS/ops
 
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,7 +63,7 @@ matrix:
           packages:
             - gcc-7
             - g++-7
-      env: DEVITO_ARCH=gcc-7 DEVITO_OPENMP=0 DEVITO_BACKEND=ops YC_CXX=g++-7 INSTALL_TYPE=conda RUN_EXAMPLES=False MPI_INSTALL=0 OPS_COMPILER=gnu OPS_INSTALL_PATH=$HOME/build/opesci/OPS/ops
+      env: DEVITO_ARCH=gcc-7 DEVITO_OPENMP=0 DEVITO_BACKEND=ops INSTALL_TYPE=conda RUN_EXAMPLES=False MPI_INSTALL=0 OPS_COMPILER=gnu OPS_INSTALL_PATH=$HOME/build/opesci/OPS/ops
 
 addons:
   apt:

--- a/Dockerfile.pipelines
+++ b/Dockerfile.pipelines
@@ -35,6 +35,12 @@ ENV testWithPip=$installWithPip
 ARG DEVITO_BACKEND=none
 ENV DEVITO_BACKEND=$DEVITO_BACKEND
 
+# Set OPS variable in case they are needed
+ARG ops_compiler=gnu
+ARG ops_install_path=/tmp/OPS/ops
+ENV OPS_COMPILER=$ops_compiler
+ENV OPS_INSTALL_PATH=$ops_install_path
+
 # Use OpenMP?
 ARG DEVITO_OPENMP=0
 ENV DEVITO_OPENMP=$DEVITO_OPENMP
@@ -129,6 +135,11 @@ RUN if [ $installWithPip == "true" ] ; then \
           make compiler-api ; \
           pip install -e . ; \
         popd ; \
+      elif [ $DEVITO_BACKEND == "ops" ] ; then \
+        git clone https://github.com/opesci/OPS.git /tmp/OPS ; \
+        cd $OPS_INSTALL_PATH/c ; \
+        make ; \
+        cd $HOME ; \
       fi ; \
       if [ $RUN_EXAMPLES == "true" ] ; then \
         bash scripts/create_ipyparallel_mpi_profile.sh; \

--- a/Dockerfile.pipelines
+++ b/Dockerfile.pipelines
@@ -137,9 +137,9 @@ RUN if [ $installWithPip == "true" ] ; then \
         popd ; \
       elif [ $DEVITO_BACKEND == "ops" ] ; then \
         git clone https://github.com/opesci/OPS.git /tmp/OPS ; \
-        cd $OPS_INSTALL_PATH/c ; \
-        make ; \
-        cd $HOME ; \
+        pushd /tmp/OPS/ops/c ; \
+          make ; \
+        popd ; \
       fi ; \
       if [ $RUN_EXAMPLES == "true" ] ; then \
         bash scripts/create_ipyparallel_mpi_profile.sh; \

--- a/devito/ops/__init__.py
+++ b/devito/ops/__init__.py
@@ -13,7 +13,7 @@ modes.add(Cpu64, {'noop': PlatformRewriter,
                   'speculative': PlatformRewriter})
 
 # The following used by backends.backendSelector
-from devito.ops.compiler import CompilerOPS as Compiler # noqa
+from devito.ops.compiler import OPSCompiler as Compiler # noqa
 
 ops_configuration = Parameters('ops')
 ops_configuration.add('compiler', Compiler())

--- a/devito/ops/compiler.py
+++ b/devito/ops/compiler.py
@@ -66,7 +66,9 @@ class CompilerOPS(configuration['compiler'].__class__):
         if self._ops_install_path:
             # Calling OPS Translator
             translator = '%s/../ops_translator/c/ops.py' % (self._ops_install_path)
-            subprocess.run([translator, c_file.name], cwd=self.get_jit_dir())
+            translation = subprocess.run([translator, c_file.name], cwd=self.get_jit_dir())
+            if translation.returncode == 1:
+                raise ValueError("OPS Translation Error")
         else:
             warning("Couldn't find OPS_INSTALL_PATH \
                 environment variable, please check your OPS installation")

--- a/devito/ops/compiler.py
+++ b/devito/ops/compiler.py
@@ -5,7 +5,7 @@ import warnings
 from codepy.jit import compile_from_string
 from devito.logger import warning
 from devito.parameters import configuration
-
+from devito.archinfo import NVIDIAX
 
 __all__ = ['OPSCompiler']
 
@@ -41,9 +41,9 @@ class OPSCompiler(OPSMetaCompiler):
         except FileNotFoundError:
             warning("Couldn't find file: %s" % self.ops_src)
 
-        if configuration['platform'] == 'nvidiaX':
+        if configuration['platform'] is NVIDIAX:
             self._compile(soname)
-        elif configuration['platform'] == 'bdw':
+        elif configuration['platform'] is 'bdw':
             pass
 
     def _translate_ops(self, soname, ccode, hcode):

--- a/devito/ops/compiler.py
+++ b/devito/ops/compiler.py
@@ -22,18 +22,16 @@ class OPSCompiler(OPSMetaCompiler):
     def __init__(self, *args, **kwargs):
         super(OPSCompiler, self).__init__(*args, **kwargs)
 
-    def jit_compile(self, soname, ccode, hcode):
-
         self._ops_install_path = os.environ.get('OPS_INSTALL_PATH')
         if not self._ops_install_path:
             raise ValueError("Couldn't find OPS_INSTALL_PATH\
                 environment variable, please check your OPS installation")
 
-        self._ops_backend = os.environ.get('OPS_BACKEND')
-        if not self._ops_backend:
-            raise ValueError("Couldn't find OPS_BACKEND\
-                environment variable, current options: `seq` or `cuda`")
+        self._devito_platform = os.environ.get('DEVITO_PLATFORM')
+        if not self._devito_platform:
+            self._devito_platform = 'seq'
 
+    def jit_compile(self, soname, ccode, hcode):
         self._translate_ops(soname, ccode, hcode)
         self.ops_src = '%s/%s_ops.cpp' % (self.get_jit_dir(), soname)
         self.cache_dir = self.get_jit_dir()
@@ -47,9 +45,9 @@ class OPSCompiler(OPSMetaCompiler):
         except FileNotFoundError:
             warning("Couldn't find file: %s" % self.ops_src)
 
-        if self._ops_backend == 'cuda':
+        if self._devito_platform == 'nvidiaX':
             OPSCompilerCUDA._compile(self, soname)
-        elif self._ops_backend == 'seq':
+        elif self._devito_platform == 'seq':
             pass
 
     def _translate_ops(self, soname, ccode, hcode):

--- a/devito/ops/compiler.py
+++ b/devito/ops/compiler.py
@@ -43,7 +43,7 @@ class OPSCompiler(OPSMetaCompiler):
 
         if configuration['platform'] is NVIDIAX:
             self._compile(soname)
-        elif configuration['platform'] is 'bdw':
+        elif configuration['platform'] == 'bdw':
             pass
 
     def _translate_ops(self, soname, ccode, hcode):

--- a/devito/ops/operator.py
+++ b/devito/ops/operator.py
@@ -122,13 +122,13 @@ class OperatorOPS(Operator):
         return super()._finalize(iet, parameters)
 
     def _compile(self):
-        if self._should_compile_with_ops:
+        if not self._should_compile_with_ops:
+            super()._compile()
+        else:
             self._compiler = ops_configuration['compiler'].copy()
             self._includes.append('%s.h' % self._soname)
             if self._lib is None:
                 self._compiler.jit_compile(self._soname, str(self.ccode), str(self.hcode))
-        else:
-            super()._compile()
 
     @cached_property
     def time_dimension(self):


### PR DESCRIPTION
- Currently, the OPS Compiler would be called even if there is no affine trees found in the IET. With this PR, if no affine tree is found in the IET, the `_compiler` method should not be overwritten. 

- This PR also refactors OPSCompiler for allowing multiple OPS backend in the future.

- Finally, this PR installs OPS in both azure and travis CI. 
