### PR TITLE
Add `shape` option in examples

### DIFF
--- a/examples/seismic/acoustic/acoustic_example.py
+++ b/examples/seismic/acoustic/acoustic_example.py
@@ -67,9 +67,9 @@ if __name__ == "__main__":
     description = ("Example script for a set of acoustic operators.")
     parser = ArgumentParser(description=description)
     parser.add_argument("-nd", dest="ndim", default=3, type=int,
-                        help="Preset to determine the number of dimensions")
+                        help="Number of dimensions")
     parser.add_argument("-d", "--shape", default=(51, 51, 51), type=int, nargs="+",
-                        help="Determine the grid shape")
+                        help="Number of grid points along each axis")
     parser.add_argument('-f', '--full', default=False, action='store_true',
                         help="Execute all operators and store forward wavefield")
     parser.add_argument("-so", "--space_order", default=6,

--- a/examples/seismic/acoustic/acoustic_example.py
+++ b/examples/seismic/acoustic/acoustic_example.py
@@ -66,8 +66,10 @@ def run(shape=(50, 50, 50), spacing=(20.0, 20.0, 20.0), tn=1000.0,
 if __name__ == "__main__":
     description = ("Example script for a set of acoustic operators.")
     parser = ArgumentParser(description=description)
-    parser.add_argument('-nd', dest='ndim', default=3, type=int,
+    parser.add_argument("-nd", dest="ndim", default=3, type=int,
                         help="Preset to determine the number of dimensions")
+    parser.add_argument("-d", "--shape", default=(51, 51, 51), type=int, nargs="+",
+                        help="Determine the grid shape")
     parser.add_argument('-f', '--full', default=False, action='store_true',
                         help="Execute all operators and store forward wavefield")
     parser.add_argument("-so", "--space_order", default=6,
@@ -90,9 +92,11 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     # 3D preset parameters
-    shape = tuple(args.ndim * [51])
-    spacing = tuple(args.ndim * [15.0])
-    tn = 750. if args.ndim < 3 else 250.
+    ndim = args.ndim
+    shape = args.shape[:args.ndim]
+    spacing = tuple(ndim * [15.0])
+    tn = 750. if ndim < 3 else 250.
+
     preset = 'constant-isotropic' if args.constant else 'layers-isotropic'
     run(shape=shape, spacing=spacing, nbl=args.nbl, tn=tn,
         space_order=args.space_order, preset=preset, kernel=args.kernel,

--- a/examples/seismic/elastic/elastic_example.py
+++ b/examples/seismic/elastic/elastic_example.py
@@ -45,8 +45,10 @@ def test_elastic():
 if __name__ == "__main__":
     description = ("Example script for a set of elastic operators.")
     parser = ArgumentParser(description=description)
-    parser.add_argument('--2d', dest='dim2', default=False, action='store_true',
-                        help="Preset to determine the physical problem setup")
+    parser.add_argument("-nd", dest='ndim', default=3, type=int,
+                        help="Preset to determine the number of dimensions")
+    parser.add_argument("-d", "--shape", default=(150, 150, 150), type=int, nargs="+",
+                        help="Determine the grid shape")
     parser.add_argument("-so", "--space_order", default=4,
                         type=int, help="Space order of the simulation")
     parser.add_argument("--nbl", default=40,
@@ -61,16 +63,11 @@ if __name__ == "__main__":
                         help="Operator auto-tuning mode")
     args = parser.parse_args()
 
-    # 2D preset parameters
-    if args.dim2:
-        shape = (150, 150)
-        spacing = (10.0, 10.0)
-        tn = 750.0
-    # 3D preset parameters
-    else:
-        shape = (150, 150, 150)
-        spacing = (10.0, 10.0, 10.0)
-        tn = 1250.0
+    # Preset parameters
+    ndim = args.ndim
+    shape = args.shape[:args.ndim]
+    spacing = tuple(ndim * [10.0])
+    tn = 750. if ndim < 3 else 1250.
 
     run(shape=shape, spacing=spacing, nbl=args.nbl, tn=tn, opt=args.opt,
         space_order=args.space_order, autotune=args.autotune, constant=args.constant)

--- a/examples/seismic/elastic/elastic_example.py
+++ b/examples/seismic/elastic/elastic_example.py
@@ -46,9 +46,9 @@ if __name__ == "__main__":
     description = ("Example script for a set of elastic operators.")
     parser = ArgumentParser(description=description)
     parser.add_argument("-nd", dest='ndim', default=3, type=int,
-                        help="Preset to determine the number of dimensions")
+                        help="Number of dimensions")
     parser.add_argument("-d", "--shape", default=(150, 150, 150), type=int, nargs="+",
-                        help="Determine the grid shape")
+                        help="Number of grid points along each axis")
     parser.add_argument("-so", "--space_order", default=4,
                         type=int, help="Space order of the simulation")
     parser.add_argument("--nbl", default=40,

--- a/examples/seismic/tti/tti_example.py
+++ b/examples/seismic/tti/tti_example.py
@@ -31,8 +31,10 @@ def run(shape=(50, 50, 50), spacing=(20.0, 20.0, 20.0), tn=250.0,
 if __name__ == "__main__":
     description = ("Example script to execute a TTI forward operator.")
     parser = ArgumentParser(description=description)
-    parser.add_argument('--2d', dest='dim2', default=False, action='store_true',
-                        help="Preset to determine the physical problem setup")
+    parser.add_argument("-nd", dest="ndim", default=3, type=int,
+                        help="Preset to determine the number of dimensions")
+    parser.add_argument("-d", "--shape", default=(50, 50, 50), type=int, nargs="+",
+                        help="Determine the grid shape")
     parser.add_argument('--noazimuth', dest='azi', default=False, action='store_true',
                         help="Whether or not to use an azimuth angle")
     parser.add_argument("-so", "--space_order", default=4,
@@ -51,15 +53,12 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     preset = 'layers-tti-noazimuth' if args.azi else 'layers-tti'
-    # 3D preset parameters
-    if args.dim2:
-        shape = (150, 150)
-        spacing = (10.0, 10.0)
-        tn = 750.0
-    else:
-        shape = (50, 50, 50)
-        spacing = (10.0, 10.0, 10.0)
-        tn = 250.0
+
+    # Preset parameters
+    ndim = args.ndim
+    shape = args.shape[:args.ndim]
+    spacing = tuple(ndim * [10.0])
+    tn = 750. if ndim < 3 else 250.
 
     run(shape=shape, spacing=spacing, nbl=args.nbl, tn=tn,
         space_order=args.space_order, autotune=args.autotune,

--- a/examples/seismic/tti/tti_example.py
+++ b/examples/seismic/tti/tti_example.py
@@ -32,9 +32,9 @@ if __name__ == "__main__":
     description = ("Example script to execute a TTI forward operator.")
     parser = ArgumentParser(description=description)
     parser.add_argument("-nd", dest="ndim", default=3, type=int,
-                        help="Preset to determine the number of dimensions")
+                        help="Number of dimensions")
     parser.add_argument("-d", "--shape", default=(50, 50, 50), type=int, nargs="+",
-                        help="Determine the grid shape")
+                        help="Number of grid points along each axis")
     parser.add_argument('--noazimuth', dest='azi', default=False, action='store_true',
                         help="Whether or not to use an azimuth angle")
     parser.add_argument("-so", "--space_order", default=4,

--- a/examples/seismic/viscoacoustic/viscoacoustic_example.py
+++ b/examples/seismic/viscoacoustic/viscoacoustic_example.py
@@ -47,9 +47,9 @@ if __name__ == "__main__":
     description = ("Example script for a set of viscoacoustic operators.")
     parser = ArgumentParser(description=description)
     parser.add_argument("-nd", dest='ndim', default=3, type=int,
-                        help="Preset to determine the number of dimensions")
+                        help="Number of dimensions")
     parser.add_argument("-d", "--shape", default=(150, 150, 150), type=int, nargs="+",
-                        help="Determine the grid shape")
+                        help="Number of grid points along each axis")
     parser.add_argument("-so", "--space_order", default=4,
                         type=int, help="Space order of the simulation")
     parser.add_argument("--nbl", default=40,

--- a/examples/seismic/viscoacoustic/viscoacoustic_example.py
+++ b/examples/seismic/viscoacoustic/viscoacoustic_example.py
@@ -46,8 +46,10 @@ def test_viscoacoustic():
 if __name__ == "__main__":
     description = ("Example script for a set of viscoacoustic operators.")
     parser = ArgumentParser(description=description)
-    parser.add_argument('--2d', dest='dim2', default=False, action='store_true',
-                        help="Preset to determine the physical problem setup")
+    parser.add_argument("-nd", dest='ndim', default=3, type=int,
+                        help="Preset to determine the number of dimensions")
+    parser.add_argument("-d", "--shape", default=(150, 150, 150), type=int, nargs="+",
+                        help="Determine the grid shape")
     parser.add_argument("-so", "--space_order", default=4,
                         type=int, help="Space order of the simulation")
     parser.add_argument("--nbl", default=40,
@@ -70,16 +72,11 @@ if __name__ == "__main__":
                         viscoacoustic equation. Defaults to 'blanch_symes'")
     args = parser.parse_args()
 
-    # 2D preset parameters
-    if args.dim2:
-        shape = (150, 150)
-        spacing = (10.0, 10.0)
-        tn = 750.0
-    # 3D preset parameters
-    else:
-        shape = (150, 150, 150)
-        spacing = (10.0, 10.0, 10.0)
-        tn = 1250.0
+    # Preset parameters
+    ndim = args.ndim
+    shape = args.shape[:args.ndim]
+    spacing = tuple(ndim * [10.0])
+    tn = 750. if ndim < 3 else 1250.
 
     run(shape=shape, spacing=spacing, nbl=args.nbl, tn=tn, opt=args.opt,
         space_order=args.space_order, autotune=args.autotune, constant=args.constant,

--- a/examples/seismic/viscoelastic/viscoelastic_example.py
+++ b/examples/seismic/viscoelastic/viscoelastic_example.py
@@ -46,9 +46,9 @@ if __name__ == "__main__":
     description = ("Example script for a set of viscoelastic operators.")
     parser = ArgumentParser(description=description)
     parser.add_argument("-nd", dest='ndim', default=3, type=int,
-                        help="Preset to determine the number of dimensions")
+                        help="Number of dimensions")
     parser.add_argument("-d", "--shape", default=(150, 150, 150), type=int, nargs="+",
-                        help="Determine the grid shape, defaults in (153, 153, 153)")
+                        help="Number of grid points along each axis")
     parser.add_argument("-so", "--space_order", default=4,
                         type=int, help="Space order of the simulation")
     parser.add_argument("--nbl", default=40,

--- a/examples/seismic/viscoelastic/viscoelastic_example.py
+++ b/examples/seismic/viscoelastic/viscoelastic_example.py
@@ -45,8 +45,10 @@ def test_viscoelastic():
 if __name__ == "__main__":
     description = ("Example script for a set of viscoelastic operators.")
     parser = ArgumentParser(description=description)
-    parser.add_argument('--2d', dest='dim2', default=False, action='store_true',
-                        help="Preset to determine the physical problem setup")
+    parser.add_argument("-nd", dest='ndim', default=3, type=int,
+                        help="Preset to determine the number of dimensions")
+    parser.add_argument("-d", "--shape", default=(150, 150, 150), type=int, nargs="+",
+                        help="Determine the grid shape, defaults in (153, 153, 153)")
     parser.add_argument("-so", "--space_order", default=4,
                         type=int, help="Space order of the simulation")
     parser.add_argument("--nbl", default=40,
@@ -61,16 +63,11 @@ if __name__ == "__main__":
                         help="Operator auto-tuning mode")
     args = parser.parse_args()
 
-    # 2D preset parameters
-    if args.dim2:
-        shape = (150, 150)
-        spacing = (10.0, 10.0)
-        tn = 750.0
-    # 3D preset parameters
-    else:
-        shape = (150, 150, 150)
-        spacing = (10.0, 10.0, 10.0)
-        tn = 1250.0
+    # Preset parameters
+    ndim = args.ndim
+    shape = args.shape[:args.ndim]
+    spacing = tuple(ndim * [10.0])
+    tn = 750. if ndim < 3 else 1250.
 
     run(shape=shape, spacing=spacing, nbl=args.nbl, tn=tn, opt=args.opt,
         space_order=args.space_order, autotune=args.autotune, constant=args.constant)


### PR DESCRIPTION
Adding shape option in examples.
Overwrites previous `-nd` option as a length of the tuple.
In general adds another enhanced option.