### PR TITLE
bench: fix results makedir to prevent exception with multiple MPI processes

### DIFF
--- a/benchmarks/user/tools/driver.py
+++ b/benchmarks/user/tools/driver.py
@@ -135,7 +135,7 @@ class Driver(object):
         Save all timing results in individually keyed files.
         """
         if not path.exists(self.resultsdir):
-            makedirs(self.resultsdir, exist_ok = True)
+            makedirs(self.resultsdir, exist_ok=True)
         timestamp = datetime.now().strftime('%Y-%m-%dT%H%M%S')
 
         for key in self.timings.keys():

--- a/benchmarks/user/tools/driver.py
+++ b/benchmarks/user/tools/driver.py
@@ -135,7 +135,7 @@ class Driver(object):
         Save all timing results in individually keyed files.
         """
         if not path.exists(self.resultsdir):
-            makedirs(self.resultsdir)
+            makedirs(self.resultsdir, exist_ok = True)
         timestamp = datetime.now().strftime('%Y-%m-%dT%H%M%S')
 
         for key in self.timings.keys():


### PR DESCRIPTION
When running the benchmark with MPI, all ranks try to make the result directory to save the json file. This might generate an exception, when a process tries to create an existing directory. This PR fix this issue by adding a parameter to the `os.makedirs` function. With the parameter `exist_ok = True`, the function does not generate an error when the directory already exists.