### PR TITLE
optimisation of parameter substitution in MPIRegion.arg_values

### DIFF
--- a/devito/mpi/routines.py
+++ b/devito/mpi/routines.py
@@ -1052,6 +1052,16 @@ class MPIMsgEnriched(MPIMsg):
         return {self.name: self.value}
 
 
+def _simple_subs(expr, args):
+    """Used for substituting operator argument values into expressions.  args is
+    expected to contain only string keys, with values that are not themselves
+    expressions which will be substituted into.
+    """
+    return expr.subs(
+        {str(k): args[str(k)] for k in expr.free_symbols if str(k) in args}
+    )
+
+
 class MPIRegion(CompositeObject):
 
     def __init__(self, prefix, key, arguments, owned):
@@ -1108,11 +1118,11 @@ class MPIRegion(CompositeObject):
             for a in self.arguments:
                 if a.is_Dimension:
                     a_m, a_M = mapper[a]
-                    setattr(entry, a.min_name, mapper[a][0].subs(args))
-                    setattr(entry, a.max_name, mapper[a][1].subs(args))
+                    setattr(entry, a.min_name, _simple_subs(a_m, args))
+                    setattr(entry, a.max_name, _simple_subs(a_M, args))
                 else:
                     try:
-                        setattr(entry, a.name, mapper[a][0].subs(args))
+                        setattr(entry, a.name, _simple_subs(mapper[a][0], args))
                     except AttributeError:
                         setattr(entry, a.name, mapper[a][0])
         return values

--- a/devito/operator/profiling.py
+++ b/devito/operator/profiling.py
@@ -15,6 +15,7 @@ from devito.ir.support import IntervalGroup
 from devito.logger import warning
 from devito.mpi import MPI
 from devito.parameters import configuration
+from devito.symbolics import subs_op_args
 from devito.types import CompositeObject
 
 __all__ = ['Timer', 'create_profile']
@@ -182,16 +183,17 @@ class AdvancedProfiler(Profiler):
             time = max(getattr(args[self.name]._obj, name), 10e-7)
 
             # Number of FLOPs performed
-            ops = int(data.ops.subs(args))
+            ops = int(subs_op_args(data.ops, args))
 
             # Number of grid points computed
-            points = int(data.points.subs(args))
+            points = int(subs_op_args(data.points, args))
 
             # Compulsory traffic
-            traffic = float(data.traffic.subs(args)*dtype().itemsize)
+            traffic = float(subs_op_args(data.traffic, args)*dtype().itemsize)
 
             # Runtime itermaps/itershapes
-            itermaps = [OrderedDict([(k, int(v.subs(args))) for k, v in i.items()])
+            itermaps = [OrderedDict([(k, int(subs_op_args(v, args)))
+                                     for k, v in i.items()])
                         for i in data.itermaps]
             itershapes = tuple(tuple(i.values()) for i in itermaps)
 

--- a/devito/symbolics/manipulation.py
+++ b/devito/symbolics/manipulation.py
@@ -12,7 +12,7 @@ from devito.tools import as_tuple, flatten, split
 from devito.types.equation import Eq
 
 __all__ = ['yreplace', 'xreplace_indices', 'pow_to_mul', 'as_symbol', 'indexify',
-           'split_affine', 'uxreplace', 'aligned_indices']
+           'split_affine', 'subs_op_args', 'uxreplace', 'aligned_indices']
 
 
 def yreplace(exprs, make, rule=None, costmodel=lambda e: True, repeat=False, eager=False):
@@ -355,3 +355,13 @@ def aligned_indices(i, j, spacing):
         return int((i - j)/spacing) == (i - j)/spacing
     except TypeError:
         return False
+
+
+def subs_op_args(expr, args):
+    """
+    Substitute Operator argument values into an expression. `args` is
+    expected to be as produced by `Operator.arguments` -- it can only
+    contain string keys, with values that are not themselves expressions
+    which will be substituted into.
+    """
+    return expr.subs({i.name: args[i.name] for i in expr.free_symbols if i.name in args})


### PR DESCRIPTION
I forget why xreplace didn't work here, but it didn't.

This saves more than 40 seconds of python overhead per operator.apply (admittedly on a CPU with fairly ordinary single-thread performance), in MPI mode.

The same code might well be reusable in the performance summary generation, where we've also seen poor performance due to `subs`.