### PR TITLE
add MatrixSparseTimeFunction to support multi-point sources

### DIFF
--- a/devito/base.py
+++ b/devito/base.py
@@ -48,6 +48,10 @@ class PrecomputedSparseTimeFunction(with_metaclass(_BackendSelector, sparse.Prec
     pass
 
 
+class MatrixSparseTimeFunction(with_metaclass(_BackendSelector, sparse.MatrixSparseTimeFunction)):  # noqa
+    pass
+
+
 class Grid(with_metaclass(_BackendSelector, grid.Grid)):
     pass
 

--- a/devito/types/sparse.py
+++ b/devito/types/sparse.py
@@ -9,14 +9,16 @@ from devito.finite_differences import Differentiable, generate_fd_shortcuts
 from devito.mpi import MPI, SparseDistributor
 from devito.operations import LinearInterpolator, PrecomputedInterpolator
 from devito.symbolics import INT, cast_mapper, indexify, retrieve_function_carriers
-from devito.tools import ReducerMap, flatten, prod, filter_ordered, memoized_meth
+from devito.tools import (
+    ReducerMap, flatten, prod, filter_ordered, memoized_meth, is_integer
+)
 from devito.types.dense import DiscreteFunction, Function, SubFunction
-from devito.types.dimension import Dimension, ConditionalDimension
+from devito.types.dimension import Dimension, ConditionalDimension, DefaultDimension
 from devito.types.basic import Symbol, Scalar
-from devito.types.equation import Eq
+from devito.types.equation import Eq, Inc
 
 __all__ = ['SparseFunction', 'SparseTimeFunction', 'PrecomputedSparseFunction',
-           'PrecomputedSparseTimeFunction']
+           'PrecomputedSparseTimeFunction', 'MatrixSparseTimeFunction']
 
 
 class AbstractSparseFunction(DiscreteFunction, Differentiable):
@@ -1082,3 +1084,677 @@ class PrecomputedSparseTimeFunction(AbstractSparseTimeFunction,
         return super(PrecomputedSparseTimeFunction, self).interpolate(
             expr, offset=offset, increment=increment, self_subs=subs
         )
+
+
+class MatrixSparseTimeFunction(AbstractSparseTimeFunction, Differentiable):
+    """
+    A specialised type of SparseTimeFunction where the interpolation is externally
+    defined.  Currently, this means that the (integer) grid points and associated
+    coefficients for each sparse point are explicitly provided as separate
+    SubFunctions.
+
+    Additionally, this class allows sources and receivers to be constructed
+    from multiple locations, each with their own coefficients.  This is to support
+    injection and sampling of dipole (and more general) sources and receivers,
+    without needing to store multiple versions of the sample data that vary only
+    by a scalar constant.
+
+    matrix: scipy.sparse matrix
+        A scipy-style sparse matrix with a row for each physical
+        point in the grid, and a column for each index into the
+        data array.
+    r: int
+        The number of gridpoints in each dimension used to inject/interpolate
+        each physical point.  e.g. bi-/tri-linear interplation would use 2 coefficients
+        in each dimension.
+
+    other parameters as per SparseTimeFunction
+
+    Location/coefficient data:
+        msf.gridpoints.data[iloc, idim]: int
+            integer, position (in global coordinates)
+            of the _minimum_ index that location index
+            `iloc` is interpolated from / injected into, in dimension `idim`
+        msf.interpolation_coefficients: Dict[Dimension, np.ndarray]
+            For each dimension, there is an array of interpolation coefficients
+            for each location `iloc`.
+
+            This array is of shape (nloc, r), and is also available as
+                msf.coefficients_x.data[iloc, ir]
+
+            These are the coefficients that are multiplied by sample values
+            at the gridpoints in the range:
+
+            [msf.gridpoints.data[iloc, idim], msf.gridoints.data[iloc, idim] + r)
+
+    NOTE: *** restriction on space order of functions being sampled/injected into
+
+    The halo of the function being interpolated/injected into
+    must be larger than r, otherwise out of bounds access may result.
+
+    NOTE: *** explicit scatter/gather semantics
+
+    Before using this in an Operator, msf.manual_scatter() must be called to
+    distribute the data.  This only needs to be done once for any number of
+    calls to the Operator (e.g. for checkpointing), if the data, gridpoints
+    and coefficients have not changed.
+
+    This is true whether or not MPI is being used, and independent of
+    the MPI_Size.
+
+    Likewise, after all time steps have been run, data must be collected
+    from remote ranks using msf.manual_gather() before relying on any of the
+    data from msf.data[:]
+
+    .. note::
+
+        The parameters must always be given as keyword arguments, since
+        SymPy uses `*args` to (re-)create the dimension arguments of the
+        symbolic function.
+    """
+
+    _time_position = 0
+    """Position of time index among the function indices."""
+
+    def __init_finalize__(self, *args, **kwargs):
+        # The crucial argument to DugSparseTimeFunction is a sparse
+        # matrix mapping a "source" or "receiver" to a set of locations
+        self.matrix = kwargs.pop('matrix')
+
+        from devito.data.allocators import default_allocator
+        self._allocator = kwargs.get("allocator", default_allocator())
+
+        # Rows are locations, columns are source/receivers
+        nloc, npoint = self.matrix.shape
+
+        super().__init_finalize__(
+            *args, **kwargs, npoint=npoint)
+
+        # Grid points per sparse point
+        r = kwargs.get('r')
+        if r is None or not is_integer(r) or r <= 0:
+            raise ValueError('Interpolation requires parameter `r` (>0)')
+        if r % 2 != 0:
+            raise ValueError('Interpolation requires r to be even')
+
+        self._radius = r
+
+        # This has one value per dimension (e.g. size=3 for 3D)
+        # Maybe this should be unique per SparseFunction,
+        # but I can't see a need yet.
+        ddim = Dimension('d')
+
+        # Sources have their own Dimension
+        # As do Locations
+        locdim = Dimension('loc_%s' % self.name)
+
+        self._gridpoints = SubFunction(
+            name="%s_gridpoints" % self.name,
+            dtype=np.int32,
+            dimensions=(locdim, ddim),
+            shape=(nloc, self.grid.dim),
+            allocator=self._allocator,
+            space_order=0, parent=self)
+
+        # There is a coefficient array per grid dimension
+        # I could pack these into one array but that seems less readable?
+        self.interpolation_coefficients = {}
+        for d in self.grid.dimensions:
+            rdim = DefaultDimension(
+                name='r%s_%s' % (d.name, self.name),
+                default_value=self.r)
+            self.interpolation_coefficients[d] = SubFunction(
+                name="%s_coefficients_%s" % (self.name, d.name),
+                dtype=self.dtype,
+                dimensions=(locdim, rdim),
+                shape=(nloc, self.r),
+                allocator=self._allocator,
+                space_order=0, parent=self)
+
+            # For the _sub_functions, these must be named attributes of
+            # this SparseFunction object
+            setattr(
+                self, "coefficients_%s" % d.name,
+                self.interpolation_coefficients[d])
+
+        # We also need arrays to represent the sparse matrix map
+        # The shapes are bogus; these are really only used when
+        # constructing the expression,
+        # - the mpi logic dynamically constructs arrays to feed to the
+        # operator C code.
+        self.nnzdim = Dimension('nnz_%s' % self.name)
+
+        # In the non-MPI case, at least, we should fill these in once
+        if self.grid.distributor.nprocs == 1:
+            m_coo = self.matrix.tocoo(copy=False)
+            nnz_size = m_coo.nnz
+        else:
+            nnz_size = 1
+
+        self._mrow = SubFunction(
+            name='mrow_%s' % self.name,
+            dtype=np.int32,
+            dimensions=(self.nnzdim,),
+            shape=(nnz_size,),
+            space_order=0,
+            parent=self,
+            allocator=self._allocator,
+        )
+        self._mcol = SubFunction(
+            name='mcol_%s' % self.name,
+            dtype=np.int32,
+            dimensions=(self.nnzdim,),
+            shape=(nnz_size,),
+            space_order=0,
+            parent=self,
+            allocator=self._allocator,
+        )
+        self._mval = SubFunction(
+            name='mval_%s' % self.name,
+            dtype=self.dtype,
+            dimensions=(self.nnzdim,),
+            shape=(nnz_size,),
+            space_order=0,
+            parent=self,
+            allocator=self._allocator,
+        )
+
+        if self.grid.distributor.nprocs == 1:
+            self._mrow.data[:] = m_coo.row
+            self._mcol.data[:] = m_coo.col
+            self._mval.data[:] = m_coo.data
+
+        self._fd = generate_fd_shortcuts(self)
+
+        self.scatter_result = None
+        self.scattered_data = None
+
+    def free_data(self):
+        # The sympy cache holds the symbol references, but we can break the link
+        # between the symbol and the data, thus causing the memory to be freed
+        # This renders the object useless
+        self._data = None
+        self._gridpoints._data = None
+        self._mrow._data = None
+        self._mcol._data = None
+        self._mval._data = None
+        for f in self.interpolation_coefficients.values():
+            f._data = None
+
+        self.scatter_result = None
+        self.scattered_data = None
+
+        # Because AbstractSparseFunction._arg_defaults caches the values of the
+        # above arrays, we also need to wipe out our per-object cache
+        try:
+            # Names are mangled to prevent this kind of tomfoolery
+            # So instead of clearing __cache we do this
+            # https://dbader.org/blog/meaning-of-underscores-in-python
+            del self._memoized_meth__cache_meth
+        except AttributeError:
+            pass
+
+    @property
+    def dt(self):
+        t = self.time_dim
+        dt = self.time_dim.spacing
+        return (-1 * self.subs(t, t - dt) + self.subs(t, t + dt))/(2 * dt)
+
+    @property
+    def dt2(self):
+        t = self.time_dim
+        dt = self.time_dim.spacing
+        return (self.subs(t, t - dt) - 2 * self + self.subs(t, t + dt))/(dt*dt)
+
+    @property
+    def mrow(self):
+        return self._mrow
+
+    @property
+    def mcol(self):
+        return self._mcol
+
+    @property
+    def mval(self):
+        return self._mval
+
+    @property
+    def _sub_functions(self):
+        return ('gridpoints',
+                *['coefficients_%s' % d.name for d in self.grid.dimensions],
+                'mrow', 'mcol', 'mval')
+
+    @property
+    def r(self):
+        return self._radius
+
+    def interpolate(self, expr, offset=0, u_t=None, p_t=None):
+        """Creates a :class:`sympy.Eq` equation for the interpolation
+        of an expression onto this sparse point collection.
+
+        :param expr: The expression to interpolate.
+        :param offset: Additional offset from the boundary for
+                       absorbing boundary conditions.
+        :param u_t: (Optional) time index to use for indexing into
+                    field data in `expr`.
+        :param p_t: (Optional) time index to use for indexing into
+                    the sparse point data.
+        """
+        expr = indexify(expr)
+
+        # Apply optional time symbol substitutions to expr
+        if u_t is not None:
+            time = self.grid.time_dim
+            t = self.grid.stepping_dim
+            expr = expr.subs(t, u_t).subs(time, u_t)
+
+        gridpoints = self._gridpoints.indexed
+        mrow = self._mrow.indexed
+        mcol = self._mcol.indexed
+        mval = self._mval.indexed
+        tdim, pdim = self.indices
+        locdim, ddim = self._gridpoints.indices
+        nnzdim = self.nnzdim
+
+        row = mrow[nnzdim]
+
+        dim_subs = [(pdim, mcol[nnzdim])]
+        coeffs = [mval[nnzdim]]
+        for i, d in enumerate(self.grid.dimensions):
+            _, rd = self.interpolation_coefficients[d].dimensions
+            coefficients = self.interpolation_coefficients[d].indexed
+            dim_subs.append((d, rd + gridpoints[row, i]))
+            coeffs.append(coefficients[row, rd])
+
+        # Apply optional time symbol substitutions to lhs of assignment
+        lhs = self if p_t is None else self.subs(tdim, p_t)
+        lhs = lhs.subs([(pdim, mcol[nnzdim])])
+        rhs = prod(coeffs) * expr.subs(dim_subs)
+
+        return [Eq(self, 0), Inc(lhs, rhs)]
+
+    def inject(self, field, expr, offset=0, u_t=None, p_t=None):
+        """Symbol for injection of an expression onto a grid
+
+        :param field: The grid field into which we inject.
+        :param expr: The expression to inject.
+        :param offset: Additional offset from the boundary for
+                       absorbing boundary conditions.
+        :param u_t: (Optional) time index to use for indexing into `field`.
+        :param p_t: (Optional) time index to use for indexing into `expr`.
+        """
+        expr = indexify(expr)
+        field = indexify(field)
+
+        tdim, pdim = self.indices
+        nnzdim = self.nnzdim
+        locdim, ddim = self.gridpoints.indices
+
+        # Apply optional time symbol substitutions to field and expr
+        if u_t is not None:
+            field = field.subs(field.indices[0], u_t)
+        if p_t is not None:
+            expr = expr.subs(tdim, p_t)
+
+        gridpoints = self._gridpoints.indexed
+        mrow = self._mrow.indexed
+        mcol = self._mcol.indexed
+        mval = self._mval.indexed
+
+        row = mrow[nnzdim]
+
+        dim_subs = [(pdim, mcol[nnzdim])]
+        coeffs = [mval[nnzdim]]
+        for i, d in enumerate(self.grid.dimensions):
+            _, rd = self.interpolation_coefficients[d].dimensions
+            dim_subs.append((d, rd + gridpoints[row, i]))
+            coefficients = self.interpolation_coefficients[d].indexed
+            coeffs.append(coefficients[row, rd])
+
+        rhs = prod(coeffs) * expr
+        field = field.subs(dim_subs)
+        out = [Inc(field, rhs.subs(dim_subs))]
+
+        return out
+
+    @classmethod
+    def __indices_setup__(cls, **kwargs):
+        """
+        Return the default dimension indices for a given data shape.
+        """
+        dimensions = kwargs.get('dimensions')
+        if dimensions is None:
+            dimensions = (kwargs['grid'].time_dim, Dimension(
+                name='p_%s' % kwargs["name"]))
+        return dimensions, dimensions
+
+    @classmethod
+    def __shape_setup__(cls, **kwargs):
+        # This happens before __init__, so we have to get 'npoint'
+        # from the matrix
+        _, npoint = kwargs['matrix'].shape
+        return kwargs.get('shape', (kwargs.get('nt'), npoint))
+
+    @property
+    def _arg_names(self):
+        """Return a tuple of argument names introduced by this function."""
+        return tuple([self.name, self.name + "_" + self.gridpoints.name]
+                     + ['%s_%s' % (self.name, x.name)
+                        for x in self.interpolation_coefficients.values()])
+
+    @property
+    def gridpoints(self):
+        return self._gridpoints
+
+    def _rank_to_points(self):
+        """
+        For each rank in self.grid.distributor, return
+        a numpy array of int32s for the positions within
+        this rank's self.gridpoints/self.interpolation_coefficients (i.e.
+        the locdim) which must be injected into that rank.
+
+        Any given location may require injection into several
+        ranks, based on the radius of the injection stencil
+        and its proximity to a rank boundary.
+
+        It is assumed, for now, that any given location may be
+        completely sampled from within one rank - so when
+        gathering the data, any point sampled from more than
+        one rank may have duplicates discarded.  This implies
+        that the radius of the sampling is less than
+        the halo size of the Functions being sampled from.
+        It also requires that the halos be exchanged before
+        interpolation (must verify that this occurs).
+        """
+        distributor = self.grid.distributor
+
+        # Along each dimension, the coordinate indices are broken into
+        # 2*decomposition_size+3 groups, numbered starting at 0
+
+        # Group 2*i contributes only to rank i-1
+        # Group 2*i+1 contributes to rank i-1 and rank i
+
+        # Obviously this means groups 0 and 1 are "bad" - they contribute
+        #  to points to the left of the domain (rank -1)
+        # So is group 2*decomp_size+1 and 2*decomp_size+2
+        #  (these contributes to rank "decomp_size")
+
+        # binned_gridpoints will hold which group the particular
+        # point is along that decomposed dimension.
+        binned_gridpoints = np.empty_like(self._gridpoints.data)
+        dim_group_dim_rank = []
+
+        for idim, dim in enumerate(self.grid.dimensions):
+            decomp = distributor.decomposition[idim]
+            decomp_size = len(decomp)
+            dim_breaks = np.empty([2*decomp_size+2], dtype=np.int32)
+            dim_breaks[:-2:2] = [
+                decomp_part[0] - self.r + 1 for decomp_part in decomp]
+            dim_breaks[-2] = decomp[-1][-1] + 1 - self.r + 1
+            dim_breaks[1:-1:2] = [
+                decomp_part[0] for decomp_part in decomp]
+            dim_breaks[-1] = decomp[-1][-1] + 1
+
+            try:
+                binned_gridpoints[:, idim] = np.digitize(
+                    self._gridpoints.data[:, idim], dim_breaks)
+            except ValueError as e:
+                raise ValueError(
+                    "decomposition failed!  Are some ranks too skinny?"
+                ) from e
+
+            this_group_rank_map = {
+                0: {None},
+                1: {None, 0},
+                **{2*i+2: {i} for i in range(decomp_size)},
+                **{2*i+2+1: {i, i+1} for i in range(decomp_size-1)},
+                2*decomp_size+1: {decomp_size-1, None},
+                2*decomp_size+2: {None}}
+
+            dim_group_dim_rank.append(this_group_rank_map)
+
+        # This allows the points to be grouped into non-overlapping sets
+        # based on their bin in each dimension.  For each set we build a list
+        # of points.
+        bins, inverse, counts = np.unique(
+            binned_gridpoints,
+            return_inverse=True,
+            return_counts=True,
+            axis=0)
+
+        # inverse is now a "unique bin number" for each point gridpoints
+        # we want to turn that into a list of points for each bin
+        # so we argsort
+        inverse_argsort = np.argsort(inverse).astype(np.int32)
+        cumulative_counts = np.cumsum(counts)
+        gp_map = {tuple(bi): inverse_argsort[cci-ci:cci]
+                  for bi, cci, ci in zip(bins, cumulative_counts, counts)
+                  }
+
+        # the result is now going to be a concatenation of these lists
+        # for each of the output ranks
+        # each bin has a set of ranks -> each rank has a set (possibly empty)
+        # of bins
+
+        # For each rank get the per-dimension coordinates
+        # TODO maybe we should cache this on the distributor
+        dim_ranks_to_glb = {
+            tuple(distributor.comm.Get_coords(rank)): rank
+            for rank in range(distributor.comm.Get_size())}
+
+        global_rank_to_bins = {}
+
+        from itertools import product
+        for bi in bins:
+            # This is a list of sets for the dimension-specific rank
+            dim_rank_sets = [dgdr[bii]
+                             for dgdr, bii in zip(dim_group_dim_rank, bi)]
+
+            # Convert these to an absolute rank
+            # This is where we will throw a KeyError if there are points OOB
+            for dim_ranks in product(*dim_rank_sets):
+                global_rank = dim_ranks_to_glb[tuple(dim_ranks)]
+                global_rank_to_bins\
+                    .setdefault(global_rank, set())\
+                    .add(tuple(bi))
+
+        empty = np.array([], dtype=np.int32)
+
+        return [np.concatenate((
+            empty, *[gp_map[bi] for bi in global_rank_to_bins.get(rank, [])]))
+            for rank in range(distributor.comm.Get_size())]
+
+    def manual_scatter(self, *, data_all_zero=False):
+        distributor = self.grid.distributor
+
+        if distributor.nprocs == 1:
+            self.scattered_data = self.data
+            self.scatter_result = {
+                self: self.data,
+                **{
+                    getattr(self, k): getattr(self, k).data for k in self._sub_functions
+                },
+                self.mrow: self.mrow.data,
+                self.mcol: self.mcol.data,
+                self.mval: self.mval.data,
+            }
+            return
+
+        # Generate the matrix arrays
+        m_coo = self.matrix.tocoo(copy=False)
+
+        # HACK: for now, only take npoints != 0 on rank 0
+        # Broadcast all the data, gridpoints, coefficients to all ranks
+        # Each rank then ignores any of the data which isn't in its own
+        #  domain.
+        if distributor.myrank != 0 and self.npoint != 0:
+            raise ValueError("can only accept sources/receivers on rank 0")
+
+        # args[self.mrow.name] = m_coo.row.copy()
+        # args[self.mcol.name] = m_coo.col.copy()
+        # args[self.mval.name] = m_coo.data.copy()
+        # args.update(self.nnzdim._arg_defaults(size=m_coo.nnz))
+
+        # Send out data
+        # Send out gridpoints
+        # Send out coefficients
+        # Send out matrix rows, cols, data
+        npoint, nloc, nnz, ndim, r, nt = distributor.comm.bcast(
+            (self.npoint,
+             self._gridpoints.data.shape[0],
+             m_coo.nnz,
+             self._gridpoints.data.shape[-1],
+             self.r,
+             self.data.shape[self._time_position]), root=0)
+
+        # important that all ranks have the same ndims and same r
+        assert r == self.r
+        assert ndim == self._gridpoints.data.shape[-1]
+
+        # now all ranks can allocate the buffers to receive into
+        if distributor.myrank != 0:
+            if data_all_zero:
+                scattered_data = np.zeros([nt, npoint], dtype=self.dtype)
+            else:
+                scattered_data = np.empty([nt, npoint], dtype=self.dtype)
+            scattered_gp = np.empty([nloc, ndim], dtype=np.int32)
+            scattered_coeffs = [
+                np.empty([nloc, r], dtype=self.dtype) for _ in range(ndim)]
+            scattered_mrow = np.empty([nnz], dtype=np.int32)
+            scattered_mcol = np.empty([nnz], dtype=np.int32)
+            scattered_mval = np.empty([nnz], dtype=self.dtype)
+        else:
+            scattered_data = self.data
+
+            # These are copies because we mess with them down below
+            scattered_gp = self._gridpoints.data.copy()
+            scattered_coeffs = [
+                self.interpolation_coefficients[d].data.copy()
+                for d in self.grid.dimensions]
+            scattered_mrow = m_coo.row.copy()
+            scattered_mcol = m_coo.col.copy()
+            scattered_mval = m_coo.data.copy()
+
+        if not data_all_zero:
+            distributor.comm.Bcast(scattered_data, root=0)
+        for arr in [scattered_gp, *scattered_coeffs,
+                    scattered_mrow, scattered_mcol, scattered_mval]:
+            distributor.comm.Bcast(arr, root=0)
+
+        # now recreate the matrix to only contain points in our
+        # local domain.
+        # along each dimension, each point is in one of 5 groups
+        #  0 - completely to the left
+        #  1 - to the left, but the injection stencil touches our domain
+        #  2 - completely in our domain
+        #  3 - in the domain, but the injection stencil includes points
+        #      to the right
+        #  4 - completely to the right
+        active_mrow = scattered_mrow
+        active_mcol = scattered_mcol
+        active_mval = scattered_mval
+
+        # first, build a reduced matrix excluding any points outside our domain
+        for idim, (dim, mycoord) in enumerate(zip(
+                self.grid.dimensions, distributor.mycoords)):
+            _left = distributor.decomposition[idim][mycoord][0]
+            _right = distributor.decomposition[idim][mycoord][-1] + 1
+
+            # rewrite the matrix to remove the rows in groups 0 and 4
+            mask = (
+                (scattered_gp[active_mrow, idim] >= _left - self.r + 1)
+                & (scattered_gp[active_mrow, idim] < _right))
+
+            which = np.nonzero(mask)
+            active_mrow = active_mrow[which]
+            active_mcol = active_mcol[which]
+            active_mval = active_mval[which]
+
+        # then, zero any of the coefficients which refer to points outside our
+        # domain.  Do this on all the gridpoints for now, since this is a hack
+        # anyway
+        for idim, (dim, mycoord) in enumerate(zip(
+                self.grid.dimensions, distributor.mycoords)):
+            _left = distributor.decomposition[idim][mycoord][0]
+            _right = distributor.decomposition[idim][mycoord][-1] + 1
+
+            # points to the left have the first few coeffs zeroed
+            trim_size = np.clip(_left - scattered_gp[:, idim], 0, self.r)
+            for ir in range(self.r):
+                # which points need zeroing?
+                mask = (trim_size > ir)
+                scattered_coeffs[idim][mask, ir] = 0
+
+            # points to the right have the last few coeffs zeroed
+            trim_size = np.clip(
+                scattered_gp[:, idim] - (_right - self.r), 0, self.r)
+            for ir in range(self.r):
+                # which points need zeroing?
+                mask = (trim_size > ir)
+                scattered_coeffs[idim][mask, -(ir+1)] = 0
+
+            # finally, we translate to local coordinates
+            scattered_gp[:, idim] -= _left
+
+        self.scattered_data = scattered_data
+        self.scatter_result = {
+            self: scattered_data,
+            self.gridpoints: scattered_gp,
+            **{
+                self.interpolation_coefficients[d]: scattered_coeffs[idim]
+                for idim, d in enumerate(self.grid.dimensions)
+            },
+            self.mrow: active_mrow,
+            self.mcol: active_mcol,
+            self.mval: active_mval,
+        }
+
+    def _dist_scatter(self, data=None):
+        assert data is None
+        if self.scatter_result is None:
+            raise Exception("_dist_scatter called before manual_scatter called")
+        return self.scatter_result
+
+    # The implementation in AbstractSparseFunction now relies on us
+    # having a .coordinates property, which we don't have.
+    def _arg_apply(self, dataobj, alias=None):
+        key = alias if alias is not None else self
+        if isinstance(key, AbstractSparseFunction):
+            # Gather into `self.data`
+            key._dist_gather(self._C_as_ndarray(dataobj))
+        elif self.grid.distributor.nprocs > 1:
+            raise NotImplementedError("Don't know how to gather data from an "
+                                      "object of type `%s`" % type(key))
+
+    def manual_gather(self):
+        # data, in this case, is set to whatever dist_scatter provided?
+        # on rank 0, this is the original data array (hack...)
+        distributor = self.grid.distributor
+
+        # If not using MPI, don't waste time
+        if distributor.nprocs == 1:
+            return
+
+        # This relies on all ranks having a copy of all data. Which feels "bad".
+        if distributor.myrank != 0:
+            distributor.comm.Reduce(
+                self.scattered_data,
+                None,
+                op=MPI.SUM,
+                root=0
+            )
+        else:
+            distributor.comm.Reduce(
+                MPI.IN_PLACE,
+                self.scattered_data,  # Note: on rank 0 data === scattered_data.
+                op=MPI.SUM,
+                root=0
+            )
+
+    def _dist_gather(self, data):
+        pass
+
+    # We use DiscreteFunction instead of AbstractSparseTimeFunction
+    # because we want to get rid of 'npoint'
+    _pickle_kwargs = DiscreteFunction._pickle_kwargs + (
+        ['dimensions', 'r', 'matrix', 'nt', 'grid'])

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1,8 +1,11 @@
 import pytest
+from math import floor
 import numpy as np
+import scipy.sparse
 
 from devito import (Grid, Function, TimeFunction, SparseTimeFunction, Dimension, # noqa
-                    Eq, Operator, ALLOC_GUARD, ALLOC_FLAT, configuration, switchconfig)
+                    Eq, Operator, ALLOC_GUARD, ALLOC_FLAT, configuration, switchconfig,
+                    MatrixSparseTimeFunction)
 from devito.data import LEFT, RIGHT, Decomposition, loc_data_idx, convert_index
 from devito.tools import as_tuple
 from devito.types import Scalar
@@ -1328,6 +1331,338 @@ def test_external_allocator():
     f.data[:] = 4.
     # Ensure the underlying numpy array changes too
     assert(np.array_equal(f.data, numpy_array))
+
+
+class TestMatrixSparseTimeFunction:
+    def _precompute_linear_interpolation(self, points, grid, origin):
+        """ Sample precompute function that, given point and grid information
+            precomputes gridpoints and coefficients according to a linear
+            scheme to be used in PrecomputedSparseFunction.
+        """
+        gridpoints = [
+            tuple(
+                floor((point[i] - origin[i]) / grid.spacing[i]) for i in range(len(point))
+            )
+            for point in points
+        ]
+
+        coefficients = np.zeros((len(points), 2, 2))
+        for i, point in enumerate(points):
+            for d in range(grid.dim):
+                coefficients[i, d, 0] = (
+                    (gridpoints[i][d] + 1) * grid.spacing[d] - point[d]
+                ) / grid.spacing[d]
+                coefficients[i, d, 1] = (
+                    point[d] - gridpoints[i][d] * grid.spacing[d]
+                ) / grid.spacing[d]
+        return gridpoints, coefficients
+
+    def test_precomputed_interpolation(self):
+        shape = (101, 101)
+        points = [(0.05, 0.9), (0.01, 0.8), (0.07, 0.84)]
+        origin = (0, 0)
+
+        grid = Grid(shape=shape, origin=origin)
+        x, y = grid.dimensions
+        r = 2
+
+        nt = 10
+
+        m = TimeFunction(name="m", grid=grid, space_order=0, save=nt, time_order=0)
+        for it in range(nt):
+            m.data[it, :] = it
+
+        gridpoints, coefficients = self._precompute_linear_interpolation(
+            points, grid, origin
+        )
+
+        mat = scipy.sparse.eye(len(points), dtype=np.float32)
+
+        sf = MatrixSparseTimeFunction(name="s", grid=grid, r=r, matrix=mat, nt=nt)
+
+        sf.gridpoints.data[:] = gridpoints
+        sf.interpolation_coefficients[x].data[:] = coefficients[:, 0, :]
+        sf.interpolation_coefficients[y].data[:] = coefficients[:, 1, :]
+
+        eqn = sf.interpolate(m)
+        op = Operator(eqn)
+
+        sf.manual_scatter()
+
+        # args = op.arguments(time_m=0, time_M=9)
+        op(time_m=0, time_M=9)
+
+        sf.manual_gather()
+
+        for it in range(nt):
+            assert np.all(sf.data[it, :] == pytest.approx(it))
+
+    def test_precomputed_interpolation_empty(self):
+        shape = (101, 101)
+        origin = (0, 0)
+
+        grid = Grid(shape=shape, origin=origin)
+        x, y = grid.dimensions
+        #  because we interpolate across 2 neighbouring points in each dimension
+        r = 2
+
+        nt = 10
+
+        m = TimeFunction(name="m", grid=grid, space_order=0, save=nt, time_order=0)
+        for it in range(nt):
+            m.data[it, :] = it
+
+        mat = scipy.sparse.coo_matrix((0, 0), dtype=np.float32)
+        sf = MatrixSparseTimeFunction(name="s", grid=grid, r=r, matrix=mat, nt=nt)
+
+        eqn = sf.interpolate(m)
+        op = Operator(eqn)
+
+        sf.manual_scatter()
+        op(time_m=0, time_M=9)
+        sf.manual_gather()
+        # There are no receivers, so nothing to assert here
+
+    def test_precomputed2(self):
+        shape = (101, 101)
+        grid = Grid(shape=shape)
+        x, y = grid.dimensions
+        r = 2  # Constant for linear interpolation
+        #  because we interpolate across 2 neighbouring points in each dimension
+
+        nt = 10
+
+        m = TimeFunction(name="m", grid=grid, space_order=0, save=None, time_order=1)
+
+        m.data[:] = 0.0
+        m.data[:, 40, 40] = 1.0
+
+        matrix = scipy.sparse.eye(1, dtype=np.float32)
+        sf = MatrixSparseTimeFunction(name="s", grid=grid, r=r, matrix=matrix, nt=nt)
+
+        # Lookup the exact point
+        sf.gridpoints.data[0, 0] = 40
+        sf.gridpoints.data[0, 1] = 40
+        sf.interpolation_coefficients[x].data[0, 0] = 1.0
+        sf.interpolation_coefficients[x].data[0, 1] = 2.0
+        sf.interpolation_coefficients[y].data[0, 0] = 1.0
+        sf.interpolation_coefficients[y].data[0, 1] = 2.0
+        sf.data[:] = 0.0
+
+        step = [Eq(m.forward, m)]
+        interp = sf.interpolate(m)
+        op = Operator(step + interp)
+
+        sf.manual_scatter()
+        op(time_m=0, time_M=0)
+        sf.manual_gather()
+
+        assert sf.data[0, 0] == 1.0
+
+    def test_precomputed_subpoints(self):
+        shape = (101, 101)
+        grid = Grid(shape=shape)
+        x, y = grid.dimensions
+        r = 2  # Constant for linear interpolation
+        #  because we interpolate across 2 neighbouring points in each dimension
+
+        nt = 10
+
+        m = TimeFunction(name="m", grid=grid, space_order=0, save=None, time_order=1)
+
+        m.data[:] = 0.0
+        m.data[:, 40, 40] = 1.0
+
+        # Two-location source with 2 coefficients the same
+        matrix = scipy.sparse.coo_matrix(np.array([[1], [1]], dtype=np.float32))
+
+        sf = MatrixSparseTimeFunction(name="s", grid=grid, r=r, matrix=matrix, nt=nt)
+
+        # Lookup the exact point
+        sf.gridpoints.data[0, 0] = 40
+        sf.gridpoints.data[0, 1] = 40
+        sf.interpolation_coefficients[x].data[0, 0] = 1.0
+        sf.interpolation_coefficients[x].data[0, 1] = 2.0
+        sf.interpolation_coefficients[y].data[0, 0] = 1.0
+        sf.interpolation_coefficients[y].data[0, 1] = 2.0
+        sf.gridpoints.data[1, 0] = 39
+        sf.gridpoints.data[1, 1] = 39
+        sf.interpolation_coefficients[x].data[1, 0] = 1.0
+        sf.interpolation_coefficients[x].data[1, 1] = 2.0
+        sf.interpolation_coefficients[y].data[1, 0] = 1.0
+        sf.interpolation_coefficients[y].data[1, 1] = 2.0
+        sf.data[:] = 0.0
+
+        step = [Eq(m.forward, m)]
+        interp = sf.interpolate(m)
+        op = Operator(step + interp)
+
+        sf.manual_scatter()
+        op(time_m=0, time_M=0)
+        sf.manual_gather()
+
+        assert sf.data[0, 0] == 5.0
+
+    def test_precomputed_subpoints_inject(self):
+        shape = (101, 101)
+        grid = Grid(shape=shape)
+        x, y = grid.dimensions
+        r = 2  # Constant for linear interpolation
+        #  because we interpolate across 2 neighbouring points in each dimension
+
+        nt = 10
+
+        m = TimeFunction(name="m", grid=grid, space_order=0, save=None, time_order=1)
+
+        m.data[:] = 0.0
+        m.data[:, 40, 40] = 1.0
+
+        # Single two-component source with coefficients both +1
+        matrix = scipy.sparse.coo_matrix(np.array([[1], [1]], dtype=np.float32))
+
+        sf = MatrixSparseTimeFunction(name="s", grid=grid, r=r, matrix=matrix, nt=nt)
+
+        # Lookup the exact point
+        sf.gridpoints.data[0, 0] = 40
+        sf.gridpoints.data[0, 1] = 40
+        sf.interpolation_coefficients[x].data[0, 0] = 1.0
+        sf.interpolation_coefficients[x].data[0, 1] = 2.0
+        sf.interpolation_coefficients[y].data[0, 0] = 1.0
+        sf.interpolation_coefficients[y].data[0, 1] = 2.0
+        sf.gridpoints.data[1, 0] = 39
+        sf.gridpoints.data[1, 1] = 39
+        sf.interpolation_coefficients[x].data[1, 0] = 1.0
+        sf.interpolation_coefficients[x].data[1, 1] = 2.0
+        sf.interpolation_coefficients[y].data[1, 0] = 1.0
+        sf.interpolation_coefficients[y].data[1, 1] = 2.0
+        sf.data[0, 0] = 1.0
+
+        step = [Eq(m.forward, m)]
+        inject = sf.inject(field=m.forward, expr=sf)
+        op = Operator(step + inject)
+
+        sf.manual_scatter()
+        op(time_m=0, time_M=0)
+        sf.manual_gather()
+
+        assert m.data[1, 40, 40] == 6.0  # 1 + 1 + 4
+        assert m.data[1, 40, 41] == 2.0
+        assert m.data[1, 41, 40] == 2.0
+        assert m.data[1, 41, 41] == 4.0
+        assert m.data[1, 39, 39] == 1.0
+        assert m.data[1, 39, 40] == 2.0
+        assert m.data[1, 40, 39] == 2.0
+
+    def test_precomputed_subpoints_inject_dt2(self):
+        shape = (101, 101)
+        grid = Grid(shape=shape)
+        x, y = grid.dimensions
+        r = 2  # Constant for linear interpolation
+        #  because we interpolate across 2 neighbouring points in each dimension
+
+        nt = 10
+
+        m = TimeFunction(name="m", grid=grid, space_order=0, save=None, time_order=1)
+
+        m.data[:] = 0.0
+        m.data[:, 40, 40] = 1.0
+
+        matrix = scipy.sparse.coo_matrix(np.array([[1], [1]], dtype=np.float32))
+
+        sf = MatrixSparseTimeFunction(
+            name="s", grid=grid, r=r, matrix=matrix, nt=nt, time_order=2
+        )
+
+        # Lookup the exact point
+        sf.gridpoints.data[0, 0] = 40
+        sf.gridpoints.data[0, 1] = 40
+        sf.interpolation_coefficients[x].data[0, 0] = 1.0
+        sf.interpolation_coefficients[x].data[0, 1] = 2.0
+        sf.interpolation_coefficients[y].data[0, 0] = 1.0
+        sf.interpolation_coefficients[y].data[0, 1] = 2.0
+        sf.gridpoints.data[1, 0] = 39
+        sf.gridpoints.data[1, 1] = 39
+        sf.interpolation_coefficients[x].data[1, 0] = 1.0
+        sf.interpolation_coefficients[x].data[1, 1] = 2.0
+        sf.interpolation_coefficients[y].data[1, 0] = 1.0
+        sf.interpolation_coefficients[y].data[1, 1] = 2.0
+
+        # Single timestep, -0.5*1e-6, so that with dt=0.001, the .dt2 == 1 at t=1
+        sf.data[1, 0] = -5e-7
+
+        step = [Eq(m.forward, m)]
+        inject = sf.inject(field=m.forward, expr=sf.dt2)
+        op = Operator(step + inject)
+
+        sf.manual_scatter()
+        op(time_m=1, time_M=1, dt=0.001)
+        sf.manual_gather()
+
+        assert m.data[0, 40, 40] == pytest.approx(6.0)  # 1 + 1 + 4
+        assert m.data[0, 40, 41] == pytest.approx(2.0)
+        assert m.data[0, 41, 40] == pytest.approx(2.0)
+        assert m.data[0, 41, 41] == pytest.approx(4.0)
+        assert m.data[0, 39, 39] == pytest.approx(1.0)
+        assert m.data[0, 39, 40] == pytest.approx(2.0)
+        assert m.data[0, 40, 39] == pytest.approx(2.0)
+
+    @pytest.mark.parallel(mode=4)
+    def test_mpi(self):
+        # Shape chosen to get a source in multiple ranks
+        shape = (91, 91)
+        grid = Grid(shape=shape)
+        x, y = grid.dimensions
+        #  because we interpolate across 2 neighbouring points in each dimension
+        r = 2
+
+        nt = 10
+
+        # NOTE: halo on function (space_order//2?) must be at least >= r
+        m = TimeFunction(name="m", grid=grid, space_order=4, save=None, time_order=1)
+
+        m.data[:] = 0.0
+        m.data[:, 40, 40] = 1.0
+        m.data[:, 50, 50] = 1.0
+
+        # only rank 0 is allowed to have points
+        if grid.distributor.myrank == 0:
+            # A single dipole source - so two rows, one column
+            matrix = scipy.sparse.coo_matrix(np.array([[1], [-1]], dtype=np.float32))
+        else:
+            matrix = scipy.sparse.coo_matrix((0, 0), dtype=np.float32)
+
+        sf = MatrixSparseTimeFunction(name="s", grid=grid, r=r, matrix=matrix, nt=nt)
+
+        if grid.distributor.myrank == 0:
+            # First component of the dipole at 40, 40
+            sf.gridpoints.data[0, 0] = 40
+            sf.gridpoints.data[0, 1] = 40
+            sf.interpolation_coefficients[x].data[0, 0] = 1.0
+            sf.interpolation_coefficients[x].data[0, 1] = 2.0
+            sf.interpolation_coefficients[y].data[0, 0] = 1.0
+            sf.interpolation_coefficients[y].data[0, 1] = 2.0
+            sf.gridpoints.data[1, 0] = 50
+            sf.gridpoints.data[1, 1] = 50
+            sf.interpolation_coefficients[x].data[1, 0] = 2.0
+            sf.interpolation_coefficients[x].data[1, 1] = 2.0
+            sf.interpolation_coefficients[y].data[1, 0] = 2.0
+            sf.interpolation_coefficients[y].data[1, 1] = 2.0
+
+        op = Operator(sf.interpolate(m))
+        sf.manual_scatter()
+        args = op.arguments(time_m=0, time_M=9)
+        print("rank %d: %s" % (grid.distributor.myrank, str(args)))
+        op.apply(time_m=0, time_M=0)
+        sf.manual_gather()
+
+        for i in range(grid.distributor.nprocs):
+            print("==== from rank %d" % i)
+            if i == grid.distributor.myrank:
+                print(repr(sf.data))
+            grid.distributor.comm.Barrier()
+
+        if grid.distributor.myrank == 0:
+            assert sf.data[0, 0] == -3.0  # 1 * (1 * 1) * 1 + (-1) * (2 * 2) * 1
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This adds a `MatrixSparseTimeFunction` class, which allows a single time-series of source data to be injected (with different weights) at, or sampled from, multiple physical locations in the grid.

The typical use case is to inject a dipole source, or sample a dipole receiver (where the weights are +1 for one injection point and -1 for the other).  This is used, for example, if one wishes to model ghosting-type behaviour without using a free surface, and without storing twice as much data to do so.