### PR TITLE
indexify fix

### DIFF
--- a/devito/operator/operator.py
+++ b/devito/operator/operator.py
@@ -306,7 +306,7 @@ class Operator(Callable):
                 dimension_map = {}
 
             # Handle Functions (typical case)
-            mapper = {f: f.indexify(w_shift=True, extra_subs=dimension_map)
+            mapper = {f: f.indexify(lshift=True, subs=dimension_map)
                       for f in retrieve_functions(expr)}
 
             # Handle Indexeds (from index notation)

--- a/devito/operator/operator.py
+++ b/devito/operator/operator.py
@@ -305,26 +305,9 @@ class Operator(Callable):
             else:
                 dimension_map = {}
 
-            mapper = {}
-
             # Handle Functions (typical case)
-            for f in retrieve_functions(expr):
-                # Get spacing symbols for replacement
-                spacings = [i.spacing for i in f.dimensions]
-
-                # Only keep the ones used as indices
-                spacings = [s for i, s in enumerate(spacings)
-                            if s.free_symbols.intersection(f.args[i].free_symbols)]
-
-                # Substitution for each index
-                subs = {**{s: 1 for s in spacings}, **dimension_map}
-
-                # Introduce shifting to align with the computational domain,
-                # and apply substitutions
-                indices = [(a - i + o).xreplace(subs)
-                           for a, i, o in zip(f.args, f.origin, f._size_nodomain.left)]
-
-                mapper[f] = f.indexed[indices]
+            mapper = {f: f.indexify(w_shift=True, extra_subs=dimension_map)
+                      for f in retrieve_functions(expr)}
 
             # Handle Indexeds (from index notation)
             for i in retrieve_indexed(expr):

--- a/devito/types/basic.py
+++ b/devito/types/basic.py
@@ -919,17 +919,17 @@ class AbstractFunction(sympy.Function, Basic, Cached, Pickable, Evaluable):
         """
         return default_allocator().guaranteed_alignment
 
-    def indexify(self, indices=None, w_shift=False, extra_subs=None):
+    def indexify(self, indices=None, lshift=False, subs=None):
         """Create a types.Indexed from the current object."""
         if indices is not None:
             return Indexed(self.indexed, *indices)
 
         # Substitution for each index (spacing only used in own dimension)
-        extra_subs = extra_subs or {}
-        subs = [{**d._indexify_map, **extra_subs} for d in self.dimensions]
+        subs = subs or {}
+        subs = [{**{d.spacing: 1, -d.spacing: -1}, **subs} for d in self.dimensions]
 
         # Add halo shift
-        shift = self._size_nodomain.left if w_shift else tuple([0]*len(self.dimensions))
+        shift = self._size_nodomain.left if lshift else tuple([0]*len(self.dimensions))
         # Indices after substitutions
         indices = [(a - o + f).xreplace(s) for a, o, f, s in
                    zip(self.args, self.origin, shift, subs)]

--- a/devito/types/basic.py
+++ b/devito/types/basic.py
@@ -773,7 +773,7 @@ class AbstractFunction(sympy.Function, Basic, Cached, Pickable, Evaluable):
                     for i, j, k in zip(domain, halo, padding))
         return DimensionTuple(*ret, getters=self.dimensions)
 
-    @property
+    @cached_property
     def indexed(self):
         """The wrapped IndexedData object."""
         return IndexedData(self.name, shape=self.shape, function=self.function)
@@ -919,25 +919,22 @@ class AbstractFunction(sympy.Function, Basic, Cached, Pickable, Evaluable):
         """
         return default_allocator().guaranteed_alignment
 
-    def indexify(self, indices=None):
+    def indexify(self, indices=None, w_shift=False, extra_subs=None):
         """Create a types.Indexed from the current object."""
         if indices is not None:
             return Indexed(self.indexed, *indices)
 
-        # Get spacing symbols for replacement
-        spacings = [i.spacing for i in self.dimensions]
+        # Substitution for each index (spacing only used in own dimension)
+        extra_subs = extra_subs or {}
+        subs = [{**d._indexify_map, **extra_subs} for d in self.dimensions]
 
-        # Only keep the ones used as indices.
-        spacings = [s for i, s in enumerate(spacings)
-                    if s.free_symbols.intersection(self.args[i].free_symbols)]
-
-        # Substitution for each index
-        subs = {a*s: a for s in spacings for a in [-1, 1]}
-
+        # Add halo shift
+        shift = self._size_nodomain.left if w_shift else tuple([0]*len(self.dimensions))
         # Indices after substitutions
-        indices = [(a - o).xreplace(subs) for a, o in zip(self.args, self.origin)]
+        indices = [(a - o + f).xreplace(s) for a, o, f, s in
+                   zip(self.args, self.origin, shift, subs)]
 
-        return Indexed(self.indexed, *indices)
+        return self.indexed[indices]
 
     def __getitem__(self, index):
         """Shortcut for ``self.indexed[index]``."""

--- a/devito/types/basic.py
+++ b/devito/types/basic.py
@@ -932,7 +932,7 @@ class AbstractFunction(sympy.Function, Basic, Cached, Pickable, Evaluable):
                     if s.free_symbols.intersection(self.args[i].free_symbols)]
 
         # Substitution for each index
-        subs = {s: 1 for s in spacings}
+        subs = {a*s: a for s in spacings for a in [-1, 1]}
 
         # Indices after substitutions
         indices = [(a - o).xreplace(subs) for a, o in zip(self.args, self.origin)]

--- a/devito/types/dimension.py
+++ b/devito/types/dimension.py
@@ -305,6 +305,10 @@ class BasicDimension(Dimension, Symbol):
     def __init_finalize__(self, name, spacing=None):
         self._spacing = spacing or Scalar(name='h_%s' % name, is_const=True)
 
+    @cached_property
+    def _indexify_map(self):
+        return {self.spacing: 1}
+
 
 class DefaultDimension(Dimension, DataSymbol):
 
@@ -741,6 +745,10 @@ class ConditionalDimension(DerivedDimension):
         if self.condition is not None:
             retval |= self.condition.free_symbols
         return retval
+
+    @cached_property
+    def _indexify_map(self):
+        return {self.spacing: 1, -self.spacing: -1}
 
     # Pickling support
     _pickle_kwargs = DerivedDimension._pickle_kwargs + ['factor', 'condition', 'indirect']

--- a/devito/types/dimension.py
+++ b/devito/types/dimension.py
@@ -305,10 +305,6 @@ class BasicDimension(Dimension, Symbol):
     def __init_finalize__(self, name, spacing=None):
         self._spacing = spacing or Scalar(name='h_%s' % name, is_const=True)
 
-    @cached_property
-    def _indexify_map(self):
-        return {self.spacing: 1}
-
 
 class DefaultDimension(Dimension, DataSymbol):
 
@@ -745,10 +741,6 @@ class ConditionalDimension(DerivedDimension):
         if self.condition is not None:
             retval |= self.condition.free_symbols
         return retval
-
-    @cached_property
-    def _indexify_map(self):
-        return {self.spacing: 1, -self.spacing: -1}
 
     # Pickling support
     _pickle_kwargs = DerivedDimension._pickle_kwargs + ['factor', 'condition', 'indirect']


### PR DESCRIPTION
fix subsampled dim FD.

A little bug was introduce by xreplace in indexify as `(-2*dt).xreplace({2*dt: 1}) = -2*dt` as xreplace doesn't recognise it with - sign, which breaks FD with subsampling. Wasn't caught in test because it's forward FD (only 2*dt, not -2*dt), so added a test for it too.