### PR TITLE
Sparse MPI redundant computation fix

### DIFF
--- a/devito/types/sparse.py
+++ b/devito/types/sparse.py
@@ -111,12 +111,8 @@ class AbstractSparseFunction(DiscreteFunction, Differentiable):
         The grid points surrounding each sparse point within the radius of self's
         injection/interpolation operators.
         """
-        return self._build_support(points=self.gridpoints)
-
-    @memoized_meth
-    def _build_support(self, points=None):
         ret = []
-        points = points or self.gridpoints
+        points = self.gridpoints
         for i in points:
             support = [range(max(0, j - self._radius + 1), min(M, j + self._radius + 1))
                        for j, M in zip(i, self.grid.shape)]
@@ -597,7 +593,7 @@ class SparseFunction(AbstractSparseFunction):
             raise ValueError("No coordinates attached to this SparseFunction")
         ret = []
         for coords in self.coordinates.data._local:
-            ret.append(tuple(int(sympy.floor((c - o.data)/i.spacing.data)) for c, o, i in
+            ret.append(tuple(int(np.floor(c - o.data)/i.spacing.data) for c, o, i in
                              zip(coords, self.grid.origin, self.grid.dimensions)))
         return tuple(ret)
 

--- a/devito/types/sparse.py
+++ b/devito/types/sparse.py
@@ -112,8 +112,7 @@ class AbstractSparseFunction(DiscreteFunction, Differentiable):
         injection/interpolation operators.
         """
         ret = []
-        points = self.gridpoints
-        for i in points:
+        for i in self.gridpoints:
             support = [range(max(0, j - self._radius + 1), min(M, j + self._radius + 1))
                        for j, M in zip(i, self.grid.shape)]
             ret.append(tuple(product(*support)))

--- a/examples/seismic/acoustic/acoustic_example.py
+++ b/examples/seismic/acoustic/acoustic_example.py
@@ -4,30 +4,18 @@ from argparse import ArgumentParser
 from devito.logger import info
 from devito import Constant, Function, smooth, configuration
 from examples.seismic.acoustic import AcousticWaveSolver
-from examples.seismic import demo_model, AcquisitionGeometry
+from examples.seismic import demo_model, setup_geometry
 
 
 def acoustic_setup(shape=(50, 50, 50), spacing=(15.0, 15.0, 15.0),
                    tn=500., kernel='OT2', space_order=4, nbl=10,
                    preset='layers-isotropic', **kwargs):
-    nrec = kwargs.pop('nrec', shape[0])
     model = demo_model(preset, space_order=space_order, shape=shape, nbl=nbl,
                        dtype=kwargs.pop('dtype', np.float32), spacing=spacing,
                        **kwargs)
 
     # Source and receiver geometries
-    src_coordinates = np.empty((1, len(spacing)))
-    src_coordinates[0, :] = np.array(model.domain_size) * .5
-    if len(shape) > 1:
-        src_coordinates[0, -1] = model.origin[-1] + 2 * spacing[-1]
-
-    rec_coordinates = np.empty((nrec, len(spacing)))
-    rec_coordinates[:, 0] = np.linspace(0., model.domain_size[0], num=nrec)
-    if len(shape) > 1:
-        rec_coordinates[:, 1] = np.array(model.domain_size)[1] * .5
-        rec_coordinates[:, -1] = model.origin[-1] + 2 * spacing[-1]
-    geometry = AcquisitionGeometry(model, rec_coordinates, src_coordinates,
-                                   t0=0.0, tn=tn, src_type='Ricker', f0=0.010)
+    geometry = setup_geometry(model, tn)
 
     # Create solver object to provide relevant operators
     solver = AcousticWaveSolver(model, geometry, kernel=kernel,

--- a/examples/seismic/tti/tti_example.py
+++ b/examples/seismic/tti/tti_example.py
@@ -1,29 +1,17 @@
-import numpy as np
 from argparse import ArgumentParser
 from devito import configuration
-from examples.seismic import demo_model, AcquisitionGeometry
+from examples.seismic import demo_model, setup_geometry
 from examples.seismic.tti import AnisotropicWaveSolver
 
 
 def tti_setup(shape=(50, 50, 50), spacing=(20.0, 20.0, 20.0), tn=250.0,
               space_order=4, nbl=10, preset='layers-tti', **kwargs):
 
-    nrec = 101
     # Two layer model for true velocity
     model = demo_model(preset, shape=shape, spacing=spacing, nbl=nbl)
-    # Source and receiver geometries
-    src_coordinates = np.empty((1, len(spacing)))
-    src_coordinates[0, :] = np.array(model.domain_size) * .5
-    if len(shape) > 1:
-        src_coordinates[0, -1] = model.origin[-1] + 2 * spacing[-1]
 
-    rec_coordinates = np.empty((nrec, len(spacing)))
-    rec_coordinates[:, 0] = np.linspace(0., model.domain_size[0], num=nrec)
-    if len(shape) > 1:
-        rec_coordinates[:, 1] = np.array(model.domain_size)[1] * .5
-        rec_coordinates[:, -1] = model.origin[-1] + 2 * spacing[-1]
-    geometry = AcquisitionGeometry(model, rec_coordinates, src_coordinates,
-                                   t0=0.0, tn=tn, src_type='Ricker', f0=0.010)
+    # Source and receiver geometries
+    geometry = setup_geometry(model, tn)
 
     return AnisotropicWaveSolver(model, geometry,
                                  space_order=space_order, **kwargs)

--- a/examples/seismic/viscoelastic/viscoelastic_example.py
+++ b/examples/seismic/viscoelastic/viscoelastic_example.py
@@ -4,30 +4,18 @@ from argparse import ArgumentParser
 from devito import configuration
 from devito.logger import info
 from examples.seismic.viscoelastic import ViscoelasticWaveSolver
-from examples.seismic import demo_model, AcquisitionGeometry
+from examples.seismic import demo_model, setup_geometry
 
 
 def viscoelastic_setup(shape=(50, 50), spacing=(15.0, 15.0), tn=500., space_order=4,
                        nbl=10, constant=True, **kwargs):
 
-    nrec = 2*shape[0]
     preset = 'constant-viscoelastic' if constant else 'layers-viscoelastic'
     model = demo_model(preset, space_order=space_order, shape=shape, nbl=nbl,
                        dtype=kwargs.pop('dtype', np.float32), spacing=spacing)
 
     # Source and receiver geometries
-    src_coordinates = np.empty((1, len(spacing)))
-    src_coordinates[0, :] = np.array(model.domain_size) * .5
-    if len(shape) > 1:
-        src_coordinates[0, -1] = model.origin[-1] + 2 * spacing[-1]
-
-    rec_coordinates = np.empty((nrec, len(spacing)))
-    rec_coordinates[:, 0] = np.linspace(0., model.domain_size[0], num=nrec)
-    if len(shape) > 1:
-        rec_coordinates[:, 1] = np.array(model.domain_size)[1] * .5
-        rec_coordinates[:, -1] = model.origin[-1] + 2 * spacing[-1]
-    geometry = AcquisitionGeometry(model, rec_coordinates, src_coordinates,
-                                   t0=0.0, tn=tn, src_type='Ricker', f0=0.12)
+    geometry = setup_geometry(model, tn)
 
     # Create solver object to provide relevant operators
     solver = ViscoelasticWaveSolver(model, geometry, space_order=space_order, **kwargs)
@@ -50,8 +38,8 @@ def run(shape=(50, 50), spacing=(20.0, 20.0), tn=1000.0,
 def test_viscoelastic():
     _, _, _, [rec1, rec2, v, tau] = run()
     norm = lambda x: np.linalg.norm(x.data.reshape(-1))
-    assert np.isclose(norm(rec1), 5.774392, atol=1e-3, rtol=0)
-    assert np.isclose(norm(rec2), 0.119801, atol=1e-3, rtol=0)
+    assert np.isclose(norm(rec1), 13.0748, atol=1e-3, rtol=0)
+    assert np.isclose(norm(rec2), 0.43070, atol=1e-3, rtol=0)
 
 
 if __name__ == "__main__":

--- a/tests/test_checkpointing.py
+++ b/tests/test_checkpointing.py
@@ -8,7 +8,6 @@ from conftest import skipif
 from devito import Grid, TimeFunction, Operator, Function, Eq, switchconfig, Constant
 from examples.checkpointing.checkpoint import DevitoCheckpoint, CheckpointOperator
 from examples.seismic.acoustic.acoustic_example import acoustic_setup
-from examples.seismic import Receiver
 
 pytestmark = skipif(['yask', 'ops'])
 
@@ -122,16 +121,13 @@ def test_forward_with_breaks(shape, kernel, space_order):
     spacing = tuple([15.0 for _ in shape])
     tn = 500.
     time_order = 2
-    nrec = shape[0]
 
     solver = acoustic_setup(shape=shape, spacing=spacing, tn=tn,
                             space_order=space_order, kernel=kernel)
 
     grid = solver.model.grid
 
-    rec = Receiver(name='rec', grid=grid, time_range=solver.geometry.time_axis,
-                   npoint=nrec)
-    rec.coordinates.data[:, :] = solver.geometry.rec_positions
+    rec = solver.geometry.rec
 
     dt = solver.model.critical_dt
 


### PR DESCRIPTION
This basically makes `_dist_datamap` and `_support` memoized method based on the gridpoints (coordinates).

This reduce the call to `_dist_datamap` to 1 instead of 8 per operator call per sparse function
For example:
```
Allocating memory for rec(1355, 159600)
Allocating memory for rec(1355, 159600)
Allocating memory for rec(1355, 159600)
Allocating memory for rec(1355, 159601)
```

`args_defaults` (currently) takes 36 minutes on this size (4 MPI ranks), in testing with this
update