### PR TITLE
ops: adding RawAccess/RawAccessible

### DIFF
--- a/devito/ops/node_factory.py
+++ b/devito/ops/node_factory.py
@@ -1,9 +1,9 @@
 from collections import defaultdict, OrderedDict
 
-from devito import Constant, TimeFunction
+from devito import TimeFunction
 from devito.types.dimension import SpaceDimension
 from devito.symbolics import split_affine
-from devito.ops.types import OpsAccess, OpsAccessible
+from devito.ops.types import OpsAccess, OpsAccessible, RawAccess, RawAccessible
 from devito.ops.utils import AccessibleInfo
 
 
@@ -69,15 +69,10 @@ class OPSNodeFactory(object):
 
         return OpsAccess(symbol_to_access, space_indices)
 
-    def new_ops_gbl(self, c):
-        if c in self.ops_args:
-            return self.ops_args[c].accessible
+    def new_ops_gbl(self, expr):
+        if expr not in self.ops_args:
+            param = RawAccessible(expr.name, expr.dtype)
+            self.ops_args[expr] = AccessibleInfo(param, None, None, None)
+            self.ops_params.append(param)
 
-        new_c = AccessibleInfo(Constant(name='*%s' % c.name, dtype=c.dtype),
-                               None,
-                               None,
-                               None)
-        self.ops_args[c] = new_c
-        self.ops_params.append(new_c.accessible)
-
-        return new_c.accessible
+        return RawAccess(expr)

--- a/devito/ops/node_factory.py
+++ b/devito/ops/node_factory.py
@@ -71,7 +71,7 @@ class OPSNodeFactory(object):
 
     def new_ops_gbl(self, expr):
         if expr not in self.ops_args:
-            param = RawAccessible(expr.name, expr.dtype)
+            param = RawAccessible(name=expr.name, dtype=expr.dtype)
             self.ops_args[expr] = AccessibleInfo(param, None, None, None)
             self.ops_params.append(param)
 

--- a/devito/ops/transformer.py
+++ b/devito/ops/transformer.py
@@ -271,7 +271,7 @@ def create_ops_arg(p, accessible_origin, name_to_ops_dat, par_to_ops_stencil):
     elements_per_point = 1
     dtype = Literal('"%s"' % dtype_to_cstr(p.dtype))
 
-    if p.is_Constant:
+    if p.is_Scalar:
         ops_type = namespace['ops_arg_gbl']
         ops_name = Byref(Constant(name=p.name[1:]))
         rw_flag = namespace['ops_read']

--- a/devito/ops/transformer.py
+++ b/devito/ops/transformer.py
@@ -37,7 +37,7 @@ def opsit(trees, count, name_to_ops_dat, block, dims):
                        for expr in expressions]
 
     parameters = sorted(node_factory.ops_params,
-                        key=lambda i: (i.is_Constant, i.name))
+                        key=lambda i: (i.is_Scalar, i.name))
 
     stencil_arrays_initializations = []
     par_to_ops_stencil = {}

--- a/devito/ops/types.py
+++ b/devito/ops/types.py
@@ -51,12 +51,6 @@ class RawAccess(basic.Basic, sympy.Basic):
         # other is not NaN, 0, or 1
         return None
 
-    def as_coeff_Mul(self):
-        return sympy.S.One, self
-
-    def as_coeff_Add(self):
-        return sympy.S.Zero, self
-
 
 class OpsAccessible(basic.Symbol):
     """

--- a/devito/ops/types.py
+++ b/devito/ops/types.py
@@ -3,8 +3,10 @@ import sympy
 
 import devito.types.basic as basic
 
-from devito.tools import dtype_to_cstr
+from devito.tools import dtype_to_cstr, ctypes_to_cstr
 from devito.ops.utils import namespace
+
+from ctypes import c_float
 
 
 class Array(basic.Array):
@@ -15,6 +17,34 @@ class Array(basic.Array):
             return self.dtype
 
         return super()._C_typedata
+
+
+class RawAccessible(basic.Symbol):
+    is_Scalar = True
+
+    def __init_finalize__(self, name, read_only=True, **kwargs):
+        self.read_only = read_only
+        super().__init_finalize__(name, **kwargs)
+
+    @property
+    def _C_typename(self):
+        # TODO: can't change self.dtype from __init_finalize__
+        return '%s%s *' % (
+            'const ' if self.read_only else '',
+            ctypes_to_cstr(c_float)
+        )
+
+
+class RawAccess(basic.Basic, sympy.Basic):
+    def __init__(self, base, *args, **kwargs):
+        self.base = base
+        super().__init__(*args, **kwargs)
+
+    def __str__(self):
+        return '(*%s)' % self.base._C_name
+
+    def __repr__(self):
+        return self.base._C_name
 
 
 class OpsAccessible(basic.Symbol):
@@ -30,7 +60,7 @@ class OpsAccessible(basic.Symbol):
         to ``np.float32``.
     """
 
-    is_Scalar = True
+    is_Scalar = False
 
     def __init_finalize__(self, name, read_only=False, **kwargs):
         self.read_only = read_only

--- a/devito/ops/types.py
+++ b/devito/ops/types.py
@@ -46,6 +46,17 @@ class RawAccess(basic.Basic, sympy.Basic):
     def __repr__(self):
         return self.base._C_name
 
+    def _eval_power(self, other):
+        # subclass to compute self**other for cases when
+        # other is not NaN, 0, or 1
+        return None
+
+    def as_coeff_Mul(self):
+        return sympy.S.One, self
+
+    def as_coeff_Add(self):
+        return sympy.S.Zero, self
+
 
 class OpsAccessible(basic.Symbol):
     """
@@ -146,6 +157,9 @@ class OpsAccess(basic.Basic, sympy.Basic):
         return (self,)
 
     __repr__ = __str__
+
+    def as_base_exp(self):
+        return self.args, sympy.S.One
 
 
 class OpsBlock(basic.Symbol):

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -30,13 +30,13 @@ class TestOPSExpression(object):
         ('Eq(u,3*a - 4**a)', 'void OPS_Kernel_0(ACC<float> & ut00)\n'
          '{\n  ut00(0) = -2.97015324253729F;\n}'),
         ('Eq(u, u.dxl)',
-         'void OPS_Kernel_0(const float * h_x, ACC<float> & ut00)\n'
+         'void OPS_Kernel_0(ACC<float> & ut00, const float * h_x)\n'
          '{\n  float r0 = 1.0/(*h_x);\n  '
          'ut00(0) = (-2.0F*ut00(-1) + 5.0e-1F*ut00(-2) + 1.5F*ut00(0))*r0;\n}'),
         ('Eq(v,1)', 'void OPS_Kernel_0(ACC<float> & vt00)\n'
          '{\n  vt00(0, 0) = 1;\n}'),
         ('Eq(v,v.dxl + v.dxr - v.dyr - v.dyl)',
-         'void OPS_Kernel_0(const float * h_x, const float * h_y, ACC<float> & vt00)\n'
+         'void OPS_Kernel_0(ACC<float> & vt00, const float * h_x, const float * h_y)\n'
          '{\n  float r1 = 1.0/(*h_y);\n  float r0 = 1.0/(*h_x);\n  '
          'vt00(0, 0) = (5.0e-1F*(-vt00(2, 0) + vt00(-2, 0)) + 2.0F*(-vt00(-1, 0) + '
          'vt00(1, 0)))*r0 + (5.0e-1F*(-vt00(0, -2) + vt00(0, 2)) + '
@@ -54,8 +54,8 @@ class TestOPSExpression(object):
          'void OPS_Kernel_0(const ACC<float> & ut00, ACC<float> & ut10)\n'
          '{\n  ut10(0) = 1 + ut00(0);\n}'),
         ('Eq(v.forward, v.dt - v.laplace + v.dt)',
-         'void OPS_Kernel_0(const float * dt, const float * h_x, const float * h_y, '
-         'const ACC<float> & vt00, ACC<float> & vt10)\n'
+         'void OPS_Kernel_0(const ACC<float> & vt00, ACC<float> & vt10, '
+         'const float * dt, const float * h_x, const float * h_y)\n'
          '{\n  float r2 = 1.0/(*dt);\n'
          '  float r1 = 1.0/((*h_y)*(*h_y));\n'
          '  float r0 = 1.0/((*h_x)*(*h_x));\n'

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -30,14 +30,14 @@ class TestOPSExpression(object):
         ('Eq(u,3*a - 4**a)', 'void OPS_Kernel_0(ACC<float> & ut00)\n'
          '{\n  ut00(0) = -2.97015324253729F;\n}'),
         ('Eq(u, u.dxl)',
-         'void OPS_Kernel_0(ACC<float> & ut00, const float *h_x)\n'
-         '{\n  float r0 = 1.0/*h_x;\n  '
+         'void OPS_Kernel_0(const float * h_x, ACC<float> & ut00)\n'
+         '{\n  float r0 = 1.0/(*h_x);\n  '
          'ut00(0) = (-2.0F*ut00(-1) + 5.0e-1F*ut00(-2) + 1.5F*ut00(0))*r0;\n}'),
         ('Eq(v,1)', 'void OPS_Kernel_0(ACC<float> & vt00)\n'
          '{\n  vt00(0, 0) = 1;\n}'),
         ('Eq(v,v.dxl + v.dxr - v.dyr - v.dyl)',
-         'void OPS_Kernel_0(ACC<float> & vt00, const float *h_x, const float *h_y)\n'
-         '{\n  float r1 = 1.0/*h_y;\n  float r0 = 1.0/*h_x;\n  '
+         'void OPS_Kernel_0(const float * h_x, const float * h_y, ACC<float> & vt00)\n'
+         '{\n  float r1 = 1.0/(*h_y);\n  float r0 = 1.0/(*h_x);\n  '
          'vt00(0, 0) = (5.0e-1F*(-vt00(2, 0) + vt00(-2, 0)) + 2.0F*(-vt00(-1, 0) + '
          'vt00(1, 0)))*r0 + (5.0e-1F*(-vt00(0, -2) + vt00(0, 2)) + '
          '2.0F*(-vt00(0, 1) + vt00(0, -1)))*r1;\n}'),
@@ -54,11 +54,11 @@ class TestOPSExpression(object):
          'void OPS_Kernel_0(const ACC<float> & ut00, ACC<float> & ut10)\n'
          '{\n  ut10(0) = 1 + ut00(0);\n}'),
         ('Eq(v.forward, v.dt - v.laplace + v.dt)',
-         'void OPS_Kernel_0(const ACC<float> & vt00, ACC<float> & vt10, '
-         'const float *dt, const float *h_x, const float *h_y)\n'
-         '{\n  float r2 = 1.0/*dt;\n'
-         '  float r1 = 1.0/(*h_y**h_y);\n'
-         '  float r0 = 1.0/(*h_x**h_x);\n'
+         'void OPS_Kernel_0(const float * dt, const float * h_x, const float * h_y, '
+         'const ACC<float> & vt00, ACC<float> & vt10)\n'
+         '{\n  float r2 = 1.0/(*dt);\n'
+         '  float r1 = 1.0/((*h_y)*(*h_y));\n'
+         '  float r0 = 1.0/((*h_x)*(*h_x));\n'
          '  vt10(0, 0) = (-(vt00(1, 0) + vt00(-1, 0)) + 2.0F*vt00(0, 0))*r0 + '
          '(-(vt00(0, 1) + vt00(0, -1)) + 2.0F*vt00(0, 0))*r1 + '
          '2*(-vt00(0, 0) + vt10(0, 0))*r2;\n}'),


### PR DESCRIPTION
This PR is an updated version of #1002 .

From #991:
When translating to OPS a division by pointer (like `/*dt`), it would make the rest of the code to be a commentary according to C++ syntax. 
This was solved by encasing the pointer by parenthesis (like `/(*dt)`).

In this PR, requested changes are made upon updated master.