### PR TITLE
Ensure av runner always shutdown

### DIFF
--- a/.github/workflows/asv.yml
+++ b/.github/workflows/asv.yml
@@ -124,6 +124,7 @@ jobs:
   # Stop the runner
   stop-runner:
     name: stop-runner
+    if: ${{ always() }}
     needs: benchmarks
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
Tiny patch to ensure the asv runner is shutdown even if, for some reason, the benchmark fails.