### PR TITLE
Test speedup

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,17 @@
+coverage:
+  precision: 2
+  round: down
+  range: 70...100
+
+  status:
+    # Learn more at http://docs.codecov.io/docs/codecov-yaml
+    project:
+      default:
+        enabled: yes
+        target: auto
+        threshold: 0.1
+    patch:
+      default:
+        enabled: yes
+        target: auto
+        threshold: 0.1

--- a/examples/seismic/preset_models.py
+++ b/examples/seismic/preset_models.py
@@ -203,13 +203,16 @@ def demo_model(preset, **kwargs):
         phi = None
         if len(shape) > 2 and preset.lower() not in ['layers-tti-noazimuth']:
             phi = .25*(v - 1.5)
+
         model = Model(space_order=space_order, vp=v, origin=origin, shape=shape,
                       dtype=dtype, spacing=spacing, nbl=nbl, epsilon=epsilon,
                       delta=delta, theta=theta, phi=phi, **kwargs)
-        if len(shape) > 2 and preset.lower() not in ['layers-tti-noazimuth']:
-            model.smooth(('epsilon', 'delta', 'theta', 'phi'))
-        else:
-            model.smooth(('epsilon', 'delta', 'theta'))
+
+        if kwargs.get('smooth', True):
+            if len(shape) > 2 and preset.lower() not in ['layers-tti-noazimuth']:
+                model.smooth(('epsilon', 'delta', 'theta', 'phi'))
+            else:
+                model.smooth(('epsilon', 'delta', 'theta'))
 
         return model
 

--- a/tests/test_adjoint.py
+++ b/tests/test_adjoint.py
@@ -12,27 +12,27 @@ pytestmark = skipif(['yask', 'ops'])
 
 presets = {
     'constant': {'preset': 'constant-isotropic'},
-    'layers': {'preset': 'layers-isotropic', 'ratio': 3},
+    'layers': {'preset': 'layers-isotropic', 'nlayers': 2},
 }
 
 
 class TestAdjoint(object):
 
-    @pytest.mark.parametrize('mkey, shape, kernel, space_order, nbl', [
+    @pytest.mark.parametrize('mkey, shape, kernel, space_order', [
         # 1 tests with varying time and space orders
-        ('layers', (60, ), 'OT2', 4, 10), ('layers', (60, ), 'OT2', 8, 10),
-        ('layers', (60, ), 'OT4', 4, 10),
+        ('layers', (60, ), 'OT2', 12), ('layers', (60, ), 'OT2', 8),
+        ('layers', (60, ), 'OT4', 4),
         # 2D tests with varying time and space orders
-        ('layers', (60, 70), 'OT2', 4, 10), ('layers', (60, 70), 'OT2', 8, 10),
-        ('layers', (60, 70), 'OT2', 12, 10), ('layers', (60, 70), 'OT4', 8, 10),
+        ('layers', (60, 70), 'OT2', 12), ('layers', (60, 70), 'OT2', 8),
+        ('layers', (60, 70), 'OT2', 4), ('layers', (60, 70), 'OT4', 2),
         # 3D tests with varying time and space orders
-        ('layers', (60, 70, 80), 'OT2', 4, 10), ('layers', (60, 70, 80), 'OT2', 8, 10),
-        ('layers', (60, 70, 80), 'OT2', 12, 10), ('layers', (60, 70, 80), 'OT4', 4, 10),
+        ('layers', (60, 70, 80), 'OT2', 8), ('layers', (60, 70, 80), 'OT2', 6),
+        ('layers', (60, 70, 80), 'OT2', 4), ('layers', (60, 70, 80), 'OT4', 2),
         # Constant model in 2D and 3D
-        ('constant', (60, 70), 'OT2', 8, 14), ('constant', (60, 70, 80), 'OT2', 8, 14),
-        ('constant', (60, 70), 'OT4', 12, 14), ('constant', (60, 70, 80), 'OT4', 4, 14),
+        ('constant', (60, 70), 'OT2', 10), ('constant', (60, 70, 80), 'OT2', 8),
+        ('constant', (60, 70), 'OT2', 4), ('constant', (60, 70, 80), 'OT4', 2),
     ])
-    def test_adjoint_F(self, mkey, shape, kernel, space_order, nbl):
+    def test_adjoint_F(self, mkey, shape, kernel, space_order):
         """
         Adjoint test for the forward modeling operator.
         The forward modeling operator F generates a shot record (measurements)
@@ -44,7 +44,7 @@ class TestAdjoint(object):
 
         # Create solver from preset
         solver = acoustic_setup(shape=shape, spacing=[15. for _ in shape], kernel=kernel,
-                                nbl=nbl, tn=tn, space_order=space_order,
+                                nbl=10, tn=tn, space_order=space_order,
                                 **(presets[mkey]), dtype=np.float64)
 
         # Create adjoint receiver symbol

--- a/tests/test_autotuner.py
+++ b/tests/test_autotuner.py
@@ -177,9 +177,9 @@ def test_mixed_blocking_nthreads():
 
 
 def test_tti_aggressive():
-    from test_dse import tti_operator
-    wave_solver = tti_operator(dse='aggressive', dle=('advanced', {'openmp': False}))
-    op = wave_solver.op_fwd(kernel='centered', save=False)
+    from test_dse import TestTTI
+    wave_solver = TestTTI().tti_operator(dse='aggressive')
+    op = wave_solver.op_fwd(kernel='centered')
     op.apply(time=0, autotune='aggressive')
     assert op._state['autotuning'][0]['runs'] == 28
 

--- a/tests/test_dse.py
+++ b/tests/test_dse.py
@@ -679,8 +679,12 @@ def test_custom_rewriter():
 # TTI
 class TestTTI(object):
 
-    _model = demo_model('layers-tti', ratio=3, nbl=10, space_order=4,
-                        shape=(50, 50, 50), spacing=(20., 20., 20.))
+    # TTI layered model for the tti test, no need for a smooth interace bewtween
+    # the two layer as the dse/compiler is tested not the physical prettiness
+    # of the result, saves testing time
+    _model = demo_model('layers-tti', nlayers=3, nbl=10, space_order=4,
+                        shape=(50, 50, 50), spacing=(20., 20., 20.),
+                        smooth=False)
 
     @cached_property
     def model(self):

--- a/tests/test_dse.py
+++ b/tests/test_dse.py
@@ -2,6 +2,7 @@ from sympy import Add, cos, sin, sqrt  # noqa
 import numpy as np
 import pytest
 from unittest.mock import patch
+from cached_property import cached_property
 
 from conftest import skipif, EVAL, x, y, z  # noqa
 from devito import (Eq, Inc, Constant, Function, TimeFunction, SparseTimeFunction,  # noqa
@@ -10,7 +11,7 @@ from devito.ir import Stencil, FindSymbols, retrieve_iteration_tree  # noqa
 from devito.dle import BlockDimension
 from devito.dse import common_subexprs_elimination, collect, make_is_time_invariant
 from devito.symbolics import yreplace, estimate_cost, pow_to_mul
-from devito.tools import generator
+from devito.tools import generator, memoized_meth
 from devito.types import Scalar
 
 from examples.seismic.acoustic import AcousticWaveSolver
@@ -676,153 +677,153 @@ def test_custom_rewriter():
 
 
 # TTI
+class TestTTI(object):
 
-def tti_operator(dse=False, dle='advanced', space_order=4):
-    nrec = 101
-    t0 = 0.0
-    tn = 250.
-    nbl = 10
-    shape = (50, 50, 50)
-    spacing = (20., 20., 20.)
+    @memoized_meth
+    def model(self, space_order=4):
+        # Two layer model for true velocity
+        return demo_model('layers-tti', ratio=3, nbl=1, space_order=space_order,
+                          shape=(50, 50, 50), spacing=(20., 20., 20.))
 
-    # Two layer model for true velocity
-    model = demo_model('layers-tti', ratio=3, nbl=nbl, space_order=space_order,
-                       shape=shape, spacing=spacing)
+    @cached_property
+    def geometry(self):
+        nrec = 101
+        t0 = 0.0
+        tn = 250.
 
-    # Source and receiver geometries
-    src_coordinates = np.empty((1, len(spacing)))
-    src_coordinates[0, :] = np.array(model.domain_size) * .5
-    src_coordinates[0, -1] = model.origin[-1] + 2 * spacing[-1]
+        model = self.model()
+        # Source and receiver geometries
+        src_coordinates = np.empty((1, len(model.spacing)))
+        src_coordinates[0, :] = np.array(model.domain_size) * .5
+        src_coordinates[0, -1] = model.origin[-1] + 2 * model.spacing[-1]
 
-    rec_coordinates = np.empty((nrec, len(spacing)))
-    rec_coordinates[:, 0] = np.linspace(0., model.domain_size[0], num=nrec)
-    rec_coordinates[:, 1:] = src_coordinates[0, 1:]
+        rec_coordinates = np.empty((nrec, len(model.spacing)))
+        rec_coordinates[:, 0] = np.linspace(0., model.domain_size[0], num=nrec)
+        rec_coordinates[:, 1:] = src_coordinates[0, 1:]
 
-    geometry = AcquisitionGeometry(model, rec_coordinates, src_coordinates,
-                                   t0=t0, tn=tn, src_type='Gabor', f0=0.010)
+        geometry = AcquisitionGeometry(model, rec_coordinates, src_coordinates,
+                                       t0=t0, tn=tn, src_type='Gabor', f0=0.010)
+        return geometry
 
-    return AnisotropicWaveSolver(model, geometry, space_order=space_order, dse=dse)
+    def tti_operator(self, dse=False, dle='advanced', space_order=4):
+        model = self.model(space_order=space_order)
+        return AnisotropicWaveSolver(model, self.geometry,
+                                     space_order=space_order, dse=dse)
 
+    @cached_property
+    def tti_nodse(self):
+        operator = self.tti_operator(dse=None)
+        rec, u, v, _ = operator.forward()
+        return v, rec
 
-@pytest.fixture(scope="session")
-def tti_nodse():
-    operator = tti_operator(dse=None)
-    rec, u, v, _ = operator.forward()
-    return v, rec
+    def test_tti_rewrite_basic(self):
+        operator = self.tti_operator(dse='basic')
+        rec, u, v, _ = operator.forward()
 
+        assert np.allclose(self.tti_nodse[0].data, v.data, atol=10e-3)
+        assert np.allclose(self.tti_nodse[1].data, rec.data, atol=10e-3)
 
-def test_tti_rewrite_basic(tti_nodse):
-    operator = tti_operator(dse='basic')
-    rec, u, v, _ = operator.forward()
+    def test_tti_rewrite_advanced(self):
+        operator = self.tti_operator(dse='advanced')
+        rec, u, v, _ = operator.forward()
 
-    assert np.allclose(tti_nodse[0].data, v.data, atol=10e-3)
-    assert np.allclose(tti_nodse[1].data, rec.data, atol=10e-3)
+        assert np.allclose(self.tti_nodse[0].data, v.data, atol=10e-1)
+        assert np.allclose(self.tti_nodse[1].data, rec.data, atol=10e-1)
 
+    def test_tti_rewrite_aggressive(self):
+        operator = self.tti_operator(dse='aggressive')
+        rec, u, v, _ = operator.forward(kernel='centered', save=False)
 
-def test_tti_rewrite_advanced(tti_nodse):
-    operator = tti_operator(dse='advanced')
-    rec, u, v, _ = operator.forward()
+        assert np.allclose(self.tti_nodse[0].data, v.data, atol=10e-1)
+        assert np.allclose(self.tti_nodse[1].data, rec.data, atol=10e-1)
 
-    assert np.allclose(tti_nodse[0].data, v.data, atol=10e-1)
-    assert np.allclose(tti_nodse[1].data, rec.data, atol=10e-1)
+        # Also check that DLE's loop blocking with DSE=aggressive does the right thing
+        # There should be exactly two BlockDimensions; bugs in the past were generating
+        # either code with no blocking (zero BlockDimensions) or code with four
+        # BlockDimensions (i.e., Iteration folding was somewhat broken)
+        op = operator.op_fwd(kernel='centered', save=False)
+        block_dims = [i for i in op.dimensions if isinstance(i, BlockDimension)]
+        assert len(block_dims) == 2
 
+        # Also, in this operator, we expect six temporary Arrays:
+        # * four Arrays are allocated on the heap
+        # * two Arrays are allocated on the stack and only appear within an efunc
+        arrays = [i for i in FindSymbols().visit(op) if i.is_Array]
+        assert len(arrays) == 5
+        assert all(i._mem_heap and not i._mem_external for i in arrays)
+        arrays = [i for i in FindSymbols().visit(op._func_table['bf0'].root)
+                  if i.is_Array]
+        assert len(arrays) == 7
+        assert all(not i._mem_external for i in arrays)
+        assert len([i for i in arrays if i._mem_heap]) == 5
+        assert len([i for i in arrays if i._mem_stack]) == 2
 
-def test_tti_rewrite_aggressive(tti_nodse):
-    operator = tti_operator(dse='aggressive')
-    rec, u, v, _ = operator.forward(kernel='centered', save=False)
+    @skipif(['nompi'])
+    @pytest.mark.parallel(mode=[(1, 'full')])
+    def test_tti_rewrite_aggressive_wmpi(self):
+        tti_nodse = self.tti_operator(dse=None)
+        rec0, u0, v0, _ = tti_nodse.forward(kernel='centered', save=False)
+        tti_agg = self.tti_operator(dse='aggressive')
+        rec1, u1, v1, _ = tti_agg.forward(kernel='centered', save=False)
 
-    assert np.allclose(tti_nodse[0].data, v.data, atol=10e-1)
-    assert np.allclose(tti_nodse[1].data, rec.data, atol=10e-1)
+        assert np.allclose(v0.data, v1.data, atol=10e-1)
+        assert np.allclose(rec0.data, rec1.data, atol=10e-1)
 
-    # Also check that DLE's loop blocking with DSE=aggressive does the right thing
-    # There should be exactly two BlockDimensions; bugs in the past were generating
-    # either code with no blocking (zero BlockDimensions) or code with four
-    # BlockDimensions (i.e., Iteration folding was somewhat broken)
-    op = operator.op_fwd(kernel='centered', save=False)
-    block_dims = [i for i in op.dimensions if isinstance(i, BlockDimension)]
-    assert len(block_dims) == 2
+    @switchconfig(profiling='advanced')
+    @pytest.mark.parametrize('space_order,expected', [
+        (8, 174), (16, 306)
+    ])
+    def test_tti_rewrite_aggressive_opcounts(self, space_order, expected):
+        operator = self.tti_operator(self, dse='aggressive', space_order=space_order)
+        _, _, _, summary = operator.forward(kernel='centered', save=False, time_M=0)
+        assert summary[('section1', None)].ops == expected
 
-    # Also, in this operator, we expect six temporary Arrays:
-    # * four Arrays are allocated on the heap
-    # * two Arrays are allocated on the stack and only appear within an efunc
-    arrays = [i for i in FindSymbols().visit(op) if i.is_Array]
-    assert len(arrays) == 5
-    assert all(i._mem_heap and not i._mem_external for i in arrays)
-    arrays = [i for i in FindSymbols().visit(op._func_table['bf0'].root) if i.is_Array]
-    assert len(arrays) == 7
-    assert all(not i._mem_external for i in arrays)
-    assert len([i for i in arrays if i._mem_heap]) == 5
-    assert len([i for i in arrays if i._mem_stack]) == 2
+    @switchconfig(profiling='advanced')
+    @pytest.mark.parametrize('space_order,expected', [
+        (4, 194), (12, 386)
+    ])
+    def test_tti_v2_rewrite_aggressive_opcounts(self, space_order, expected):
+        grid = Grid(shape=(3, 3, 3))
 
+        s = 0.00067
+        u = TimeFunction(name='u', grid=grid, space_order=space_order)
+        v = TimeFunction(name='v', grid=grid, space_order=space_order)
+        f = Function(name='f', grid=grid)
+        g = Function(name='g', grid=grid)
+        m = Function(name='m', grid=grid)
+        e = Function(name='e', grid=grid)
+        d = Function(name='d', grid=grid)
 
-@skipif(['nompi'])
-@pytest.mark.parallel(mode=[(1, 'full')])
-def test_tti_rewrite_aggressive_wmpi():
-    tti_nodse = tti_operator(dse=None)
-    rec0, u0, v0, _ = tti_nodse.forward(kernel='centered', save=False)
-    tti_agg = tti_operator(dse='aggressive')
-    rec1, u1, v1, _ = tti_agg.forward(kernel='centered', save=False)
+        ang0 = cos(f)
+        ang1 = sin(f)
+        ang2 = cos(g)
+        ang3 = sin(g)
 
-    assert np.allclose(v0.data, v1.data, atol=10e-1)
-    assert np.allclose(rec0.data, rec1.data, atol=10e-1)
+        H1u = (ang1*ang1*ang2*ang2*u.dx2 +
+               ang1*ang1*ang3*ang3*u.dy2 +
+               ang0*ang0*u.dz2 +
+               2*ang1*ang1*ang3*ang2*u.dxdy +
+               2*ang0*ang1*ang3*u.dydz +
+               2*ang0*ang1*ang2*u.dxdz)
+        H2u = -H1u + u.laplace
 
+        H1v = (ang1*ang1*ang2*ang2*v.dx2 +
+               ang1*ang1*ang3*ang3*v.dy2 +
+               ang0*ang0*v.dz2 +
+               2*ang1*ang1*ang3*ang2*v.dxdy +
+               2*ang0*ang1*ang3*v.dydz +
+               2*ang0*ang1*ang2*v.dxdz)
+        H2v = -H1v + v.laplace
 
-@switchconfig(profiling='advanced')
-@pytest.mark.parametrize('space_order,expected', [
-    (8, 174), (16, 306)
-])
-def test_tti_rewrite_aggressive_opcounts(space_order, expected):
-    operator = tti_operator(dse='aggressive', space_order=space_order)
-    _, _, _, summary = operator.forward(kernel='centered', save=False)
-    assert summary[('section1', None)].ops == expected
+        eqns = [Eq(u.forward, (2*u - u.backward) + s**2/m * (e * H2u + H1v)),
+                Eq(v.forward, (2*v - v.backward) + s**2/m * (d * H2v + H1v))]
+        op = Operator(eqns, dse='aggressive')
 
-
-@switchconfig(profiling='advanced')
-@pytest.mark.parametrize('space_order,expected', [
-    (4, 194), (12, 386)
-])
-def test_tti_v2_rewrite_aggressive_opcounts(space_order, expected):
-    grid = Grid(shape=(3, 3, 3))
-
-    s = 0.00067
-    u = TimeFunction(name='u', grid=grid, space_order=space_order)
-    v = TimeFunction(name='v', grid=grid, space_order=space_order)
-    f = Function(name='f', grid=grid)
-    g = Function(name='g', grid=grid)
-    m = Function(name='m', grid=grid)
-    e = Function(name='e', grid=grid)
-    d = Function(name='d', grid=grid)
-
-    ang0 = cos(f)
-    ang1 = sin(f)
-    ang2 = cos(g)
-    ang3 = sin(g)
-
-    H1u = (ang1*ang1*ang2*ang2*u.dx2 +
-           ang1*ang1*ang3*ang3*u.dy2 +
-           ang0*ang0*u.dz2 +
-           2*ang1*ang1*ang3*ang2*u.dxdy +
-           2*ang0*ang1*ang3*u.dydz +
-           2*ang0*ang1*ang2*u.dxdz)
-    H2u = -H1u + u.laplace
-
-    H1v = (ang1*ang1*ang2*ang2*v.dx2 +
-           ang1*ang1*ang3*ang3*v.dy2 +
-           ang0*ang0*v.dz2 +
-           2*ang1*ang1*ang3*ang2*v.dxdy +
-           2*ang0*ang1*ang3*v.dydz +
-           2*ang0*ang1*ang2*v.dxdz)
-    H2v = -H1v + v.laplace
-
-    eqns = [Eq(u.forward, (2*u - u.backward) + s**2/m * (e * H2u + H1v)),
-            Eq(v.forward, (2*v - v.backward) + s**2/m * (d * H2v + H1v))]
-    op = Operator(eqns, dse='aggressive')
-
-    sections = list(op._profiler._sections.values())
-    assert len(sections) == 2
-    assert sections[0].sops == 4
-    assert sections[1].sops == expected
+        sections = list(op._profiler._sections.values())
+        assert len(sections) == 2
+        assert sections[0].sops == 4
+        assert sections[1].sops == expected
 
 
 if __name__ == "__main__":
-    test_tti_v2_rewrite_aggressive_opcounts(4, 183)
+    TestTTI().test_tti_v2_rewrite_aggressive_opcounts(4, 194)

--- a/tests/test_yask.py
+++ b/tests/test_yask.py
@@ -588,8 +588,7 @@ class TestIsotropicAcoustic(object):
         Full acoustic wave test, forward + adjoint operators
         """
         from test_adjoint import TestAdjoint
-        TestAdjoint().test_adjoint_F('layers', self.shape, self.kernel,
-                                     self.space_order, self.nbl)
+        TestAdjoint().test_adjoint_F('layers', self.shape, self.kernel, self.space_order)
 
     @switchconfig(openmp=True)
     def test_acoustic_adjoint_omp(self):
@@ -598,5 +597,4 @@ class TestIsotropicAcoustic(object):
         sparse loops.
         """
         from test_adjoint import TestAdjoint
-        TestAdjoint().test_adjoint_F('layers', self.shape, self.kernel,
-                                     self.space_order, self.nbl)
+        TestAdjoint().test_adjoint_F('layers', self.shape, self.kernel, self.space_order)


### PR DESCRIPTION
Improved `test_dse/tti` tests so that

- Model is created only once (with max space_order) so that only a single call to pad/smooth is done
- Doesn't run operators for tests that don't need it

On top of #1038 