### PR TITLE
Deallocate stopped VMs

### DIFF
--- a/.github/azure/stopVM.ps1
+++ b/.github/azure/stopVM.ps1
@@ -38,6 +38,7 @@ az account set --subscription $azureSubscriptionName
 Write-Output "Stopping VM"
 try {
     az vm stop -g $resourceGroupName -n $vmName --verbose
+    az vm deallocate -g $resourceGroupName -n $vmName --verbose
     Write-Output "VM stopped"
     }
 catch {


### PR DESCRIPTION
To stop charges stopped VMs also need to be deallocated so adding the deallocate command to the stop script.