### PR TITLE
Avoid dererencing dangling pointers on GC'd objects

### DIFF
--- a/devito/types/dense.py
+++ b/devito/types/dense.py
@@ -640,6 +640,11 @@ class DiscreteFunction(AbstractFunction, ArgProvider):
         dataobj._obj.hsize = (c_int*(self.ndim*2))(*flatten(self._size_halo))
         dataobj._obj.hofs = (c_int*(self.ndim*2))(*flatten(self._offset_halo))
         dataobj._obj.oofs = (c_int*(self.ndim*2))(*flatten(self._offset_owned))
+
+        # stash a reference to the array on _obj, so we don't let it get freed
+        # while we hold onto _obj
+        dataobj._obj.underlying_array = data
+
         return dataobj
 
     def _C_as_ndarray(self, dataobj):

--- a/devito/types/sparse.py
+++ b/devito/types/sparse.py
@@ -273,7 +273,6 @@ class AbstractSparseFunction(DiscreteFunction, Differentiable):
         """
         raise NotImplementedError
 
-    @memoized_meth
     def _arg_defaults(self, alias=None):
         key = alias or self
         mapper = {self: key}

--- a/devito/types/sparse.py
+++ b/devito/types/sparse.py
@@ -273,6 +273,7 @@ class AbstractSparseFunction(DiscreteFunction, Differentiable):
         """
         raise NotImplementedError
 
+    @memoized_meth
     def _arg_defaults(self, alias=None):
         key = alias or self
         mapper = {self: key}


### PR DESCRIPTION
This patch ensures that python holds a reference to objects that it passes to C for the duration of the call.  It was possible for this to not happen since the ctypes pointers are not sufficient to keep objects alive, but memoization of `arg_defaults`/`arg_values` had been covering up this issue.

Previously we didn't run into this since some of the functions that returned these objects
were memoized, which means they hung onto the objects indefinitely.  Removal of the memoization caused them to become eligible for GC, resulting in segfaults and other fun.