### PR TITLE
WIP-RFC: Nested indexification Fix for #1283

### DIFF
--- a/devito/ir/equations/algorithms.py
+++ b/devito/ir/equations/algorithms.py
@@ -76,6 +76,7 @@ def lower_exprs(expressions, **kwargs):
         * Indexify functions;
         * Align Indexeds with the computational domain;
         * Apply user-provided substitution;
+        * Apply nested substitutions;
 
     Examples
     --------
@@ -94,6 +95,7 @@ def lower_exprs(expressions, **kwargs):
         mapper = {f: f.indexify(lshift=True, subs=dimension_map)
                   for f in retrieve_functions(expr)}
 
+        nsubs = {}
         # Handle Indexeds (from index notation)
         for i in retrieve_indexed(expr, deep=True):
             f = i.function
@@ -102,12 +104,10 @@ def lower_exprs(expressions, **kwargs):
             indices = [(a + o) for a, o in zip(i.indices, f._size_nodomain.left)]
 
             # Indexify indices of nested functions
-            tmp_mapper = {}
             for index in indices:
                 for nested_func in retrieve_functions(index):
-                    tmp_mapper = {nested_func: nested_func.indexify(lshift=True)}
-                    index = index.xreplace(tmp_mapper)
-                    expr = expr.xreplace(tmp_mapper)
+                    nsubs.update({nested_func: nested_func.indexify(lshift=True)})
+                    index = index.xreplace(nsubs)
 
             # Apply substitutions, if necessary
             if dimension_map:
@@ -122,6 +122,10 @@ def lower_exprs(expressions, **kwargs):
             processed.append(expr.xreplace({**mapper, **subs}))
         else:
             processed.append(uxreplace(expr, mapper))
+
+        if nsubs:
+            # Apply the nested substitutions
+            processed = {d.xreplace(nsubs) for d in processed}
 
     if isinstance(expressions, Iterable):
         return processed

--- a/devito/ir/equations/algorithms.py
+++ b/devito/ir/equations/algorithms.py
@@ -76,7 +76,6 @@ def lower_exprs(expressions, **kwargs):
         * Indexify functions;
         * Align Indexeds with the computational domain;
         * Apply user-provided substitution;
-        * Apply nested substitutions;
 
     Examples
     --------
@@ -96,7 +95,7 @@ def lower_exprs(expressions, **kwargs):
                   for f in retrieve_functions(expr)}
 
         # Handle Indexeds (from index notation)
-        for i in retrieve_indexed(expr, deep=True):
+        for i in retrieve_indexed(expr):
             f = i.function
 
             # Introduce shifting to align with the computational domain

--- a/devito/ir/equations/algorithms.py
+++ b/devito/ir/equations/algorithms.py
@@ -95,11 +95,19 @@ def lower_exprs(expressions, **kwargs):
                   for f in retrieve_functions(expr)}
 
         # Handle Indexeds (from index notation)
-        for i in retrieve_indexed(expr):
+        for i in retrieve_indexed(expr, deep=True):
             f = i.function
 
             # Introduce shifting to align with the computational domain
             indices = [(a + o) for a, o in zip(i.indices, f._size_nodomain.left)]
+
+            # Indexify indices of nested functions
+            tmp_mapper = {}
+            for index in indices:
+                for nested_func in retrieve_functions(index):
+                    tmp_mapper = {nested_func: nested_func.indexify(lshift=True)}
+                    index = index.xreplace(tmp_mapper)
+                    expr = expr.xreplace(tmp_mapper)
 
             # Apply substitutions, if necessary
             if dimension_map:

--- a/tests/test_operator.py
+++ b/tests/test_operator.py
@@ -217,21 +217,25 @@ class TestCodeGen(object):
         u5 = Function(name="u5", grid=grid, dtype=np.int32)
 
         Eq1 = Eq(u1, u2[x, u3[x, u4[x, u5[x, u1]]]])
+        Eq2 = Eq(u1, u2[x, u3[x, u4[x, u5[x, u1[x + 1, y + 1]]]]])
 
         op1 = Operator([Eq1])
+        op2 = Operator([Eq2])
 
         op1.apply()
+        op2.apply()
 
-        print(op1.ccode)
-        assert ('u1[x + 1][y + 1] = u2[x][u3[x][u4[x][u5[x]'
-                '[u1[x + 1][y + 1]]]]]') in str(op1.ccode)
+        assert ('u1[x + 1][y + 1] = u2[x + 1][u3[x][u4[x][u5[x]'
+                '[u1[x + 1][y + 1]]]] + 1]') in str(op2.ccode)
+
+        assert str(op2.ccode) == str(op1.ccode)
 
     def test_nested_lowering_and_indexing_rhs_lhs(self):
         """
         Tests that deeply nested (depth > 2) functions used as indices are indexified.
         """
-        x1, x2, x3, x4, x5 = dimensions('x1 x2 x3 x4 x5')
-        y1, y2, y3, y4, y5 = dimensions('y1 y2 y3 y4 y5')
+        x1, x2, x3, x4 = dimensions('x1 x2 x3 x4')
+        y1, y2, y3, y4 = dimensions('y1 y2 y3 y4')
 
         u1 = Function(name="u1", shape=(4, 4), dimensions=(x1, y1), dtype=np.int32)
         u2 = Function(name="u2", shape=(4, 4), dimensions=(x2, y2), dtype=np.int32)
@@ -245,9 +249,6 @@ class TestCodeGen(object):
 
         op1.apply()
         op2.apply()
-
-        print(op1.ccode)
-        print(op2.ccode)
 
         assert str(op1.ccode) == str(op2.ccode)
 

--- a/tests/test_operator.py
+++ b/tests/test_operator.py
@@ -217,16 +217,15 @@ class TestCodeGen(object):
         u5 = Function(name="u5", grid=grid, dtype=np.int32)
 
         Eq1 = Eq(u1, u2[x, u3[x, u4[x, u5[x, u1]]]])
-        Eq2 = Eq(u1, u2[x, u3[x, u4[x, u5[x, u1[x + 1, y + 1]]]]])
+        Eq2 = Eq(u1, u2[x, u3[x, u4[x, u5[x, u1[x, y]]]]])
 
         op1 = Operator([Eq1])
         op2 = Operator([Eq2])
 
         op1.apply()
         op2.apply()
-
-        assert ('u1[x + 1][y + 1] = u2[x + 1][u3[x][u4[x][u5[x]'
-                '[u1[x + 1][y + 1]]]] + 1]') in str(op2.ccode)
+        assert ('u1[x + 1][y + 1] = u2[x + 1][u3[x + 1][u4[x + 1][u5[x + 1]'
+                '[u1[x + 1][y + 1] + 1] + 1] + 1] + 1]') in str(op2.ccode)
 
         assert str(op2.ccode) == str(op1.ccode)
 


### PR DESCRIPTION
This PR adds indexing support for indexing nested (deeply or not) functions that are used for directing a dimension index.
Still WIP. Waiting for discussion and reviews to improve.

- [x] Add more tests
- [x] Add grid tests, alignment with computational domain
- [x] Two dim indirection tests, nesting in more than one dims.
- [x] Remove hacks