### PR TITLE
Fix 'SubDomain'.shape

### DIFF
--- a/devito/types/dimension.py
+++ b/devito/types/dimension.py
@@ -517,25 +517,7 @@ class SubDimension(DerivedDimension):
                        is_const=True, nonnegative=True))
 
     @classmethod
-    def left(cls, name, parent, thickness, local=True):
-        lst, rst = cls._symbolic_thickness(name)
-        return cls(name, parent,
-                   left=parent.symbolic_min,
-                   right=parent.symbolic_min+lst-1,
-                   thickness=((lst, thickness), (rst, 0)),
-                   local=local)
-
-    @classmethod
-    def right(cls, name, parent, thickness, local=True):
-        lst, rst = cls._symbolic_thickness(name)
-        return cls(name, parent,
-                   left=parent.symbolic_max-rst+1,
-                   right=parent.symbolic_max,
-                   thickness=((lst, 0), (rst, thickness)),
-                   local=local)
-
-    @classmethod
-    def middle(cls, name, parent, thickness_left, thickness_right, local=False):
+    def properties(cls, name, parent, thickness_left, thickness_right, local=False):
         lst, rst = cls._symbolic_thickness(name)
         return cls(name, parent,
                    left=parent.symbolic_min+lst,

--- a/devito/types/grid.py
+++ b/devito/types/grid.py
@@ -360,20 +360,20 @@ class SubDomain(object):
                     side, thickness_left, thickness_right = v
                     if side != 'middle':
                         raise ValueError("Expected side 'middle', not `%s`" % side)
-                    sub_dimensions.append(SubDimension.middle('%si%d' %
-                                                              (k.name, counter),
-                                                              k, thickness_left,
-                                                              thickness_right))
+                    sub_dimensions.append(SubDimension.properties('%si%d' %
+                                                                  (k.name, counter),
+                                                                  k, thickness_left,
+                                                                  thickness_right))
                 except ValueError:
                     side, thickness = v
                     if side == 'left':
-                        sub_dimensions.append(SubDimension.left('%si%d' %
-                                                                (k.name, counter),
-                                                                k, thickness))
+                        sub_dimensions.append(SubDimension.properties('%si%d' %
+                                                                      (k.name, counter),
+                                                                      k, thickness, 0))
                     elif side == 'right':
-                        sub_dimensions.append(SubDimension.right('%si%d' %
-                                                                 (k.name, counter),
-                                                                 k, thickness))
+                        sub_dimensions.append(SubDimension.properties('%si%d' %
+                                                                      (k.name, counter),
+                                                                      k, 0, thickness))
                     else:
                         raise ValueError("Expected sides 'left|right', not `%s`" % side)
         self._dimensions = tuple(sub_dimensions)
@@ -533,8 +533,8 @@ class SubDomainSet(SubDomain):
         sub_dimensions = []
         for d in dimensions:
             sub_dimensions.append(
-                SubDimension.middle('%si_%s' % (d.name, self.implicit_dimension.name),
-                                    d, 0, 0))
+                SubDimension.properties('%si_%s' % (d.name, self.implicit_dimension.name),
+                                        d, 0, 0))
         self._dimensions = tuple(sub_dimensions)
         # Compute the SubDomain shape
         self._shape = tuple(s - (sum(d._thickness_map.values()) if d.is_Sub else 0)

--- a/tests/test_subdomains.py
+++ b/tests/test_subdomains.py
@@ -54,6 +54,37 @@ class TestSubdomains(object):
                              [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]], dtype=np.int32)
         assert((np.array(f.data) == expected).all())
 
+    def test_shape(self):
+        class sd0(SubDomain):
+            name = 'd0'
+
+            def define(self, dimensions):
+                x, y = dimensions
+                return {x: ('middle', 1, 6), y: ('middle', 1, 1)}
+        s_d0 = sd0()
+
+        class sd1(SubDomain):
+            name = 'd1'
+
+            def define(self, dimensions):
+                x, y = dimensions
+                return {x: ('right', 4), y: ('left', 2)}
+        s_d1 = sd1()
+
+        class sd2(SubDomain):
+            name = 'd2'
+
+            def define(self, dimensions):
+                x, y = dimensions
+                return {x: ('left', 3), y: ('middle', 1, 2)}
+        s_d2 = sd2()
+
+        grid = Grid(shape=(10, 10), subdomains=(s_d0, s_d1, s_d2))
+
+        assert grid.subdomains['d0'].shape == (3, 8)
+        assert grid.subdomains['d1'].shape == (6, 8)
+        assert grid.subdomains['d2'].shape == (7, 7)
+
     def test_iterate_NDomains(self):
         """
         Test that a set of subdomains are iterated upon correctly.


### PR DESCRIPTION
`'SubDomain'.shape` currently returns the incorrect result if the subdomain was defined with 'right' or 'left'.

This PR fixes that through removing some in `dimension.py` and some appropriate re-naming or properties. 

An associated test has also been added.