### PR TITLE
Publish releases

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -10,6 +10,9 @@ jobs:
       uses: actions/setup-python@v1
       with:
         python-version: 3.7
+    - name: Install wheel
+      run: >-
+        python -m pip install wheel --user
     - name: Build a binary wheel and source package in dist/
       run: >-
         python setup.py sdist bdist_wheel

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -1,0 +1,23 @@
+name: Publish to PyPI
+on: push
+jobs:
+  build-and-publish:
+    name: Build and publish Python package to PyPI
+    runs-on: Ubuntu 18.04
+    steps:
+    - uses: actions/checkout@master
+    - name: Set up Python
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.7
+    - name: Install setuptools
+      run: >-
+        python -m pip install setuptools --user
+    - name: Build a binary wheel and source package in dist/
+      run: >-
+        python setup.py sdist bdist_wheel
+    - name: Publish distribution to Test PyPI
+      uses: pypa/gh-action-pypi-publish@master
+      with:
+        password: ${{ secrets.test_pypi_password }}
+        repository_url: https://test.pypi.org/legacy/

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -3,7 +3,7 @@ on: push
 jobs:
   build-and-publish:
     name: Build and publish Python package to PyPI
-    runs-on: Ubuntu 18.04
+    runs-on: ubuntu-18.04
     steps:
     - uses: actions/checkout@master
     - name: Set up Python

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -10,9 +10,6 @@ jobs:
       uses: actions/setup-python@v1
       with:
         python-version: 3.7
-    - name: Install setuptools
-      run: >-
-        python -m pip install setuptools --user
     - name: Build a binary wheel and source package in dist/
       run: >-
         python setup.py sdist bdist_wheel

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -17,7 +17,11 @@ jobs:
       run: >-
         python setup.py sdist bdist_wheel
     - name: Publish distribution to fake Test PyPI repo
+      if: startsWith(github.event.ref, 'refs/tags')
       uses: pypa/gh-action-pypi-publish@master
       with:
-        password: ${{ secrets.test_pypi_password }}
-        repository_url: https://test.pypi.org/legacy/
+        password: ${{ secrets.pypi_password }}
+        # publish to the test PyPI repository instead like this:
+        # (you'll need to create an API token at test.pypi.org)
+        # password: ${{ secrets.test_pypi_password }}
+        # repository_url: https://test.pypi.org/legacy/

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Build a binary wheel and source package in dist/
       run: >-
         python setup.py sdist bdist_wheel
-    - name: Publish distribution to Test PyPI repo
+    - name: Publish distribution to fake Test PyPI repo
       uses: pypa/gh-action-pypi-publish@master
       with:
         password: ${{ secrets.test_pypi_password }}

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Build a binary wheel and source package in dist/
       run: >-
         python setup.py sdist bdist_wheel
-    - name: Publish distribution to Test PyPI
+    - name: Publish distribution to Test PyPI repo
       uses: pypa/gh-action-pypi-publish@master
       with:
         password: ${{ secrets.test_pypi_password }}

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ docs/_build
 .ipynb_checkpoints
 
 devito.egg-info/*
+
+build
+dist

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ for ir in optionals:
         opt_reqs += [ir]
 extras_require['extras'] = opt_reqs
 
-setup(name='devito',
+setup(name='devito-iamleeg-fork',
       version=versioneer.get_version(),
       cmdclass=versioneer.get_cmdclass(),
       description="Finite Difference DSL for symbolic computation.",

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ for ir in optionals:
         opt_reqs += [ir]
 extras_require['extras'] = opt_reqs
 
-setup(name='devito-iamleeg-fork',
+setup(name='devito',
       version=versioneer.get_version(),
       cmdclass=versioneer.get_cmdclass(),
       description="Finite Difference DSL for symbolic computation.",


### PR DESCRIPTION
An action to build packages automatically, and publish them to pypi. Only runs on pushing a tag, name your tag after the package version e.g. `git tag -a v4.0.1 -m "Release patch fix 4.0.1"; git push --tags`.

Also: you need to create yourself an API key at pypi.org, and paste it into a secret called `pypi_password` in this repo's settings.

I tested this by renaming the package and publishing to test.pypi.org, which published to https://test.pypi.org/project/devito-iamleeg-fork/.