### PR TITLE
Smooth on GPUs (for now)

### DIFF
--- a/devito/builtins.py
+++ b/devito/builtins.py
@@ -196,17 +196,10 @@ def gaussian_smooth(f, sigma=1, truncate=4.0, mode='reflect'):
 
         mapper[d] = {'lhs': lhs, 'rhs': rhs, 'options': options}
 
-    # Note: we impose the smoother runs on the host as there's generally not
-    # enough parallelism to be performant on a device
-    platform = 'cpu64'
-    # TODO: openacc on CPUs not supported yet
-    if dv.configuration['language'] == 'openacc':
-        language = 'openmp'
-    else:
-        language = dv.configuration['language']
+    # Note: generally not enough parallelism to be performant on a gpu device
+    # TODO: Add openacc support for CPUs and set platform = 'cpu64'
 
-    initialize_function(f_c, f, lw, mapper=mapper, mode='reflect', name='smooth',
-                        platform=platform, language=language)
+    initialize_function(f_c, f, lw, mapper=mapper, mode='reflect', name='smooth')
 
     fset(f, f_c)
     return f


### PR DESCRIPTION
When using `openacc` + `mpi` we build `mpi4py` differently. Hence I don't think we can switch the smoothing over to `platform = 'cpu64'` when `mpi` is involved (until `openacc` is supported on CPUs). For the time being I think it's better we just carry out the smoothing on GPUs. Or we could check if `DEVITO_MPI /= 0` and not switch in that case only? 