### PR TITLE
MPI testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ matrix:
             - gcc-4.9
             - g++-4.9
       env: DEVITO_ARCH=gcc-4.9 DEVITO_OPENMP=0 INSTALL_TYPE=pip_setup RUN_EXAMPLES=False MPI_INSTALL=1 MPI_RESTRAIN=1
-    - python: 3.7
+    - python: 3.8
       dist: xenial
       os: linux
       addons:
@@ -89,7 +89,8 @@ before_install:
 install:
   # Install devito with conda
   - if [[ $INSTALL_TYPE == 'conda' ]]; then
-      conda env create -q -f environment.yml python=$TRAVIS_PYTHON_VERSION;
+      sed -i -E 's/(python=)(.*)/\1'$TRAVIS_PYTHON_VERSION'/' environment.yml;
+      conda env create -q -f environment.yml;
       source activate devito;
       conda update -q conda;
       pip install -e .;

--- a/Dockerfile.pipelines
+++ b/Dockerfile.pipelines
@@ -84,14 +84,13 @@ RUN rm -f /usr/bin/gcc && ln -s /usr/bin/gcc-$gccVersion /usr/bin/gcc ;
 ENV PATH=/usr/local/miniconda/bin:$PATH
 
 # Python installs
-RUN if [ $installWithPip == "true" ] ; then \ 
-      if [ $PYTHON_VERSION == "3.6" ] ; then \
-        apt-get install -y python3.6-dev python3-pip ; \
-      rm -f /usr/bin/python && ln -s /usr/bin/python3.6 /usr/bin/python ; \
-      else \
-        apt-get install -y python3.7-dev python3-pip ; \
-      rm -f /usr/bin/python && ln -s /usr/bin/python3.7 /usr/bin/python ; \
+RUN if [ $installWithPip == "true" ] ; then \
+      if [ "$PYTHON_VERSION" == "3.8"] ; then \
+        apt update ; \
+        apt install -y software-properties-common ; \
       fi ; \
+      apt-get install -y python$PYTHON_VERSION-dev python3-pip ; \
+      rm -f /usr/bin/python && ln -s /usr/bin/python$PYTHON_VERSION /usr/bin/python ; \
     else \
       wget --no-verbose https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O /tmp/miniconda.sh ; \
       bash /tmp/miniconda.sh -b -p /usr/local/miniconda ; \
@@ -113,7 +112,8 @@ RUN if [ $installWithPip == "true" ] ; then \
         python -m pip install --user -e .[extras] ; \
       fi ; \
     else \
-      conda env create -q -f environment.yml ; \
+      sed -i -E 's/(python=)(.*)/\1'$PYTHON_VERSION'/' environment.yml ; \
+      conda env create -q -f environment.yml; \
       source activate devito ; \
       conda update -q conda ; \
       echo $PATH ; \
@@ -123,9 +123,9 @@ RUN if [ $installWithPip == "true" ] ; then \
       fi ; \
       pip install pytest-xdist ; \
       if [ $DEVITO_BACKEND == "yask" ] ; then \
-        conda install swig ; \ 
+        conda install swig ; \
         git clone https://github.com/devitocodes/yask.git /tmp/yask ; \
-        pushd /tmp/yask ; \ 
+        pushd /tmp/yask ; \
           make compiler-api ; \
           pip install -e . ; \
         popd ; \

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -2,7 +2,7 @@ trigger:
 - master
 
 pr:
-- master  
+- master
 
 jobs:
 
@@ -36,14 +36,14 @@ jobs:
         DEVITO_BACKEND: 'core'
         RUN_EXAMPLES: 'true'
         PYTHON_VERSION: '3.7'
-      nompi-conda-gcc5:
+      nompi-conda-gcc5-py38:
         gccVersion: '5'
-        DEVITO_OPENMP: '0'
+        DEVITO_OPENMP: '1'
         MPI_INSTALL: '0'
         installWithPip: 'false'
         DEVITO_BACKEND: 'core'
         RUN_EXAMPLES: 'false'
-        PYTHON_VERSION: '3.7'
+        PYTHON_VERSION: '3.8'
       ops-conda-gcc7:
         gccVersion: '7'
         DEVITO_OPENMP: '0'

--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@ channels:
   - defaults
   - conda-forge
 dependencies:
-  - python>=3.6
+  - python=3
   - numpy>=1.14
   - sympy>=1.4
   - cgen

--- a/examples/seismic/acoustic/acoustic_example.py
+++ b/examples/seismic/acoustic/acoustic_example.py
@@ -12,7 +12,8 @@ def acoustic_setup(shape=(50, 50, 50), spacing=(15.0, 15.0, 15.0),
                    preset='layers-isotropic', **kwargs):
     nrec = kwargs.pop('nrec', shape[0])
     model = demo_model(preset, space_order=space_order, shape=shape, nbl=nbl,
-                       dtype=kwargs.pop('dtype', np.float32), spacing=spacing)
+                       dtype=kwargs.pop('dtype', np.float32), spacing=spacing,
+                       **kwargs)
 
     # Source and receiver geometries
     src_coordinates = np.empty((1, len(spacing)))

--- a/tests/test_installation.py
+++ b/tests/test_installation.py
@@ -1,0 +1,14 @@
+import platform
+import os
+
+
+def test_python_version():
+    """
+    Test that the CI runs with the expected python version
+    """
+    # expected version
+    e_ver = os.environ.get("PYTHON_VERSION") or os.environ.get("TRAVIS_PYTHON_VERSION")
+    # Installed version
+    i_ver = platform.python_version()
+
+    assert i_ver.startswith(e_ver)


### PR DESCRIPTION
This one is on me, setup of the Acoustic Class in `test_mpi` was pretty stupid and not doing what I thought i made it do, this should save quite the time in CI (~32 less PDE solve with mpi) and make `test_mpi.py/TestAcoustic` about two times faster (eyeballing it).

It is no super pretty but the "hack" is necessary because basically `purest.mark.parallel` starts a new `pytest` session each time and therefore creates a new class an "regenerate" the norms (and because at that point it's inside MPI it would recompute the norms with MPI). So now I just dump it locally (it's tiny so it's fine) so that the reference norms are computed once *in serial mode* instead of like 30 times.

Travis : Saves 2-4 min per MPI build
Pipeline: Saves ~10-15min per MPI build 