### PR TITLE
jit: Smarter CustomCompiler

### DIFF
--- a/devito/compiler.py
+++ b/devito/compiler.py
@@ -489,8 +489,11 @@ class IntelKNLCompiler(IntelCompiler):
 
 
 class CustomCompiler(Compiler):
+
     """
     Custom compiler based on standard environment flags.
+
+    If no environment flags are found, defaults to the GNUCompiler.
 
     Notes
     -----
@@ -499,6 +502,14 @@ class CustomCompiler(Compiler):
     is set to 'openmp', then the OpenMP linker flags are read from OMP_LDFLAGS
     or otherwise default to ``-fopenmp``.
     """
+
+    def __new__(cls, *args, **kwargs):
+        if any(i in environ for i in ['CC', 'CXX', 'CFLAGS', 'LDFLAGS']):
+            obj = super().__new__(cls, *args, **kwargs)
+            obj.__init__(*args, **kwargs)
+            return obj
+        else:
+            return GNUCompiler(*args, **kwargs)
 
     def __init__(self, *args, **kwargs):
         super(CustomCompiler, self).__init__(*args, **kwargs)


### PR DESCRIPTION
by returning GNUCompiler, we eventually add `-fopenmp`  (as long as the gcc version is >= 4.9 as usual) , which ensures 1) our `#pragma omp simd` are interpreted and 2) no annoying warnings "unrecognised pragma omp simd" are emitted to screen

clearly, all of this useful only if one doesn't set DEVITO_ARCH