### PR TITLE
fix pow_to_mul to handle float-represented integer powers

### DIFF
--- a/devito/symbolics/manipulation.py
+++ b/devito/symbolics/manipulation.py
@@ -266,12 +266,12 @@ def pow_to_mul(expr):
             # looking for other Pows
             return expr.func(pow_to_mul(base), exp, evaluate=False)
         elif exp > 0:
-            return sympy.Mul(*[base]*exp, evaluate=False)
+            return sympy.Mul(*[base]*int(exp), evaluate=False)
         else:
             # SymPy represents 1/x as Pow(x,-1). Also, it represents
             # 2/x as Mul(2, Pow(x, -1)). So we shouldn't end up here,
             # but just in case SymPy changes its internal conventions...
-            posexpr = sympy.Mul(*[base]*(-exp), evaluate=False)
+            posexpr = sympy.Mul(*[base]*(-int(exp)), evaluate=False)
             return sympy.Pow(posexpr, -1, evaluate=False)
     else:
         return expr.func(*[pow_to_mul(i) for i in expr.args], evaluate=False)

--- a/tests/test_dse.py
+++ b/tests/test_dse.py
@@ -169,7 +169,8 @@ def test_cse(exprs, expected):
     ('1/(fb[x]**2 + 1)', '1/(fb[x]*fb[x] + 1)'),
     ('1/(fa[x] + fb[x])', '1/(fa[x] + fb[x])'),
     ('3*sin(fa[x])**2', '3*(sin(fa[x])*sin(fa[x]))'),
-    ('fa[x]/(fb[x]**2)', 'fa[x]/((fb[x]*fb[x]))')
+    ('fa[x]/(fb[x]**2)', 'fa[x]/((fb[x]*fb[x]))'),
+    ('(fa[x]**0.5)**2', 'fa[x]'),
 ])
 def test_pow_to_mul(expr, expected):
     grid = Grid((4, 5))


### PR DESCRIPTION
Without this, integer powers that are constructed from floats result in the following error:

```
            elif exp > 0:
>               return sympy.Mul(*[base]*exp, evaluate=False)
E               TypeError: can't multiply sequence by non-int of type 'Float'
```