### PR TITLE
Speed up compilation

### DIFF
--- a/devito/core/autotuning.py
+++ b/devito/core/autotuning.py
@@ -9,7 +9,6 @@ from devito.logger import perf, warning as _warning
 from devito.mpi.distributed import MPI, MPINeighborhood
 from devito.mpi.routines import MPIMsgEnriched
 from devito.parameters import configuration
-from devito.symbolics import evaluate
 from devito.tools import filter_ordered, flatten, is_integer, prod
 
 __all__ = ['autotune']
@@ -118,7 +117,7 @@ def autotune(operator, args, level, mode):
             # Make sure we remain within stack bounds, otherwise skip run
             try:
                 stack_footprint = operator._mem_summary['stack']
-                if int(evaluate(stack_footprint, **at_args)) > options['stack_limit']:
+                if int(stack_footprint.subs(at_args)) > options['stack_limit']:
                     continue
             except TypeError:
                 warning("could not determine stack size; skipping run %s" % str(i))

--- a/devito/core/cpu.py
+++ b/devito/core/cpu.py
@@ -4,8 +4,8 @@ from devito.core.operator import OperatorCore
 from devito.exceptions import InvalidOperator
 from devito.ir.clusters import Toposort
 from devito.passes.clusters import (Blocking, Lift, cire, cse, eliminate_arrays,
-                                    extract_increments, factorize, freeze, fuse,
-                                    optimize_pows, scalarize)
+                                    extract_increments, factorize, fuse, optimize_pows,
+                                    scalarize)
 from devito.passes.iet import (DataManager, Ompizer, avoid_denormals, mpiize,
                                optimize_halospots, loop_wrapping, hoist_prodders,
                                relax_incr_dimensions)
@@ -103,7 +103,6 @@ class CPU64Operator(CPU64NoopOperator):
         clusters = cire(clusters, template, 'sops', options, platform)
         clusters = factorize(clusters)
         clusters = optimize_pows(clusters)
-        clusters = freeze(clusters)
 
         # Reduce flops (no arithmetic alterations)
         clusters = cse(clusters, template)
@@ -218,7 +217,6 @@ class Intel64FSGOperator(Intel64Operator):
         clusters = cire(clusters, template, 'sops', options, platform)
         clusters = factorize(clusters)
         clusters = optimize_pows(clusters)
-        clusters = freeze(clusters)
 
         # Reduce flops (no arithmetic alterations)
         clusters = cse(clusters, template)

--- a/devito/core/gpu_openmp.py
+++ b/devito/core/gpu_openmp.py
@@ -9,7 +9,7 @@ from devito.ir.clusters import Toposort
 from devito.ir.iet import MapExprStmts
 from devito.logger import warning
 from devito.passes.clusters import (Lift, cire, cse, eliminate_arrays, extract_increments,
-                                    factorize, freeze, fuse, optimize_pows, scalarize)
+                                    factorize, fuse, optimize_pows, scalarize)
 from devito.passes.iet import (DataManager, Storage, Ompizer, ParallelIteration,
                                ParallelTree, optimize_halospots, mpiize, hoist_prodders,
                                iet_pass)
@@ -247,7 +247,6 @@ class DeviceOpenMPNoopOperator(OperatorCore):
         clusters = cire(clusters, template, 'sops', options, platform)
         clusters = factorize(clusters)
         clusters = optimize_pows(clusters)
-        clusters = freeze(clusters)
 
         # Reduce flops (no arithmetic alterations)
         clusters = cse(clusters, template)

--- a/devito/core/operator.py
+++ b/devito/core/operator.py
@@ -1,5 +1,4 @@
 from devito.core.autotuning import autotune
-from devito.ir.support import align_accesses
 from devito.parameters import configuration
 from devito.passes import NThreads
 from devito.operator import Operator

--- a/devito/core/operator.py
+++ b/devito/core/operator.py
@@ -9,13 +9,6 @@ __all__ = ['OperatorCore']
 
 class OperatorCore(Operator):
 
-    @classmethod
-    def _specialize_exprs(cls, expressions):
-        # Align data accesses to the computational domain
-        key = lambda i: i.is_DiscreteFunction
-        expressions = [align_accesses(e, key=key) for e in expressions]
-        return super(OperatorCore, cls)._specialize_exprs(expressions)
-
     def _autotune(self, args, setup):
         if setup in [False, 'off']:
             return args

--- a/devito/finite_differences/__init__.py
+++ b/devito/finite_differences/__init__.py
@@ -1,3 +1,4 @@
+from .lazy import *  # noqa
 from .differentiable import *  # noqa
 from .finite_difference import *  # noqa
 from .derivative import *  # noqa

--- a/devito/finite_differences/coefficients.py
+++ b/devito/finite_differences/coefficients.py
@@ -27,8 +27,8 @@ class Coefficient(object):
         intended to be used in place of the standard
         weights (obtained from a Taylor expansion).
 
-    Example
-    -------
+    Examples
+    --------
     >>> import numpy as np
     >>> from devito import Grid, Function, Coefficient
     >>> grid = Grid(shape=(4, 4))

--- a/devito/finite_differences/differentiable.py
+++ b/devito/finite_differences/differentiable.py
@@ -263,6 +263,35 @@ class DifferentiableOp(Differentiable):
 
         return obj
 
+    # Bypass useless expensive SymPy _eval_ methods, for which we either already
+    # know or don't care about the answer, because it'd have ~zero impact on our
+    # average expressions
+
+    def _eval_is_even(self):
+        return None
+
+    def _eval_is_odd(self):
+        return None
+
+    def _eval_is_integer(self):
+        return None
+
+    def _eval_is_negative(self):
+        return None
+
+    def _eval_is_extended_negative(self):
+        return None
+
+    def _eval_is_positive(self):
+        return None
+
+    def _eval_is_extended_positive(self):
+        return None
+
+    def _eval_is_zero(self):
+        return None
+
+
 
 class Add(DifferentiableOp, sympy.Add):
     __new__ = DifferentiableOp.__new__

--- a/devito/finite_differences/differentiable.py
+++ b/devito/finite_differences/differentiable.py
@@ -292,7 +292,6 @@ class DifferentiableOp(Differentiable):
         return None
 
 
-
 class Add(DifferentiableOp, sympy.Add):
     __new__ = DifferentiableOp.__new__
 

--- a/devito/finite_differences/differentiable.py
+++ b/devito/finite_differences/differentiable.py
@@ -6,8 +6,9 @@ from sympy.functions.elementary.integers import floor
 from sympy.core.evalf import evalf_table
 
 from cached_property import cached_property
+from devito.finite_differences.lazy import Evaluable
 from devito.logger import warning
-from devito.tools import Evaluable, EnrichedTuple, filter_ordered, flatten
+from devito.tools import EnrichedTuple, filter_ordered, flatten
 
 __all__ = ['Differentiable']
 

--- a/devito/finite_differences/finite_difference.py
+++ b/devito/finite_differences/finite_difference.py
@@ -276,7 +276,7 @@ def indices_weights_to_fd(expr, dim, inds, weights, matvec=1):
         except AttributeError:
             iloc = i
         subs = dict((d, iloc) for d in all_dims)
-        terms.append(expr.xreplace(subs) * c)
+        terms.append(expr.subs(subs) * c)
     deriv = Add(*terms)
 
     return deriv.evalf(_PRECISION)

--- a/devito/finite_differences/finite_difference.py
+++ b/devito/finite_differences/finite_difference.py
@@ -1,9 +1,7 @@
-from sympy import finite_diff_weights
-
 from devito.finite_differences.differentiable import Add
-from devito.finite_differences.tools import (symbolic_weights, left, right,
-                                             generate_indices, centered, check_input,
-                                             check_symbolic, direct, transpose)
+from devito.finite_differences.tools import (numeric_weights, symbolic_weights, left,
+                                             right, generate_indices, centered, direct,
+                                             transpose, check_input, check_symbolic)
 
 __all__ = ['first_derivative', 'second_derivative', 'cross_derivative',
            'generic_derivative', 'left', 'right', 'centered', 'transpose',
@@ -91,7 +89,7 @@ def first_derivative(expr, dim, fd_order=None, side=centered, matvec=direct,
     if symbolic:
         c = symbolic_weights(expr, 1, ind, dim)
     else:
-        c = finite_diff_weights(1, ind, dim)[-1][-1]
+        c = numeric_weights(1, ind, dim)
 
     return indices_weights_to_fd(expr, dim, ind, c, matvec=matvec.val)
 
@@ -256,7 +254,7 @@ def generic_derivative(expr, dim, fd_order, deriv_order, symbolic=False,
     if symbolic:
         c = symbolic_weights(expr, deriv_order, indices, x0)
     else:
-        c = finite_diff_weights(deriv_order, indices, x0)[-1][-1]
+        c = numeric_weights(deriv_order, indices, x0)
 
     return indices_weights_to_fd(expr, dim, indices, c, matvec=matvec.val)
 

--- a/devito/finite_differences/lazy.py
+++ b/devito/finite_differences/lazy.py
@@ -1,0 +1,44 @@
+__all__ = ['Evaluable']
+
+
+class Evaluable(object):
+
+    """
+    A mixin class for types inherited from SymPy that may carry nested
+    unevaluated arguments.
+
+    This mixin is used to implement lazy evaluation of expressions.
+    """
+
+    @classmethod
+    def _evaluate_maybe_nested(cls, maybe_evaluable):
+        if isinstance(maybe_evaluable, Evaluable):
+            return maybe_evaluable.evaluate
+        try:
+            # Not an Evaluable, but some Evaluables may still be hidden within `args`
+            if maybe_evaluable.args:
+                evaluated = [Evaluable._evaluate_maybe_nested(i)
+                             for i in maybe_evaluable.args]
+                return maybe_evaluable.func(*evaluated)
+            else:
+                return maybe_evaluable
+        except AttributeError:
+            # No `args` to be visited
+            return maybe_evaluable
+
+    @property
+    def args(self):
+        return ()
+
+    @property
+    def func(self):
+        return self.__class__
+
+    def _evaluate_args(self):
+        return [Evaluable._evaluate_maybe_nested(i) for i in self.args]
+
+    @property
+    def evaluate(self):
+        """Return a new object from the evaluation of ``self``."""
+        args = self._evaluate_args()
+        return self.func(*args)

--- a/devito/finite_differences/lazy.py
+++ b/devito/finite_differences/lazy.py
@@ -17,9 +17,13 @@ class Evaluable(object):
         try:
             # Not an Evaluable, but some Evaluables may still be hidden within `args`
             if maybe_evaluable.args:
-                evaluated = [Evaluable._evaluate_maybe_nested(i)
-                             for i in maybe_evaluable.args]
-                return maybe_evaluable.func(*evaluated)
+                args = [Evaluable._evaluate_maybe_nested(i) for i in maybe_evaluable.args]
+                evaluate = not all(i is j for i, j in zip(args, maybe_evaluable.args))
+                try:
+                    return maybe_evaluable.func(*args, evaluate=evaluate)
+                except TypeError:
+                    # Not all objects support the `evaluate` kwarg
+                    return maybe_evaluable.func(*args)
             else:
                 return maybe_evaluable
         except AttributeError:
@@ -41,4 +45,5 @@ class Evaluable(object):
     def evaluate(self):
         """Return a new object from the evaluation of ``self``."""
         args = self._evaluate_args()
-        return self.func(*args)
+        evaluate = not all(i is j for i, j in zip(args, self.args))
+        return self.func(*args, evaluate=evaluate)

--- a/devito/finite_differences/tools.py
+++ b/devito/finite_differences/tools.py
@@ -2,9 +2,10 @@ from functools import wraps, partial
 from itertools import product
 
 import numpy as np
-from sympy import S
+from sympy import S, finite_diff_weights, cacheit
 
-from devito.tools import Tag, as_tuple
+
+from devito.tools import Tag, as_tuple, memoized_func
 from devito.finite_differences import Differentiable
 
 
@@ -155,6 +156,11 @@ def generate_fd_shortcuts(function):
 def symbolic_weights(function, deriv_order, indices, dim):
     return [function._coeff_symbol(indices[j], deriv_order, function, dim)
             for j in range(0, len(indices))]
+
+
+@cacheit
+def numeric_weights(deriv_order, indices, x0):
+    return finite_diff_weights(deriv_order, indices, x0)[-1][-1]
 
 
 def generate_indices(func, dim, order, side=None, x0=None):

--- a/devito/finite_differences/tools.py
+++ b/devito/finite_differences/tools.py
@@ -5,7 +5,7 @@ import numpy as np
 from sympy import S, finite_diff_weights, cacheit
 
 
-from devito.tools import Tag, as_tuple, memoized_func
+from devito.tools import Tag, as_tuple
 from devito.finite_differences import Differentiable
 
 

--- a/devito/ir/clusters/algorithms.py
+++ b/devito/ir/clusters/algorithms.py
@@ -143,6 +143,7 @@ class Toposort(Queue):
                     break
                 elif deps:
                     dag.add_edge(cg0, cg1)
+                    continue
 
                 # Flow-dependences along one of the `prefix` Dimensions can
                 # be ignored; all others require sequentialization

--- a/devito/ir/clusters/algorithms.py
+++ b/devito/ir/clusters/algorithms.py
@@ -131,6 +131,13 @@ class Toposort(Queue):
                 rule = lambda i: i.is_cross  # Only retain dep if cross-ClusterGroup
                 scope = Scope(exprs=cg0.exprs + cg1.exprs, rules=rule)
 
+                # Optimization: we exploit the following property:
+                # no prefix => (edge <=> at least one (any) dependence)
+                # To jump out of this potentially expensive loop as quickly as possible
+                if not prefix and any(scope.d_all_gen()):
+                    dag.add_edge(cg0, cg1)
+                    continue
+
                 # Handle anti-dependences
                 if any(i.cause & prefix for i in scope.d_anti_gen()):
                     # Anti-dependences break the execution flow

--- a/devito/ir/clusters/algorithms.py
+++ b/devito/ir/clusters/algorithms.py
@@ -6,9 +6,9 @@ import sympy
 from devito.ir.support import Any, Backward, Forward, IterationSpace, Scope
 from devito.ir.clusters.analysis import analyze
 from devito.ir.clusters.cluster import Cluster, ClusterGroup
-from devito.ir.clusters.queue import Queue
+from devito.ir.clusters.queue import Queue, QueueStateful
 from devito.symbolics import CondEq
-from devito.tools import DAG, as_tuple, flatten, timed_pass
+from devito.tools import DAG, as_tuple, timed_pass
 
 __all__ = ['clusterize', 'Toposort']
 
@@ -166,7 +166,7 @@ class Toposort(Queue):
         return dag
 
 
-class Schedule(Queue):
+class Schedule(QueueStateful):
 
     """
     This special Queue produces a new sequence of "scheduled" Clusters, which
@@ -224,7 +224,7 @@ class Schedule(Queue):
         # `clusters` are supposed to share it
         candidates = prefix[-1].dim._defines
 
-        scope = Scope(exprs=flatten(c.exprs for c in clusters))
+        scope = self._fetch_scope(clusters)
 
         # Handle the nastiest case -- ambiguity due to the presence of both a
         # flow- and an anti-dependence.

--- a/devito/ir/clusters/queue.py
+++ b/devito/ir/clusters/queue.py
@@ -6,8 +6,7 @@ __all__ = ['Queue']
 class Queue(object):
 
     """
-    A special queue to process objects in nested IterationSpaces based on
-    a divide-and-conquer algorithm.
+    A special queue to process Clusters based on a divide-and-conquer algorithm.
 
     Notes
     -----
@@ -19,8 +18,8 @@ class Queue(object):
     def callback(self, *args):
         raise NotImplementedError
 
-    def process(self, elements):
-        return self._process_fdta(elements, 1)
+    def process(self, clusters):
+        return self._process_fdta(clusters, 1)
 
     def _make_key(self, element, level):
         itintervals = element.itintervals[:level]
@@ -32,7 +31,7 @@ class Queue(object):
     def _make_key_hook(self, element, level):
         return ()
 
-    def _process_fdta(self, elements, level, prefix=None):
+    def _process_fdta(self, clusters, level, prefix=None):
         """
         fdta -> First Divide Then Apply
         """
@@ -40,7 +39,7 @@ class Queue(object):
 
         # Divide part
         processed = []
-        for k, g in groupby(elements, key=lambda i: self._make_key(i, level)):
+        for k, g in groupby(clusters, key=lambda i: self._make_key(i, level)):
             pfx = k[0]
             if level > len(pfx):
                 # Base case
@@ -54,21 +53,21 @@ class Queue(object):
 
         return processed
 
-    def _process_fatd(self, elements, level):
+    def _process_fatd(self, clusters, level):
         """
         fatd -> First Apply Then Divide
         """
         # Divide part
         processed = []
-        for k, g in groupby(elements, key=lambda i: self._make_key(i, level)):
+        for k, g in groupby(clusters, key=lambda i: self._make_key(i, level)):
             pfx = k[0]
             if level > len(pfx):
                 # Base case
                 processed.extend(list(g))
             else:
                 # Apply callback
-                _elements = self.callback(list(g), pfx)
+                _clusters = self.callback(list(g), pfx)
                 # Recursion
-                processed.extend(self._process_fatd(_elements, level + 1))
+                processed.extend(self._process_fatd(_clusters, level + 1))
 
         return processed

--- a/devito/ir/equations/equation.py
+++ b/devito/ir/equations/equation.py
@@ -1,3 +1,4 @@
+from cached_property import cached_property
 import sympy
 
 from devito.ir.equations.algorithms import dimension_sort
@@ -39,7 +40,7 @@ class IREq(object):
     def dspace(self):
         return self._dspace
 
-    @property
+    @cached_property
     def dimensions(self):
         # Note: some dimensions may be in the iteration space but not in the
         # data space (e.g., a DerivedDimension); likewise, some dimensions may

--- a/devito/ir/equations/equation.py
+++ b/devito/ir/equations/equation.py
@@ -5,7 +5,6 @@ from devito.ir.equations.algorithms import dimension_sort
 from devito.ir.support import (IterationSpace, DataSpace, Interval, IntervalGroup,
                                Stencil, detect_accesses, detect_oobs, detect_io,
                                build_intervals, build_iterators)
-from devito.symbolics import FrozenExpr
 from devito.tools import Pickable, as_tuple
 from devito.types import Eq
 
@@ -176,7 +175,7 @@ class LoweredEq(sympy.Eq, IREq):
         return super(LoweredEq, self).func(*args, **self.state, evaluate=False)
 
 
-class ClusterizedEq(sympy.Eq, IREq, FrozenExpr, Pickable):
+class ClusterizedEq(sympy.Eq, IREq, Pickable):
 
     """
     ClusterizedEq(devito.IREq, **kwargs)

--- a/devito/ir/iet/nodes.py
+++ b/devito/ir/iet/nodes.py
@@ -264,9 +264,6 @@ class Expression(ExprStmt, Node):
     def __expr_finalize__(self, expr):
         """Finalize the Expression initialization."""
         self._expr = expr
-        self._reads, _ = detect_io(expr, relax=True)
-        self._dimensions = flatten(i.indices for i in self.functions if i.is_Indexed)
-        self._dimensions = tuple(filter_ordered(self._dimensions))
 
     def __repr__(self):
         return "<%s::%s>" % (self.__class__.__name__,
@@ -285,19 +282,20 @@ class Expression(ExprStmt, Node):
         """The Symbol/Indexed this Expression writes to."""
         return self.expr.lhs
 
-    @property
+    @cached_property
     def reads(self):
         """The Functions read by the Expression."""
-        return self._reads
+        return detect_io(self.expr, relax=True)[0]
 
     @property
     def write(self):
         """The Function written by the Expression."""
         return self.expr.lhs.function
 
-    @property
+    @cached_property
     def dimensions(self):
-        return self._dimensions
+        retval = flatten(i.indices for i in self.functions if i.is_Indexed)
+        return tuple(filter_ordered(retval))
 
     @property
     def is_scalar(self):
@@ -327,7 +325,7 @@ class Expression(ExprStmt, Node):
 
     @cached_property
     def functions(self):
-        functions = list(self._reads)
+        functions = list(self.reads)
         if self.write is not None:
             functions.append(self.write)
         return tuple(filter_ordered(functions))

--- a/devito/ir/iet/nodes.py
+++ b/devito/ir/iet/nodes.py
@@ -72,7 +72,7 @@ class Node(Signer):
         handle.update(kwargs)
         return type(self)(**handle)
 
-    @property
+    @cached_property
     def ccode(self):
         """
         Generate C code.

--- a/devito/ir/iet/visitors.py
+++ b/devito/ir/iet/visitors.py
@@ -13,7 +13,7 @@ import cgen as c
 from devito.exceptions import VisitorException
 from devito.ir.iet.nodes import Node, Iteration, Expression, Call
 from devito.ir.support.space import Backward
-from devito.symbolics import ccode
+from devito.symbolics import ccode, uxreplace
 from devito.tools import GenericVisitor, as_tuple, filter_sorted, flatten
 from devito.types.basic import AbstractFunction
 
@@ -734,12 +734,12 @@ class XSubs(Transformer):
     mapper : dict, optional
         The substitution rules.
     replacer : callable, optional
-        An ad-hoc function to perform the substitution. Defaults to SymPy's ``subs``.
+        An ad-hoc function to perform the substitution. Defaults to ``uxreplace``.
     """
 
     def __init__(self, mapper=None, replacer=None):
         super(XSubs, self).__init__()
-        self.replacer = replacer or (lambda i: i.subs(mapper))
+        self.replacer = replacer or (lambda i: uxreplace(i, mapper))
 
     def visit_Expression(self, o):
         return o._rebuild(expr=self.replacer(o.expr))

--- a/devito/ir/support/basic.py
+++ b/devito/ir/support/basic.py
@@ -534,6 +534,13 @@ class Dependence(object):
         """
         return self.source.timestamp == -1 or self.sink.timestamp == -1
 
+    @cached_property
+    def is_cross(self):
+        """
+        True if both source and sink are from the same IterationSpace, False otherwise.
+        """
+        return not self.source.ispace is self.sink.ispace
+
     @property
     def is_local(self):
         return self.function.is_Symbol

--- a/devito/ir/support/basic.py
+++ b/devito/ir/support/basic.py
@@ -538,7 +538,7 @@ class Dependence(object):
         """
         True if both source and sink are from the same IterationSpace, False otherwise.
         """
-        return not self.source.ispace is self.sink.ispace
+        return self.source.ispace is not self.sink.ispace
 
     @property
     def is_local(self):

--- a/devito/ir/support/basic.py
+++ b/devito/ir/support/basic.py
@@ -144,7 +144,7 @@ class IterationInstance(LabeledVector):
         """
         return set(as_tuple(findices)).issubset(set(self.findices_irregular))
 
-    @property
+    @cached_property
     def is_regular(self):
         return all(i is AFFINE for i in self.index_mode)
 

--- a/devito/ir/support/basic.py
+++ b/devito/ir/support/basic.py
@@ -211,11 +211,16 @@ class TimedAccess(IterationInstance):
         return "%s<%s,[%s]>" % (mode, self.name, ', '.join(str(i) for i in self))
 
     def __eq__(self, other):
-        return (isinstance(other, TimedAccess) and
-                self.function is other.function and
+        if not isinstance(other, TimedAccess):
+            return False
+
+        # At this point no need to go through the class hierarchy's __eq__,
+        # which might require expensive comparisons of Vector entries (i.e.,
+        # SymPy expressions)
+
+        return (self.indexed is other.indexed and  # => self.function is other.function
                 self.mode == other.mode and
-                self.ispace == other.ispace and
-                super(TimedAccess, self).__eq__(other))
+                self.ispace == other.ispace)
 
     def __hash__(self):
         return super(TimedAccess, self).__hash__()

--- a/devito/ir/support/space.py
+++ b/devito/ir/support/space.py
@@ -137,6 +137,9 @@ class Interval(AbstractInterval):
         return hash((self.dim, self.offsets))
 
     def __eq__(self, o):
+        if self is o:
+            return True
+
         return (super(Interval, self).__eq__(o) and
                 self.lower == o.lower and
                 self.upper == o.upper)

--- a/devito/ir/support/space.py
+++ b/devito/ir/support/space.py
@@ -628,6 +628,9 @@ class IterationSpace(Space):
         return "IterationSpace[%s]" % ret
 
     def __eq__(self, other):
+        if self is other:
+            return True
+
         return (isinstance(other, IterationSpace) and
                 self.intervals == other.intervals and
                 self.directions == other.directions)

--- a/devito/ir/support/space.py
+++ b/devito/ir/support/space.py
@@ -491,7 +491,7 @@ class Space(object):
     def intervals(self):
         return self._intervals
 
-    @property
+    @cached_property
     def dimensions(self):
         return filter_ordered(self.intervals.dimensions)
 
@@ -724,15 +724,15 @@ class IterationSpace(Space):
     def directions(self):
         return self._directions
 
-    @property
+    @cached_property
     def itintervals(self):
         return tuple(IterationInterval(i, self.directions[i.dim]) for i in self.intervals)
 
-    @property
+    @cached_property
     def dimensions(self):
         sub_dims = [i.parent for v in self.sub_iterators.values() for i in v]
         return filter_ordered(self.intervals.dimensions + sub_dims)
 
-    @property
+    @cached_property
     def nonderived_directions(self):
         return {k: v for k, v in self.directions.items() if not k.is_Derived}

--- a/devito/ir/support/utils.py
+++ b/devito/ir/support/utils.py
@@ -7,7 +7,7 @@ from devito.tools import as_tuple, flatten, filter_sorted
 from devito.types import Dimension, ModuloDimension
 
 __all__ = ['detect_accesses', 'detect_oobs', 'build_iterators', 'build_intervals',
-           'align_accesses', 'detect_io']
+           'detect_io']
 
 
 def detect_accesses(exprs):
@@ -101,21 +101,6 @@ def build_intervals(stencil):
         dim = d.parent if d.is_NonlinearDerived else d
         mapper.setdefault(dim, set()).update(offs)
     return [Interval(d, min(offs), max(offs)) for d, offs in mapper.items()]
-
-
-def align_accesses(expr, key=lambda i: False):
-    """
-    ``expr -> expr'``, with ``expr'`` semantically equivalent to ``expr``, but
-    with data accesses aligned to the domain if ``key(function)`` gives True.
-    """
-    mapper = {}
-    for indexed in retrieve_indexed(expr):
-        f = indexed.function
-        if not key(f):
-            continue
-        subs = {i: i + j for i, j in zip(indexed.indices, f._size_nodomain.left)}
-        mapper[indexed] = indexed.xreplace(subs)
-    return expr.xreplace(mapper)
 
 
 def detect_io(exprs, relax=False):

--- a/devito/ir/support/vector.py
+++ b/devito/ir/support/vector.py
@@ -240,7 +240,7 @@ class Vector(tuple):
         """
         try:
             # Handle quickly the special (yet relevant) cases `other == 0`
-            if other is 0:  # noqa: Must really be int 0, can't use ==
+            if is_integer(other) and other == 0:
                 return self
             elif all(i == 0 for i in other) and self.rank == other.rank:
                 return self

--- a/devito/ir/support/vector.py
+++ b/devito/ir/support/vector.py
@@ -240,7 +240,7 @@ class Vector(tuple):
         """
         try:
             # Handle quickly the special (yet relevant) cases `other == 0`
-            if other is 0:
+            if other is 0:  # noqa: Must really be int 0, can't use ==
                 return self
             elif all(i == 0 for i in other) and self.rank == other.rank:
                 return self

--- a/devito/ir/support/vector.py
+++ b/devito/ir/support/vector.py
@@ -1,6 +1,6 @@
 from collections import OrderedDict
 
-from sympy import Basic, true
+from sympy import true
 
 from devito.tools import as_tuple, is_integer, memoized_meth
 from devito.types import Dimension
@@ -248,7 +248,6 @@ class Vector(tuple):
             pass
 
         return self - other
-
 
 
 class LabeledVector(Vector):

--- a/devito/ir/support/vector.py
+++ b/devito/ir/support/vector.py
@@ -11,33 +11,36 @@ __all__ = ['Vector', 'LabeledVector', 'vmin', 'vmax']
 class Vector(tuple):
 
     """
-    A representation of an object in Z^n.
+    An object in an N-dimensional space.
 
-    The elements of a Vector can be integers or generic SymPy expressions.
+    The elements of a vector can be anything as long as they support the
+    comparison operators (`__eq__`, `__lt__`, ...). Also, the `__sub__`
+    operator must be available.
 
     Notes
     -----
-    1) Vector-scalar comparison
+    1) Comparison of a Vector with a scalar
     If a comparison between a vector and a non-vector is attempted, then the
     non-vector is promoted to a vector; if this is not possible, an exception
     is raised. This is handy because it turns a vector-scalar comparison into
-    a vector-vector comparison with the scalar broadcasted to all vector entries.
-    For example: ::
+    a vector-vector comparison with the scalar broadcasted to as many vector
+    entries as necessary. For example:
 
         (3, 4, 5) > 4 => (3, 4, 5) > (4, 4, 4) => False
 
-    2) Comparing Vector entries when these are SymPy expressions
-    When we compare two symbolic (SymPy expressions) entries, it might not be
-    possible to determine the truth value of the relation. For example, the
-    truth value of `3*i < 4*j` cannot be determined (unless some information
-    about `i` and `j` is available). In some cases, however, the comparison is
-    feasible; for example, `i + 4 < i` is definitely False. A sufficient condition
-    for two Vectors to be comparable is that their pair-wise indices are affine
-    functions of the same variables, with identical coefficient.
-    If the Vector is instantiated passing the keyword argument ``smart = True``,
-    some manipulation will be attempted to infer the truth value of a non-trivial
-    symbolic relation. This increases the cost of the comparison, while potentially
-    being ineffective, so use it judiciously. By default, ``smart = False``.
+    2) Comparison of Vectors whose elements are SymPy expressions
+    We treat vectors of SymPy expressions as a very special case. When we
+    compare two elements, it might not be possible to determine the truth value
+    of the relation. For example, the truth value of `3*i < 4*j` cannot be
+    determined (unless some information about `i` and `j` is available). In
+    some cases, however, the comparison is feasible; for example, `i + 4 < i`
+    is definitely False. A sufficient condition for two Vectors to be
+    comparable is that their pair-wise indices are affine functions of the same
+    variables, with identical coefficient.  If the Vector is instantiated
+    passing the keyword argument ``smart = True``, some manipulation will be
+    attempted to infer the truth value of a non-trivial symbolic relation. This
+    increases the cost of the comparison (and not always an answer may be
+    derived), so use it judiciously. By default, ``smart = False``.
 
     Raises
     ------
@@ -46,8 +49,6 @@ class Vector(tuple):
     """
 
     def __new__(cls, *items, smart=False):
-        if not all(is_integer(i) or isinstance(i, Basic) for i in items):
-            raise TypeError("Illegal Vector element type")
         obj = super(Vector, cls).__new__(cls, items)
         obj.smart = smart
         return obj

--- a/devito/operations/interpolators.py
+++ b/devito/operations/interpolators.py
@@ -4,9 +4,10 @@ import sympy
 import numpy as np
 from cached_property import cached_property
 
+from devito.finite_differences import Evaluable
 from devito.logger import warning
 from devito.symbolics import retrieve_function_carriers, indexify, INT
-from devito.tools import Evaluable, powerset, flatten, prod
+from devito.tools import powerset, flatten, prod
 from devito.types import Eq, Inc
 from devito.types.basic import Scalar
 from devito.types.dense import SubFunction

--- a/devito/operator/operator.py
+++ b/devito/operator/operator.py
@@ -20,8 +20,8 @@ from devito.operator.profiling import create_profile
 from devito.mpi import MPI
 from devito.parameters import configuration
 from devito.passes import Graph
-from devito.symbolics import (estimate_cost, indexify, retrieve_functions,
-                              retrieve_indexed, uxreplace)
+from devito.symbolics import (estimate_cost, retrieve_functions, retrieve_indexed,
+                              uxreplace)
 from devito.tools import (DAG, Signer, ReducerMap, as_tuple, flatten, filter_ordered,
                           filter_sorted, split, timed_pass, timed_region)
 from devito.types import Dimension, Eq

--- a/devito/operator/operator.py
+++ b/devito/operator/operator.py
@@ -329,8 +329,7 @@ class Operator(Callable):
                 f = i.function
 
                 # Introduce shifting to align with the computational domain
-                indices = [(a + o).xreplace(dimension_map)
-                           for a, o in zip(i.indices, f._size_nodomain.left)]
+                indices = [(a + o) for a, o in zip(i.indices, f._size_nodomain.left)]
 
                 # Apply substitutions, if necessary
                 if dimension_map:

--- a/devito/operator/operator.py
+++ b/devito/operator/operator.py
@@ -9,6 +9,7 @@ import ctypes
 from devito.archinfo import platform_registry
 from devito.compiler import compiler_registry
 from devito.exceptions import InvalidOperator
+from devito.finite_differences import Evaluable
 from devito.logger import info, perf, warning, is_log_enabled_for
 from devito.ir.equations import LoweredEq
 from devito.ir.clusters import ClusterGroup, clusterize
@@ -22,7 +23,7 @@ from devito.passes import Graph
 from devito.symbolics import (estimate_cost, indexify, retrieve_functions,
                               retrieve_indexed, uxreplace)
 from devito.tools import (DAG, Signer, ReducerMap, as_tuple, flatten, filter_ordered,
-                          filter_sorted, split, timed_pass, timed_region, Evaluable)
+                          filter_sorted, split, timed_pass, timed_region)
 from devito.types import Dimension, Eq
 
 __all__ = ['Operator']

--- a/devito/operator/operator.py
+++ b/devito/operator/operator.py
@@ -19,7 +19,8 @@ from devito.operator.profiling import create_profile
 from devito.mpi import MPI
 from devito.parameters import configuration
 from devito.passes import Graph
-from devito.symbolics import estimate_cost, indexify
+from devito.symbolics import (estimate_cost, indexify, retrieve_functions,
+                              retrieve_indexed)
 from devito.tools import (DAG, Signer, ReducerMap, as_tuple, flatten, filter_ordered,
                           filter_sorted, split, timed_pass, timed_region, Evaluable)
 from devito.types import Dimension, Eq
@@ -265,27 +266,6 @@ class Operator(Callable):
         return {'optimizations': kwargs.get('mode', configuration['opt'])}
 
     @classmethod
-    def _apply_substitutions(cls, expressions, subs):
-        """
-        Transform ``expressions`` by:
-
-            * Applying any user-provided symbolic substitution;
-            * Replacing Dimensions with SubDimensions based on expression SubDomains.
-        """
-        processed = []
-        for e in expressions:
-            mapper = subs.copy()
-            if e.subdomain:
-                mapper.update(e.subdomain.dimension_map)
-
-            if mapper:
-                processed.append(e.xreplace(mapper))
-            else:
-                # Do not waste time
-                processed.append(e)
-        return processed
-
-    @classmethod
     def _specialize_exprs(cls, expressions):
         """
         Backend hook for specialization at the Expression level.
@@ -305,17 +285,67 @@ class Operator(Callable):
             * Apply substitution rules;
             * Specialize (e.g., index shifting)
         """
-        subs = kwargs.get("subs", {})
-
+        # Add in implicit expressions, e.g., induced by SubDomains
         expressions = cls._add_implicit(expressions)
+
+        # Unfold lazyiness
         expressions = flatten([i.evaluate for i in expressions])
+
+        # Scalarize tensor expressions
         expressions = [j for i in expressions for j in i._flatten]
-        expressions = [indexify(i) for i in expressions]
-        expressions = cls._apply_substitutions(expressions, subs)
 
-        expressions = cls._specialize_exprs(expressions)
+        # Indexification
+        # E.g., f(x - 2*h_x, y) -> f[xi + 2, yi + 4]  (assuming halo_size=4)
+        processed = []
+        for expr in expressions:
+            if expr.subdomain:
+                dimension_map = expr.subdomain.dimension_map
+            else:
+                dimension_map = {}
 
-        return expressions
+            mapper = {}
+
+            # Handle Functions (typical case)
+            for f in retrieve_functions(expr):
+                # Get spacing symbols for replacement
+                spacings = [i.spacing for i in f.dimensions]
+
+                # Only keep the ones used as indices
+                spacings = [s for i, s in enumerate(spacings)
+                            if s.free_symbols.intersection(f.args[i].free_symbols)]
+
+                # Substitution for each index
+                subs = {**{s: 1 for s in spacings}, **dimension_map}
+
+                # Introduce shifting to align with the computational domain,
+                # and apply substitutions
+                indices = [(a - i + o).xreplace(subs)
+                           for a, i, o in zip(f.args, f.origin, f._size_nodomain.left)]
+
+                mapper[f] = f.indexed[indices]
+
+            # Handle Indexeds (from index notation)
+            for i in retrieve_indexed(expr):
+                f = i.function
+
+                # Introduce shifting to align with the computational domain
+                indices = [(a + o).xreplace(dimension_map)
+                           for a, o in zip(i.indices, f._size_nodomain.left)]
+
+                # Apply substitutions, if necessary
+                if dimension_map:
+                    indices = [j.xreplace(dimension_map) for j in indices]
+
+                mapper[i] = f.indexed[indices]
+
+            # Include any user-supplied substitutions
+            mapper.update(kwargs.get('subs', {}))
+
+            processed.append(expr.xreplace(mapper))
+
+        processed = cls._specialize_exprs(processed)
+
+        return processed
 
     # Compilation -- Cluster level
 

--- a/devito/operator/operator.py
+++ b/devito/operator/operator.py
@@ -277,7 +277,12 @@ class Operator(Callable):
             mapper = subs.copy()
             if e.subdomain:
                 mapper.update(e.subdomain.dimension_map)
-            processed.append(e.xreplace(mapper))
+
+            if mapper:
+                processed.append(e.xreplace(mapper))
+            else:
+                # Do not waste time
+                processed.append(e)
         return processed
 
     @classmethod

--- a/devito/passes/clusters/aliases.py
+++ b/devito/passes/clusters/aliases.py
@@ -90,8 +90,7 @@ def cire(cluster, template, mode, options, platform):
     if mode == 'invariants':
         # Extraction rule
         def extractor(context):
-            is_time_invariant = make_is_time_invariant(context)
-            return lambda e: is_time_invariant(e)
+            return make_is_time_invariant(context)
 
         # Extraction model
         model = lambda e: estimate_cost(e, True) >= MIN_COST_ALIAS_INV
@@ -102,7 +101,7 @@ def cire(cluster, template, mode, options, platform):
     elif mode == 'sops':
         # Extraction rule
         def extractor(context):
-            return lambda e: q_sum_of_product(e)
+            return q_sum_of_product
 
         # Extraction model
         model = lambda e: not (q_leaf(e) or q_terminalop(e))

--- a/devito/passes/clusters/blocking.py
+++ b/devito/passes/clusters/blocking.py
@@ -2,6 +2,7 @@ from collections import Counter
 
 from devito.ir.clusters import Queue
 from devito.ir.support import TILABLE, IntervalGroup, IterationSpace
+from devito.symbolics import uxreplace
 from devito.tools import timed_pass
 from devito.types import IncrDimension
 
@@ -83,7 +84,7 @@ class Blocking(Queue):
                 ispace = decompose(c.ispace, d, block_dims)
 
                 # Use the innermost IncrDimension in place of `d`
-                exprs = [e.xreplace({d: bd}) for e in c.exprs]
+                exprs = [uxreplace(e, {d: bd}) for e in c.exprs]
 
                 # The new Cluster properties
                 properties = dict(c.properties)

--- a/devito/passes/clusters/cse.py
+++ b/devito/passes/clusters/cse.py
@@ -2,7 +2,7 @@ from collections import OrderedDict
 
 from devito.ir import DummyEq, Cluster, Scope
 from devito.passes.clusters.utils import cluster_pass, makeit_ssa
-from devito.symbolics import count, estimate_cost, q_xop, q_leaf, yreplace
+from devito.symbolics import count, estimate_cost, q_xop, q_leaf, uxreplace, yreplace
 from devito.types import Scalar
 
 __all__ = ['cse']
@@ -82,8 +82,8 @@ def _cse(maybe_exprs, make, mode='default'):
         mapper = OrderedDict([(e, make()) for i, e in enumerate(picked)])
 
         # Apply replacements
-        processed = [e.xreplace(mapper) for e in processed]
-        mapped = [e.xreplace(mapper) for e in mapped]
+        processed = [uxreplace(e, mapper) for e in processed]
+        mapped = [uxreplace(e, mapper) for e in mapped]
         mapped = [DummyEq(v, k) for k, v in reversed(list(mapper.items()))] + mapped
 
         # Update `exclude` for the same reasons as above -- to rule out CSE across

--- a/devito/passes/clusters/factorization.py
+++ b/devito/passes/clusters/factorization.py
@@ -117,18 +117,7 @@ def _collect_nested(expr):
             return rebuilt, {}
         elif expr.is_Mul:
             args, candidates = zip(*[run(arg) for arg in expr.args])
-
-            # Always collect coefficients
-            rebuilt = collect_const(expr.func(*args))
-            try:
-                if rebuilt.args:
-                    # Note: Mul(*()) -> 1, and since sympy.S.Zero.args == (),
-                    # the `if` prevents turning 0 into 1
-                    rebuilt = Mul(*rebuilt.args)
-            except AttributeError:
-                pass
-
-            return rebuilt, ReducerMap.fromdicts(*candidates)
+            return Mul(*args), ReducerMap.fromdicts(*candidates)
         elif expr.is_Equality:
             args, candidates = zip(*[run(expr.lhs), run(expr.rhs)])
             return expr.func(*args, evaluate=False), ReducerMap.fromdicts(*candidates)

--- a/devito/passes/clusters/factorization.py
+++ b/devito/passes/clusters/factorization.py
@@ -120,16 +120,20 @@ def collect_nested(expr):
             coeffs = candidates.getall('coeffs', [])
 
             # Functions/Pows are collected first, coefficients afterwards
-            # Note: below we use sets, but SymPy will ensure determinism
-            args = set(args)
-            w_funcs = {i for i in args if any(j in funcs for j in i.args)}
-            args -= w_funcs
-            w_pows = {i for i in args if any(j in pows for j in i.args)}
-            args -= w_pows
-            w_coeffs = {i for i in args if any(j in coeffs for j in i.args)}
-            args -= w_coeffs
-
             terms = []
+            w_funcs = []
+            w_pows = []
+            w_coeffs = []
+            for i in args:
+                _args = i.args
+                if any(j in funcs for j in _args):
+                    w_funcs.append(i)
+                elif any(j in pows for j in _args):
+                    w_pows.append(i)
+                elif any(j in coeffs for j in _args):
+                    w_coeffs.append(i)
+                else:
+                    terms.append(i)
 
             # Collect common funcs
             w_funcs = Add(*w_funcs, evaluate=False)
@@ -163,7 +167,7 @@ def collect_nested(expr):
                 terms.append(w_coeffs)
 
             # Collect common coefficients
-            rebuilt = Add(*terms, *args)
+            rebuilt = Add(*terms)
             rebuilt = collect_const(rebuilt)
 
             return rebuilt, {}

--- a/devito/passes/clusters/factorization.py
+++ b/devito/passes/clusters/factorization.py
@@ -4,7 +4,7 @@ from sympy import Add, Mul, collect
 
 from devito.passes.clusters.utils import cluster_pass
 from devito.symbolics import estimate_cost, retrieve_scalars
-from devito.tools import ReducerMap, as_mapper
+from devito.tools import ReducerMap
 
 __all__ = ['factorize']
 

--- a/devito/passes/clusters/misc.py
+++ b/devito/passes/clusters/misc.py
@@ -175,7 +175,7 @@ def eliminate_arrays(clusters, template):
         subs = {}
         for f, v in mapper.items():
             for i in filter_ordered(i.indexed for i in c.scope[f]):
-                subs[i] = v[f.indices]
+                subs[i] = v[i.indices]
         exprs = []
         for e in c.exprs:
             if e.lhs.function in mapper:

--- a/devito/passes/clusters/misc.py
+++ b/devito/passes/clusters/misc.py
@@ -3,12 +3,12 @@ from itertools import groupby
 from devito.ir.clusters import Cluster, Queue
 from devito.ir.support import TILABLE
 from devito.passes.clusters.utils import cluster_pass
-from devito.symbolics import pow_to_mul, xreplace_indices, freeze as _freeze
+from devito.symbolics import pow_to_mul, xreplace_indices, uxreplace
 from devito.tools import filter_ordered, timed_pass
 from devito.types import Scalar
 
 __all__ = ['Lift', 'fuse', 'scalarize', 'eliminate_arrays', 'optimize_pows',
-           'extract_increments', 'freeze']
+           'extract_increments']
 
 
 class Lift(Queue):
@@ -130,11 +130,11 @@ def scalarize(clusters, template):
                     shifting = {idx: idx + (o2 - o1) for idx, o1, o2 in
                                 zip(f.indices, e.lhs.indices, i.indices)}
 
-                    handle = e.func(mapper[i], e.rhs.xreplace(mapper))
+                    handle = e.func(mapper[i], uxreplace(e.rhs, mapper))
                     handle = xreplace_indices(handle, shifting)
                     exprs.append(handle)
             else:
-                exprs.append(e.func(e.lhs, e.rhs.xreplace(mapper)))
+                exprs.append(e.func(e.lhs, uxreplace(e.rhs, mapper)))
 
         processed.append(c.rebuild(exprs))
 
@@ -216,12 +216,3 @@ def extract_increments(cluster, template, *args):
             processed.append(e)
 
     return cluster.rebuild(processed)
-
-
-@cluster_pass(mode='all')
-def freeze(cluster):
-    """
-    Prevent future symbolic manipulations (e.g., xreplace, subs, ...) from
-    altering the arithmetic structure of the expressions.
-    """
-    return cluster.rebuild([_freeze(e) for e in cluster.exprs])

--- a/devito/passes/clusters/misc.py
+++ b/devito/passes/clusters/misc.py
@@ -181,7 +181,7 @@ def eliminate_arrays(clusters, template):
             if e.lhs.function in mapper:
                 # Drop the write
                 continue
-            exprs.append(e.xreplace(subs))
+            exprs.append(uxreplace(e, subs))
 
         processed.append(c.rebuild(exprs))
 

--- a/devito/passes/clusters/utils.py
+++ b/devito/passes/clusters/utils.py
@@ -1,6 +1,6 @@
 from collections import Iterable, OrderedDict
 
-from devito.symbolics import retrieve_terminals
+from devito.symbolics import retrieve_terminals, uxreplace
 from devito.tools import flatten, timed_pass
 from devito.types import Dimension, Symbol
 
@@ -72,7 +72,7 @@ def makeit_ssa(exprs):
     processed = []
     for i, e in enumerate(exprs):
         where = seen[e.lhs]
-        rhs = e.rhs.xreplace(mapper)
+        rhs = uxreplace(e.rhs, mapper)
         if len(where) > 1:
             needssa = e.is_Scalar or where[-1] != i
             lhs = Symbol(name='ssa%d' % c, dtype=e.dtype) if needssa else e.lhs

--- a/devito/passes/clusters/utils.py
+++ b/devito/passes/clusters/utils.py
@@ -93,6 +93,11 @@ def make_is_time_invariant(context):
     Given an ordered list of expressions, returns a callable that finds out whether
     a given expression is time invariant or not.
     """
+    dimensions = set().union(*[e.dimensions for e in context])
+    if len([i for i in dimensions if i.is_Time]) == 0:
+        # No concept of time in the provided set of expressions
+        return lambda i: False
+
     mapper = OrderedDict([(i.lhs, i) for i in makeit_ssa(context)])
 
     def is_time_invariant(mapper, expr):

--- a/devito/symbolics/extended_sympy.py
+++ b/devito/symbolics/extended_sympy.py
@@ -10,53 +10,12 @@ from sympy.core.basic import _aresame
 from devito.symbolics.printer import ccode
 from devito.tools import Pickable, as_tuple, is_integer
 
-__all__ = ['FrozenExpr', 'Eq', 'CondEq', 'CondNe', 'Mul', 'Add', 'Pow', 'IntDiv',
-           'FunctionFromPointer', 'FieldFromPointer', 'FieldFromComposite',
-           'ListInitializer', 'Byref', 'IndexedPointer', 'Macro', 'Literal',
-           'INT', 'FLOAT', 'DOUBLE', 'FLOOR', 'cast_mapper']
+__all__ = ['CondEq', 'CondNe', 'IntDiv', 'FunctionFromPointer', 'FieldFromPointer',
+           'FieldFromComposite', 'ListInitializer', 'Byref', 'IndexedPointer',
+           'Macro', 'Literal', 'INT', 'FLOAT', 'DOUBLE', 'FLOOR', 'cast_mapper']
 
 
-class FrozenExpr(Expr):
-
-    """
-    Use FrozenExpr in place of sympy.Expr to make sure than an e an expression
-    is no longer transformable; that is, standard manipulations such as
-    xreplace, collect, expand, ... have no effect, thus building a new
-    expression identical to self.
-
-    Notes
-    -----
-    At the moment, only xreplace is overridded (to prevent unpicking factorizations)
-    """
-
-    def xreplace(self, rule):
-        if self in rule:
-            return rule[self]
-        elif rule:
-            args = []
-            for a in self.args:
-                try:
-                    args.append(a.xreplace(rule))
-                except AttributeError:
-                    args.append(a)
-            args = tuple(args)
-            if not _aresame(args, self.args):
-                return self.func(*args, evaluate=False)
-        return self
-
-    def evalf(self, *args, **kwargs):
-        return self
-
-
-class Eq(sympy.Eq, FrozenExpr):
-
-    """A customized version of sympy.Eq which suppresses evaluation."""
-
-    def __new__(cls, *args, **kwargs):
-        return sympy.Eq.__new__(cls, *args, evaluate=False)
-
-
-class CondEq(sympy.Eq, FrozenExpr):
+class CondEq(sympy.Eq):
 
     """
     A customized version of sympy.Eq representing a conditional equality.
@@ -75,7 +34,7 @@ class CondEq(sympy.Eq, FrozenExpr):
         return CondNe(*self.args, evaluate=False)
 
 
-class CondNe(sympy.Ne, FrozenExpr):
+class CondNe(sympy.Ne):
 
     """
     A customized version of sympy.Ne representing a conditional inequality.
@@ -92,21 +51,6 @@ class CondNe(sympy.Ne, FrozenExpr):
     @property
     def negated(self):
         return CondEq(*self.args, evaluate=False)
-
-
-class Mul(sympy.Mul, FrozenExpr):
-    def __new__(cls, *args, **kwargs):
-        return sympy.Mul.__new__(cls, *args, evaluate=False)
-
-
-class Add(sympy.Add, FrozenExpr):
-    def __new__(cls, *args, **kwargs):
-        return sympy.Add.__new__(cls, *args, evaluate=False)
-
-
-class Pow(sympy.Pow, FrozenExpr):
-    def __new__(cls, *args, **kwargs):
-        return sympy.Pow.__new__(cls, *args, evaluate=False)
 
 
 class IntDiv(sympy.Expr):

--- a/devito/symbolics/extended_sympy.py
+++ b/devito/symbolics/extended_sympy.py
@@ -5,7 +5,6 @@ Extended SymPy hierarchy.
 import numpy as np
 import sympy
 from sympy import Expr, Integer, Function, Symbol
-from sympy.core.basic import _aresame
 
 from devito.symbolics.printer import ccode
 from devito.tools import Pickable, as_tuple, is_integer

--- a/devito/symbolics/manipulation.py
+++ b/devito/symbolics/manipulation.py
@@ -186,10 +186,7 @@ def yreplace(exprs, make, rule=None, costmodel=lambda e: True, repeat=False, eag
 
             # The whole RHS may need to be replaced
             if flag and costmodel(ret):
-                if expr.lhs.function.is_Array:
-                    ret = root
-                else:
-                    ret = replace(root)
+                ret = replace(root)
 
             if repeat and ret != root:
                 root = ret

--- a/devito/symbolics/manipulation.py
+++ b/devito/symbolics/manipulation.py
@@ -1,15 +1,19 @@
 from collections import OrderedDict, namedtuple
 from collections.abc import Iterable
+from functools import singledispatch
 
 import sympy
 from sympy import Number, Indexed, Symbol, LM, LC
+from sympy.core.add import _addsort
+from sympy.core.mul import _mulsort
 
 from devito.symbolics.extended_sympy import Add, Mul, Pow, Eq, FrozenExpr
 from devito.symbolics.search import retrieve_indexed, retrieve_functions
 from devito.tools import as_tuple, flatten, split
+from devito.types.equation import Eq as iEq  #TODO CHANGE ME
 
 __all__ = ['freeze', 'unfreeze', 'evaluate', 'yreplace', 'xreplace_indices',
-           'pow_to_mul', 'as_symbol', 'indexify', 'split_affine']
+           'pow_to_mul', 'as_symbol', 'indexify', 'split_affine', 'uxreplace']
 
 
 def freeze(expr):
@@ -198,6 +202,74 @@ def yreplace(exprs, make, rule=None, costmodel=lambda e: True, repeat=False, eag
         built.extend(expr.func(v, k) for k, v in list(found.items())[len(built):])
 
     return built + rebuilt, built
+
+
+def uxreplace(expr, rule):
+    """
+    An alternative to SymPy's ``xreplace`` for when the caller can guarantee
+    that no re-evaluations are necessary or when re-evaluations should indeed
+    be avoided at all costs (e.g., to prevent SymPy from unpicking Devito
+    transformations, such as factorization).
+
+    The canonical ordering of the arguments is however guaranteed; where this is
+    not possible, a re-evaluation will be enforced.
+
+    By avoiding re-evaluations, this function is typically much quicker than
+    SymPy's xreplace.
+    """
+    return _uxreplace(expr, rule)[0]
+
+
+def _uxreplace(expr, rule):
+    """
+    Helper for uxreplace.
+    """
+    if expr in rule:
+        return rule[expr], True
+    elif rule:
+        args = []
+        changed = False
+        for a in expr.args:
+            try:
+                ax, flag = _uxreplace(a, rule)
+                args.append(ax)
+                changed |= flag
+            except AttributeError:
+                # E.g., un-sympified numbers
+                args.append(a)
+        if changed:
+            return _uxreplace_handle(expr, args), True
+    return expr, False
+
+
+@singledispatch
+def _uxreplace_handle(expr, args):
+    return expr.func(*args)
+
+
+@_uxreplace_handle.register(sympy.Add)
+def _(expr, args):
+    if all(i.is_commutative for i in args):
+        _addsort(args)  # In-place sorting
+        return expr.func(*args, evaluate=False)
+    else:
+        return expr.func(*args)
+
+
+@_uxreplace_handle.register(sympy.Mul)
+def _(expr, args):
+    if all(i.is_commutative for i in args):
+        _mulsort(args)  # In-place sorting
+        return expr.func(*args, evaluate=False)
+    else:
+        return expr.func(*args)
+
+
+@_uxreplace_handle.register(iEq)
+def _(expr, args):
+    # Preserve properties such as `implicit_dims`
+    return expr.func(*args, subdomain=expr.subdomain, coefficients=expr.substitutions,
+                     implicit_dims=expr.implicit_dims)
 
 
 def xreplace_indices(exprs, mapper, key=None, only_rhs=False):

--- a/devito/symbolics/manipulation.py
+++ b/devito/symbolics/manipulation.py
@@ -7,60 +7,12 @@ from sympy import Number, Indexed, Symbol, LM, LC
 from sympy.core.add import _addsort
 from sympy.core.mul import _mulsort
 
-from devito.symbolics.extended_sympy import Add, Mul, Pow, Eq, FrozenExpr
 from devito.symbolics.search import retrieve_indexed, retrieve_functions
 from devito.tools import as_tuple, flatten, split
-from devito.types.equation import Eq as iEq  #TODO CHANGE ME
+from devito.types.equation import Eq
 
-__all__ = ['freeze', 'unfreeze', 'evaluate', 'yreplace', 'xreplace_indices',
-           'pow_to_mul', 'as_symbol', 'indexify', 'split_affine', 'uxreplace']
-
-
-def freeze(expr):
-    """
-    Reconstruct ``expr`` turning all sympy.Mul and sympy.Add
-    into FrozenExpr equivalents.
-    """
-    if expr.is_Atom or expr.is_Indexed:
-        return expr
-    elif expr.is_Add:
-        rebuilt_args = [freeze(e) for e in expr.args]
-        return Add(*rebuilt_args, evaluate=False)
-    elif expr.is_Mul:
-        rebuilt_args = [freeze(e) for e in expr.args]
-        return Mul(*rebuilt_args, evaluate=False)
-    elif expr.is_Pow:
-        rebuilt_args = [freeze(e) for e in expr.args]
-        return Pow(*rebuilt_args, evaluate=False)
-    elif expr.is_Equality:
-        rebuilt_args = [freeze(e) for e in expr.args]
-        if isinstance(expr, FrozenExpr):
-            # Avoid dropping metadata associated with /expr/
-            return expr.func(*rebuilt_args)
-        else:
-            return Eq(*rebuilt_args, evaluate=False)
-    else:
-        return expr.func(*[freeze(e) for e in expr.args])
-
-
-def unfreeze(expr):
-    """
-    Reconstruct ``expr`` turning all FrozenExpr subtrees into their
-    SymPy equivalents.
-    """
-    if expr.is_Atom or expr.is_Indexed:
-        return expr
-    func = expr.func.__base__ if isinstance(expr, FrozenExpr) else expr.func
-    return func(*[unfreeze(e) for e in expr.args])
-
-
-def evaluate(expr, **subs):
-    """
-    Numerically evaluate a SymPy expression. Subtrees of type FrozenExpr
-    are forcibly evaluated.
-    """
-    expr = unfreeze(expr)
-    return expr.subs(subs)
+__all__ = ['yreplace', 'xreplace_indices', 'pow_to_mul', 'as_symbol', 'indexify',
+           'split_affine', 'uxreplace']
 
 
 def yreplace(exprs, make, rule=None, costmodel=lambda e: True, repeat=False, eager=False):
@@ -265,7 +217,7 @@ def _(expr, args):
         return expr.func(*args)
 
 
-@_uxreplace_handle.register(iEq)
+@_uxreplace_handle.register(Eq)
 def _(expr, args):
     # Preserve properties such as `implicit_dims`
     return expr.func(*args, subdomain=expr.subdomain, coefficients=expr.substitutions,
@@ -296,8 +248,8 @@ def xreplace_indices(exprs, mapper, key=None, only_rhs=False):
         handle = [i for i in handle if i.base.label in key]
     elif callable(key):
         handle = [i for i in handle if key(i)]
-    mapper = dict(zip(handle, [i.xreplace(mapper) for i in handle]))
-    replaced = [i.xreplace(mapper) for i in as_tuple(exprs)]
+    mapper = dict(zip(handle, [uxreplace(i, mapper) for i in handle]))
+    replaced = [uxreplace(i, mapper) for i in as_tuple(exprs)]
     return replaced if isinstance(exprs, Iterable) else replaced[0]
 
 

--- a/devito/symbolics/manipulation.py
+++ b/devito/symbolics/manipulation.py
@@ -205,7 +205,7 @@ def _(expr, args):
         _addsort(args)  # In-place sorting
         return expr.func(*args, evaluate=False)
     else:
-        return expr.func(*args)
+        return expr._new_rawargs(*args)
 
 
 @_uxreplace_handle.register(sympy.Mul)
@@ -214,7 +214,7 @@ def _(expr, args):
         _mulsort(args)  # In-place sorting
         return expr.func(*args, evaluate=False)
     else:
-        return expr.func(*args)
+        return expr._new_rawargs(*args)
 
 
 @_uxreplace_handle.register(Eq)

--- a/devito/symbolics/printer.py
+++ b/devito/symbolics/printer.py
@@ -99,9 +99,6 @@ class CodePrinter(C99CodePrinter):
     def _print_Differentiable(self, expr):
         return "(" + self._print(expr._expr) + ")"
 
-    def _print_FrozenExpr(self, expr):
-        return self._print(expr.args[0])
-
     def _print_FunctionFromPointer(self, expr):
         indices = [self._print(i) for i in expr.params]
         return "%s->%s(%s)" % (expr.pointer, expr.function, ', '.join(indices))

--- a/devito/symbolics/queries.py
+++ b/devito/symbolics/queries.py
@@ -131,22 +131,29 @@ def q_affine(expr, vars):
     Return True if ``expr`` is (separately) affine in the variables ``vars``,
     False otherwise.
 
-    Readapted from: https://stackoverflow.com/questions/36283548\
+    Notes
+    -----
+    Exploits:
+
+        https://stackoverflow.com/questions/36283548\
         /check-if-an-equation-is-linear-for-a-specific-set-of-variables/
     """
     vars = as_tuple(vars)
-    # If any `vars` does not appear in `expr`, the only possibility
-    # for `expr` to be affine is that it's a constant function
-    if any(x not in expr.atoms() for x in vars):
-        return q_constant(expr)
+    free_symbols = expr.free_symbols
+
     # At this point, `expr` is (separately) affine in the `vars` variables
     # if all non-mixed second order derivatives are identically zero.
     for x in vars:
+        if expr is x:
+            continue
+
+        if x not in free_symbols:
+            # At this point the only hope is that `expr` is constant
+            return q_constant(expr)
+
         # The vast majority of calls here are incredibly simple tests
         # like q_affine(x+1, [x]).  Catch these quickly and
         # explicitly, instead of calling the very slow function `diff`.
-        if expr is x:
-            continue
         if expr.is_Add and len(expr.args) == 2:
             if expr.args[1] is x and expr.args[0].is_Number:
                 continue
@@ -158,6 +165,7 @@ def q_affine(expr, vars):
                 return False
         except TypeError:
             return False
+
     return True
 
 

--- a/devito/symbolics/queries.py
+++ b/devito/symbolics/queries.py
@@ -5,16 +5,15 @@ from devito.tools import as_tuple, is_integer
 
 __all__ = ['q_leaf', 'q_indexed', 'q_terminal', 'q_trigonometry', 'q_routine', 'q_xop',
            'q_terminalop', 'q_sum_of_product', 'q_indirect', 'q_constant', 'q_affine',
-           'q_linear', 'q_identity', 'q_inc', 'q_scalar', 'q_multivar', 'q_monoaffine']
+           'q_linear', 'q_identity', 'q_inc', 'q_scalar', 'q_multivar', 'q_monoaffine',
+           'q_function']
 
 
-"""
-The following SymPy objects are considered tree leaves:
-
-    * Number
-    * Symbol
-    * Indexed
-"""
+# The following SymPy objects are considered tree leaves:
+#
+# * Number
+# * Symbol
+# * Indexed
 
 
 def q_scalar(expr):

--- a/devito/tools/abc.py
+++ b/devito/tools/abc.py
@@ -2,7 +2,7 @@ import abc
 from hashlib import sha1
 
 
-__all__ = ['Tag', 'Signer', 'Pickable', 'Evaluable', 'Singleton']
+__all__ = ['Tag', 'Signer', 'Pickable', 'Singleton']
 
 
 class Tag(abc.ABC):
@@ -148,47 +148,6 @@ class Pickable(object):
     def __getnewargs_ex__(self):
         return (tuple(getattr(self, i) for i in self._pickle_args),
                 {i.lstrip('_'): getattr(self, i) for i in self._pickle_kwargs})
-
-
-class Evaluable(object):
-
-    """
-    A mixin class for types that may carry nested unevaluated arguments.
-
-    This mixin is useful to implement systems based upon lazy evaluation.
-    """
-
-    @classmethod
-    def _evaluate_maybe_nested(cls, maybe_evaluable):
-        if isinstance(maybe_evaluable, Evaluable):
-            return maybe_evaluable.evaluate
-        try:
-            # Not an Evaluable, but some Evaluables may still be hidden within `args`
-            if maybe_evaluable.args:
-                evaluated = [Evaluable._evaluate_maybe_nested(i)
-                             for i in maybe_evaluable.args]
-                return maybe_evaluable.func(*evaluated)
-            else:
-                return maybe_evaluable
-        except AttributeError:
-            # No `args` to be visited
-            return maybe_evaluable
-
-    @property
-    def args(self):
-        return ()
-
-    @property
-    def func(self):
-        return self.__class__
-
-    def _evaluate_args(self):
-        return [Evaluable._evaluate_maybe_nested(i) for i in self.args]
-
-    @property
-    def evaluate(self):
-        """Return a new object from the evaluation of ``self``."""
-        return self.func(*self._evaluate_args())
 
 
 class Singleton(type):

--- a/devito/types/basic.py
+++ b/devito/types/basic.py
@@ -195,6 +195,11 @@ class AbstractSymbol(sympy.Symbol, Basic, Pickable, Evaluable):
     is_AbstractSymbol = True
     is_Symbol = True
 
+    # SymPy default assumptions
+    is_real = True
+    is_imaginary = False
+    is_commutative = True
+
     @classmethod
     def _filter_assumptions(cls, **kwargs):
         """Extract sympy.Symbol-specific kwargs."""
@@ -599,6 +604,11 @@ class AbstractFunction(sympy.Function, Basic, Cached, Pickable, Evaluable):
     """
 
     is_AbstractFunction = True
+
+    # SymPy default assumptions
+    is_real = True
+    is_imaginary = False
+    is_commutative = True
 
     @classmethod
     def _cache_key(cls, *args, **kwargs):

--- a/devito/types/basic.py
+++ b/devito/types/basic.py
@@ -14,7 +14,6 @@ from frozendict import frozendict
 
 from devito.data import default_allocator
 from devito.parameters import configuration
-from devito.symbolics import Add
 from devito.tools import (Evaluable, Pickable, ctypes_to_cstr, dtype_to_cstr,
                           dtype_to_ctype)
 from devito.types.args import ArgProvider
@@ -767,10 +766,11 @@ class AbstractFunction(sympy.Function, Basic, Cached, Pickable, Evaluable):
         padding regions. While halo and padding are known quantities (integers),
         the domain size is given as a symbol.
         """
-        halo = [Add(*i) for i in self._size_halo]
-        padding = [Add(*i) for i in self._size_padding]
+        halo = [sympy.Add(*i, evaluate=False) for i in self._size_halo]
+        padding = [sympy.Add(*i, evaluate=False) for i in self._size_padding]
         domain = [i.symbolic_size for i in self.dimensions]
-        ret = tuple(Add(i, j, k) for i, j, k in zip(domain, halo, padding))
+        ret = tuple(sympy.Add(i, j, k, evaluate=False)
+                    for i, j, k in zip(domain, halo, padding))
         return DimensionTuple(*ret, getters=self.dimensions)
 
     @property

--- a/devito/types/basic.py
+++ b/devito/types/basic.py
@@ -13,9 +13,9 @@ from cgen import Struct, Value
 from frozendict import frozendict
 
 from devito.data import default_allocator
+from devito.finite_differences import Evaluable
 from devito.parameters import configuration
-from devito.tools import (Evaluable, Pickable, ctypes_to_cstr, dtype_to_cstr,
-                          dtype_to_ctype)
+from devito.tools import Pickable, ctypes_to_cstr, dtype_to_cstr, dtype_to_ctype
 from devito.types.args import ArgProvider
 from devito.types.caching import Cached
 from devito.types.utils import DimensionTuple

--- a/devito/types/basic.py
+++ b/devito/types/basic.py
@@ -1056,7 +1056,7 @@ class Array(AbstractFunction):
     def _C_typename(self):
         return ctypes_to_cstr(POINTER(dtype_to_ctype(self.dtype)))
 
-    @property
+    @cached_property
     def free_symbols(self):
         return super().free_symbols - {d for d in self.dimensions if d.is_Default}
 
@@ -1277,3 +1277,8 @@ class Indexed(sympy.Indexed):
     @property
     def origin(self):
         return self.function.origin
+
+    @cached_property
+    def free_symbols(self):
+        # Make it cached, since it's relatively expensive and called often
+        return super(Indexed, self).free_symbols

--- a/devito/types/basic.py
+++ b/devito/types/basic.py
@@ -738,8 +738,8 @@ class AbstractFunction(sympy.Function, Basic, Cached, Pickable, Evaluable):
             else:
                 weight *= 1/2
                 is_averaged = True
-                avg_list = [a.subs({i: i - d.spacing/2}) + a.subs({i: i + d.spacing/2})
-                            for a in avg_list]
+                avg_list = [(a.xreplace({i: i - d.spacing/2}) +
+                             a.xreplace({i: i + d.spacing/2})) for a in avg_list]
 
         if not is_averaged:
             return self
@@ -932,10 +932,10 @@ class AbstractFunction(sympy.Function, Basic, Cached, Pickable, Evaluable):
                     if s.free_symbols.intersection(self.args[i].free_symbols)]
 
         # Substitution for each index
-        subs = dict([(s, 1) for s in spacings])
+        subs = {s: 1 for s in spacings}
 
         # Indices after substitutions
-        indices = [(a - o).subs(subs) for a, o in zip(self.args, self.origin)]
+        indices = [(a - o).xreplace(subs) for a, o in zip(self.args, self.origin)]
 
         return Indexed(self.indexed, *indices)
 

--- a/devito/types/dense.py
+++ b/devito/types/dense.py
@@ -964,8 +964,8 @@ class Function(DiscreteFunction, Differentiable):
         if not self.is_parameter or self.staggered == func.staggered:
             return self
 
-        return self.subs({self.indices_ref[d1]: func.indices_ref[d1]
-                          for d1 in self.dimensions})
+        return self.xreplace({self.indices_ref[d1]: func.indices_ref[d1]
+                              for d1 in self.dimensions})
 
     @classmethod
     def __indices_setup__(cls, **kwargs):
@@ -1106,7 +1106,7 @@ class Function(DiscreteFunction, Differentiable):
                 rp = p // 2
             indices = [d - i for i in range(lp, 0, -1)]
             indices.extend([d + i for i in range(rp)])
-            points.extend([self.subs(d, i) for i in indices])
+            points.extend([self.xreplace({d: i}) for i in indices])
         return sum(points)
 
     def avg(self, p=None, dims=None):
@@ -1316,7 +1316,7 @@ class TimeFunction(Function):
         i = int(self.time_order / 2) if self.time_order >= 2 else 1
         _t = self.dimensions[self._time_position]
 
-        return self.subs(_t, _t + i * _t.spacing)
+        return self.xreplace({_t: _t + i * _t.spacing})
 
     @property
     def backward(self):
@@ -1324,7 +1324,7 @@ class TimeFunction(Function):
         i = int(self.time_order / 2) if self.time_order >= 2 else 1
         _t = self.dimensions[self._time_position]
 
-        return self.subs(_t, _t - i * _t.spacing)
+        return self.xreplace({_t: _t - i * _t.spacing})
 
     @property
     def _time_size(self):

--- a/devito/types/dense.py
+++ b/devito/types/dense.py
@@ -959,8 +959,8 @@ class Function(DiscreteFunction, Differentiable):
         if not self.is_parameter or self.staggered == func.staggered:
             return self
 
-        return self.xreplace({self.indices_ref[d1]: func.indices_ref[d1]
-                              for d1 in self.dimensions})
+        return self.subs({self.indices_ref[d1]: func.indices_ref[d1]
+                          for d1 in self.dimensions})
 
     @classmethod
     def __indices_setup__(cls, **kwargs):
@@ -1101,7 +1101,7 @@ class Function(DiscreteFunction, Differentiable):
                 rp = p // 2
             indices = [d - i for i in range(lp, 0, -1)]
             indices.extend([d + i for i in range(rp)])
-            points.extend([self.xreplace({d: i}) for i in indices])
+            points.extend([self.subs({d: i}) for i in indices])
         return sum(points)
 
     def avg(self, p=None, dims=None):
@@ -1311,7 +1311,7 @@ class TimeFunction(Function):
         i = int(self.time_order / 2) if self.time_order >= 2 else 1
         _t = self.dimensions[self._time_position]
 
-        return self.xreplace({_t: _t + i * _t.spacing})
+        return self.subs({_t: _t + i * _t.spacing})
 
     @property
     def backward(self):
@@ -1319,7 +1319,7 @@ class TimeFunction(Function):
         i = int(self.time_order / 2) if self.time_order >= 2 else 1
         _t = self.dimensions[self._time_position]
 
-        return self.xreplace({_t: _t - i * _t.spacing})
+        return self.subs({_t: _t - i * _t.spacing})
 
     @property
     def _time_size(self):

--- a/devito/types/dense.py
+++ b/devito/types/dense.py
@@ -98,14 +98,9 @@ class DiscreteFunction(AbstractFunction, ArgProvider):
                              % type(initializer))
 
     def __eq__(self, other):
-        """Quick self == other comparison."""
-        if self.__class__ is not other.__class__:
-            return False
-        # Still need to check for different arguments eg `f(x)` and `f(x+3)`
-        # Note that hash(f(x)) == hash(f(x+3)), but clearly f(x) != f(x+3)
-        # However, checking the args by equality may be expensive due to
-        # sympify(), so here we rather check for idendity
-        return all(i is j for i, j in zip(self.args, other.args))
+        # The only possibility for two DiscreteFunctions to be considered equal
+        # is that they are indeed the same exact object
+        return self is other
 
     __hash__ = AbstractFunction.__hash__  # Required since we're overriding __eq__
 

--- a/devito/types/dimension.py
+++ b/devito/types/dimension.py
@@ -104,9 +104,6 @@ class Dimension(ArgProvider):
     is_Incr = False
     is_Shifted = False
 
-    # SymPy default assumptions
-    is_integer = True
-
     _C_typename = 'const %s' % dtype_to_cstr(np.int32)
     _C_typedata = _C_typename
 

--- a/devito/types/dimension.py
+++ b/devito/types/dimension.py
@@ -104,6 +104,9 @@ class Dimension(ArgProvider):
     is_Incr = False
     is_Shifted = False
 
+    # SymPy default assumptions
+    is_integer = True
+
     _C_typename = 'const %s' % dtype_to_cstr(np.int32)
     _C_typedata = _C_typename
 

--- a/devito/types/equation.py
+++ b/devito/types/equation.py
@@ -4,8 +4,8 @@ import sympy
 
 from cached_property import cached_property
 
-from devito.finite_differences import default_rules
-from devito.tools import Evaluable, as_tuple
+from devito.finite_differences import Evaluable, default_rules
+from devito.tools import as_tuple
 
 __all__ = ['Eq', 'Inc', 'solve']
 

--- a/devito/types/sparse.py
+++ b/devito/types/sparse.py
@@ -847,7 +847,7 @@ class SparseTimeFunction(AbstractSparseTimeFunction, SparseFunction):
         if u_t is not None:
             time = self.grid.time_dim
             t = self.grid.stepping_dim
-            expr = expr.xreplace({time: u_t, t: u_t})
+            expr = expr.subs({time: u_t, t: u_t})
 
         if p_t is not None:
             subs = {self.time_dim: p_t}
@@ -875,9 +875,9 @@ class SparseTimeFunction(AbstractSparseTimeFunction, SparseFunction):
         """
         # Apply optional time symbol substitutions to field and expr
         if u_t is not None:
-            field = field.xreplace({field.time_dim: u_t})
+            field = field.subs({field.time_dim: u_t})
         if p_t is not None:
-            expr = expr.xreplace({self.time_dim: p_t})
+            expr = expr.subs({self.time_dim: p_t})
 
         return super(SparseTimeFunction, self).inject(field, expr, offset=offset)
 
@@ -1074,7 +1074,7 @@ class PrecomputedSparseTimeFunction(AbstractSparseTimeFunction,
         if u_t is not None:
             time = self.grid.time_dim
             t = self.grid.stepping_dim
-            expr = expr.xreplace({time: u_t, t: u_t})
+            expr = expr.subs({time: u_t, t: u_t})
 
         if p_t is not None:
             subs = {self.time_dim: p_t}

--- a/devito/types/sparse.py
+++ b/devito/types/sparse.py
@@ -847,7 +847,7 @@ class SparseTimeFunction(AbstractSparseTimeFunction, SparseFunction):
         if u_t is not None:
             time = self.grid.time_dim
             t = self.grid.stepping_dim
-            expr = expr.subs({time: u_t, t: u_t})
+            expr = expr.xreplace({time: u_t, t: u_t})
 
         if p_t is not None:
             subs = {self.time_dim: p_t}
@@ -875,9 +875,9 @@ class SparseTimeFunction(AbstractSparseTimeFunction, SparseFunction):
         """
         # Apply optional time symbol substitutions to field and expr
         if u_t is not None:
-            field = field.subs(field.time_dim, u_t)
+            field = field.xreplace({field.time_dim: u_t})
         if p_t is not None:
-            expr = expr.subs(self.time_dim, p_t)
+            expr = expr.xreplace({self.time_dim: p_t})
 
         return super(SparseTimeFunction, self).inject(field, expr, offset=offset)
 
@@ -1074,7 +1074,7 @@ class PrecomputedSparseTimeFunction(AbstractSparseTimeFunction,
         if u_t is not None:
             time = self.grid.time_dim
             t = self.grid.stepping_dim
-            expr = expr.subs({time: u_t, t: u_t})
+            expr = expr.xreplace({time: u_t, t: u_t})
 
         if p_t is not None:
             subs = {self.time_dim: p_t}

--- a/devito/types/tensor.py
+++ b/devito/types/tensor.py
@@ -389,7 +389,7 @@ class TensorTimeFunction(TensorFunction):
         i = int(self.time_order / 2) if self.time_order >= 2 else 1
         _t = self.indices[self._time_position]
 
-        return self.xreplace({_t: _t + i * _t.spacing})
+        return self.subs({_t: _t + i * _t.spacing})
 
     @property
     def backward(self):
@@ -397,7 +397,7 @@ class TensorTimeFunction(TensorFunction):
         i = int(self.time_order / 2) if self.time_order >= 2 else 1
         _t = self.indices[self._time_position]
 
-        return self.xreplace({_t: _t - i * _t.spacing})
+        return self.subs({_t: _t - i * _t.spacing})
 
 
 class VectorFunction(TensorFunction):

--- a/devito/types/tensor.py
+++ b/devito/types/tensor.py
@@ -389,7 +389,7 @@ class TensorTimeFunction(TensorFunction):
         i = int(self.time_order / 2) if self.time_order >= 2 else 1
         _t = self.indices[self._time_position]
 
-        return self.subs(_t, _t + i * _t.spacing)
+        return self.xreplace({_t: _t + i * _t.spacing})
 
     @property
     def backward(self):
@@ -397,7 +397,7 @@ class TensorTimeFunction(TensorFunction):
         i = int(self.time_order / 2) if self.time_order >= 2 else 1
         _t = self.indices[self._time_position]
 
-        return self.subs(_t, _t - i * _t.spacing)
+        return self.xreplace({_t: _t - i * _t.spacing})
 
 
 class VectorFunction(TensorFunction):

--- a/tests/test_dse.py
+++ b/tests/test_dse.py
@@ -7,6 +7,7 @@ from cached_property import cached_property
 from conftest import skipif, EVAL  # noqa
 from devito import (Eq, Inc, Constant, Function, TimeFunction, SparseTimeFunction,  # noqa
                     Dimension, SubDimension, Grid, Operator, switchconfig, configuration)
+from devito.finite_differences.differentiable import diffify
 from devito.ir import DummyEq, Expression, FindNodes, FindSymbols, retrieve_iteration_tree
 from devito.passes.clusters.aliases import collect
 from devito.passes.clusters.cse import _cse
@@ -149,7 +150,7 @@ def test_cse(exprs, expected):
 
     # List comprehension would need explicit locals/globals mappings to eval
     for i, e in enumerate(list(exprs)):
-        exprs[i] = DummyEq(indexify(eval(e).evaluate))
+        exprs[i] = DummyEq(indexify(diffify(eval(e).evaluate)))
 
     counter = generator()
     make = lambda: Scalar(name='r%d' % counter()).indexify()

--- a/tests/test_dse.py
+++ b/tests/test_dse.py
@@ -1302,7 +1302,7 @@ class TestTTIv2(object):
 
     @switchconfig(profiling='advanced')
     @pytest.mark.parametrize('space_order,expected', [
-        (4, 197), (12, 389)
+        (4, 203), (12, 393)
     ])
     def test_opcounts(self, space_order, expected):
         grid = Grid(shape=(3, 3, 3))

--- a/tests/test_dse.py
+++ b/tests/test_dse.py
@@ -59,6 +59,7 @@ def test_scheduling_after_rewrite():
 def test_yreplace_time_invariants(exprs, expected):
     grid = Grid((3, 3, 3))
     dims = grid.dimensions
+
     tu = TimeFunction(name="tu", grid=grid, space_order=4).indexify()
     tv = TimeFunction(name="tv", grid=grid, space_order=4).indexify()
     tw = TimeFunction(name="tw", grid=grid, space_order=4).indexify()
@@ -66,7 +67,11 @@ def test_yreplace_time_invariants(exprs, expected):
     ti1 = Array(name='ti1', shape=(3, 5, 7), dimensions=dims).indexify()
     t0 = Scalar(name='t0').indexify()
     t1 = Scalar(name='t1').indexify()
-    exprs = EVAL(exprs, tu, tv, tw, ti0, ti1, t0, t1)
+
+    # List comprehension would need explicit locals/globals mappings to eval
+    for i, e in enumerate(list(exprs)):
+        exprs[i] = DummyEq(indexify(eval(e).evaluate))
+
     counter = generator()
     make = lambda: Scalar(name='r%d' % counter()).indexify()
     processed, found = yreplace(exprs, make,
@@ -340,7 +345,7 @@ class TestAliases(object):
         for i, e in enumerate(list(expected)):
             expected[i] = eval(e)
 
-        aliases = collect(exprs)
+        aliases = collect(exprs, False, lambda i: False)
 
         assert len(aliases) == len(expected)
         assert all(i in expected for i in aliases)

--- a/tests/test_dse.py
+++ b/tests/test_dse.py
@@ -61,13 +61,13 @@ def test_yreplace_time_invariants(exprs, expected):
     grid = Grid((3, 3, 3))
     dims = grid.dimensions
 
-    tu = TimeFunction(name="tu", grid=grid, space_order=4).indexify()
-    tv = TimeFunction(name="tv", grid=grid, space_order=4).indexify()
-    tw = TimeFunction(name="tw", grid=grid, space_order=4).indexify()
-    ti0 = Array(name='ti0', shape=(3, 5, 7), dimensions=dims).indexify()
-    ti1 = Array(name='ti1', shape=(3, 5, 7), dimensions=dims).indexify()
-    t0 = Scalar(name='t0').indexify()
-    t1 = Scalar(name='t1').indexify()
+    tu = TimeFunction(name="tu", grid=grid, space_order=4).indexify()  # noqa
+    tv = TimeFunction(name="tv", grid=grid, space_order=4).indexify()  # noqa
+    tw = TimeFunction(name="tw", grid=grid, space_order=4).indexify()  # noqa
+    ti0 = Array(name='ti0', shape=(3, 5, 7), dimensions=dims).indexify()  # noqa
+    ti1 = Array(name='ti1', shape=(3, 5, 7), dimensions=dims).indexify()  # noqa
+    t0 = Scalar(name='t0').indexify()  # noqa
+    t1 = Scalar(name='t1').indexify()  # noqa
 
     # List comprehension would need explicit locals/globals mappings to eval
     for i, e in enumerate(list(exprs)):

--- a/tests/test_operator.py
+++ b/tests/test_operator.py
@@ -73,7 +73,7 @@ class TestCodeGen(object):
 
         expr = eval(expr)
 
-        with timed_region('x') as r:
+        with timed_region('x'):
             expr = Operator._lower_exprs([expr])[0]
 
         assert str(expr).replace(' ', '') == expected

--- a/tests/test_operator.py
+++ b/tests/test_operator.py
@@ -14,7 +14,7 @@ from devito.ir.iet import (Callable, Conditional, Expression, Iteration, TimedLi
 from devito.ir.support import Any, Backward, Forward
 from devito.passes.iet import DataManager
 from devito.symbolics import ListInitializer, indexify, retrieve_indexed
-from devito.tools import flatten, powerset
+from devito.tools import flatten, powerset, timed_region
 from devito.types import Array, Scalar
 
 
@@ -67,10 +67,15 @@ class TestCodeGen(object):
         grid = Grid(shape=(4, 4, 4))
         x, y, z = grid.dimensions
         t = grid.stepping_dim  # noqa
+
         u = TimeFunction(name='u', grid=grid, space_order=so, time_order=to)  # noqa
         m = Function(name='m', grid=grid, space_order=0)  # noqa
+
         expr = eval(expr)
-        expr = Operator(expr)._specialize_exprs([indexify(expr)])[0]
+
+        with timed_region('x') as r:
+            expr = Operator._lower_exprs([expr])[0]
+
         assert str(expr).replace(' ', '') == expected
 
     @pytest.mark.parametrize('expr,exp_uindices,exp_mods', [


### PR DESCRIPTION
A collection of self-contained, orthogonal commits. I could have filed 20 PRs, one per commit, or just one.

On my workstation, the compilation times w.r.t. `master` become
- tti so12 : ~27s -> ~12s
- smoothers : ~5.5s -> ~1s
- elastic so12: ~18s  -> ~8.5s
- viscoelastic so12 : ~41s -> ~14s
- iso-acoustic so12 :  ~4s -> ~2.5s

@tjb900 I'm not sure if you care about this ... tagging you, just in case

@ggorman I've been working on this intermittently for a few days, but there is still work to do

@mloubout @rhodrin if you take a profile with Python's cProfile, you shall see there's a margin of improvement especially in the DSL/SymPy layers... wonder whether/when you could this give a go. Not a top priority of course!
