### PR TITLE
Update local installations to include pip install of requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ git clone https://github.com/devitocodes/devito.git
 cd devito
 conda env create -f environment.yml
 source activate devito
+pip install -r requirements.txt
 pip install -e .
 ```
 


### PR DESCRIPTION
This PR updates the installation instructions to include `pip install -r requirements.txt` so that they are complete for running the tutorial notebooks.

Another way of achieving this would be including the contents of `requirements.txt` as a `pip` block in `environment.yaml`, making `requirements.txt` redundant. (**cc:** @tallamjr)

Related issue: https://github.com/devitocodes/devito/issues/1065