### PR TITLE
Fix subdimension thickness

### DIFF
--- a/devito/types/dimension.py
+++ b/devito/types/dimension.py
@@ -622,8 +622,8 @@ class SubDimension(DerivedDimension):
                                                    self.thickness.left[1]-1, LEFT)
                 rtkn = grid.distributor.glb_to_loc(self.root,
                                                    self.thickness.right[1]-1, RIGHT)
-                ltkn = ltkn+1 if ltkn else 0
-                rtkn = rtkn+1 if rtkn else 0
+                ltkn = ltkn+1 if ltkn is not None else 0
+                rtkn = rtkn+1 if rtkn is not None else 0
             else:
                 # dimension is of type ``middle``
                 ltkn = grid.distributor.glb_to_loc(self.root, self.thickness.left[1],

--- a/devito/types/dimension.py
+++ b/devito/types/dimension.py
@@ -615,10 +615,21 @@ class SubDimension(DerivedDimension):
     def _arg_defaults(self, grid=None, **kwargs):
         if grid is not None and grid.is_distributed(self.root):
             # Get local thickness
-            ltkn = grid.distributor.glb_to_loc(self.root,
-                                               self.thickness.left[1], LEFT) or 0
-            rtkn = grid.distributor.glb_to_loc(self.root,
-                                               self.thickness.right[1], RIGHT) or 0
+            if self.local:
+                # dimension is of type ``left``/right`` - compute the 'offset'
+                # and then add 1 to get the appropriate thickness
+                ltkn = grid.distributor.glb_to_loc(self.root,
+                                                   self.thickness.left[1]-1, LEFT)
+                rtkn = grid.distributor.glb_to_loc(self.root,
+                                                   self.thickness.right[1]-1, RIGHT)
+                ltkn = ltkn+1 if ltkn else 0
+                rtkn = rtkn+1 if rtkn else 0
+            else:
+                # dimension is of type ``middle``
+                ltkn = grid.distributor.glb_to_loc(self.root,
+                                                   self.thickness.left[1], LEFT)
+                rtkn = grid.distributor.glb_to_loc(self.root,
+                                                   self.thickness.right[1], RIGHT)
             return {i.name: v for i, v in zip(self._thickness_map, (ltkn, rtkn))}
         else:
             return {k.name: v for k, v in self.thickness}

--- a/devito/types/dimension.py
+++ b/devito/types/dimension.py
@@ -626,10 +626,10 @@ class SubDimension(DerivedDimension):
                 rtkn = rtkn+1 if rtkn else 0
             else:
                 # dimension is of type ``middle``
-                ltkn = grid.distributor.glb_to_loc(self.root,
-                                                   self.thickness.left[1], LEFT)
-                rtkn = grid.distributor.glb_to_loc(self.root,
-                                                   self.thickness.right[1], RIGHT)
+                ltkn = grid.distributor.glb_to_loc(self.root, self.thickness.left[1],
+                                                   LEFT) or 0
+                rtkn = grid.distributor.glb_to_loc(self.root, self.thickness.right[1],
+                                                   RIGHT) or 0
             return {i.name: v for i, v in zip(self._thickness_map, (ltkn, rtkn))}
         else:
             return {k.name: v for k, v in self.thickness}

--- a/devito/types/grid.py
+++ b/devito/types/grid.py
@@ -365,19 +365,29 @@ class SubDomain(object):
                     side, thickness_left, thickness_right = v
                     if side != 'middle':
                         raise ValueError("Expected side 'middle', not `%s`" % side)
+                    thickness = s-thickness_left-thickness_right
+                    if thickness <= 0:
+                        raise ValueError("All dimensions must have a thickness of "
+                                         "1 or greater, not %s" % thickness)
                     sub_dimensions.append(SubDimension.middle('i%d%s' %
                                                               (counter, k.name),
                                                               k, thickness_left,
                                                               thickness_right))
-                    sdshape.append(s-thickness_left-thickness_right)
+                    sdshape.append(thickness)
                 except ValueError:
                     side, thickness = v
                     if side == 'left':
+                        if s-thickness < 0:
+                            raise ValueError("Maximum thickness of dimension %s "
+                                             "is %d, not %d" % (k.name, s, thickness))
                         sub_dimensions.append(SubDimension.left('i%d%s' %
                                                                 (counter, k.name),
                                                                 k, thickness))
                         sdshape.append(thickness)
                     elif side == 'right':
+                        if s-thickness < 0:
+                            raise ValueError("Maximum thickness of dimension %s "
+                                             "is %d, not %d" % (k.name, s, thickness))
                         sub_dimensions.append(SubDimension.right('i%d%s' %
                                                                  (counter, k.name),
                                                                  k, thickness))

--- a/devito/types/grid.py
+++ b/devito/types/grid.py
@@ -365,14 +365,11 @@ class SubDomain(object):
                     side, thickness_left, thickness_right = v
                     if side != 'middle':
                         raise ValueError("Expected side 'middle', not `%s`" % side)
-                    thickness = s-thickness_left-thickness_right
-                    if thickness <= 0:
-                        raise ValueError("All dimensions must have a thickness of "
-                                         "1 or greater, not %s" % thickness)
                     sub_dimensions.append(SubDimension.middle('i%d%s' %
                                                               (counter, k.name),
                                                               k, thickness_left,
                                                               thickness_right))
+                    thickness = s-thickness_left-thickness_right
                     sdshape.append(thickness)
                 except ValueError:
                     side, thickness = v

--- a/tests/test_subdomains.py
+++ b/tests/test_subdomains.py
@@ -86,6 +86,55 @@ class TestSubdomains(object):
         assert grid.subdomains['d1'].shape == (4, 2)
         assert grid.subdomains['d2'].shape == (3, 7)
 
+    def test_definitions(self):
+
+        class sd0(SubDomain):
+            name = 'sd0'
+
+            def define(self, dimensions):
+                x, y = dimensions
+                return {x: ('middle', 2, 2), y: ('right', 10)}
+
+        class sd1(SubDomain):
+            name = 'sd1'
+
+            def define(self, dimensions):
+                x, y = dimensions
+                return {x: ('middle', 2, 2), y: ('left', 10)}
+
+        class sd2(SubDomain):
+            name = 'sd2'
+
+            def define(self, dimensions):
+                x, y = dimensions
+                return {x: ('middle', 2, 2), y: y}
+
+        class sd3(SubDomain):
+            name = 'sd3'
+
+            def define(self, dimensions):
+                x, y = dimensions
+                return {x: ('middle', 2, 2), y: ('middle', 0, 0)}
+
+        sd_def0 = sd0()
+        sd_def1 = sd1()
+        sd_def2 = sd2()
+        sd_def3 = sd3()
+
+        grid = Grid(shape=(10, 10), extent=(10, 10),
+                    subdomains=(sd_def0, sd_def1, sd_def2, sd_def3))
+        u0 = Function(name='u0', grid=grid)
+        u1 = Function(name='u1', grid=grid)
+        u2 = Function(name='u2', grid=grid)
+        u3 = Function(name='u3', grid=grid)
+        eq0 = Eq(u0, u0+1, subdomain=grid.subdomains['sd0'])
+        eq1 = Eq(u1, u1+1, subdomain=grid.subdomains['sd1'])
+        eq2 = Eq(u2, u2+1, subdomain=grid.subdomains['sd2'])
+        eq3 = Eq(u3, u3+1, subdomain=grid.subdomains['sd3'])
+        Operator([eq0, eq1, eq2, eq3])()
+
+        assert u0.data.all() == u1.data.all() == u2.data.all() == u3.data.all()
+
     def test_iterate_NDomains(self):
         """
         Test that a set of subdomains are iterated upon correctly.


### PR DESCRIPTION
Owing the inconsistency in how the thickness of subdimensions is defined (see #1183) a subdomain defined as, e.g.,
```
class sd0(SubDomain):
    name = 'sd0'
    def define(self, dimensions):
        x, y = dimensions
        return {x: x, y: ('right', 10)}
```
on a grid with shape `(N, 10)` doesn't currently work. This PR fixes that. Note that it doesn't fix the underlying issue raised in #1183.