### PR TITLE
MPI overlap+: Fix offset identification

### DIFF
--- a/devito/mpi/halo_scheme.py
+++ b/devito/mpi/halo_scheme.py
@@ -76,11 +76,10 @@ class HaloScheme(object):
         # Track the IterationSpace offsets induced by SubDomains/SubDimensions.
         # These should be honored in the derivation of the `omapper`
         self._honored = {}
-        # SubDimensions are not necessarily included in directloy in
+        # SubDimensions are not necessarily included directly in
         # ispace.dimensions and hence we need to first utilize the `_defines` method
-        dims = set().union(*[d._defines for d in ispace.dimensions])
-        dims.difference_update([d for d in ispace.dimensions if
-                                not d._defines & set(self.dimensions)])
+        dims = set().union(*[d._defines for d in ispace.dimensions
+                             if d._defines & self.dimensions])
         subdims = [d for d in dims if d.is_Sub and not d.local]
         for i in subdims:
             ltk, _ = i.thickness.left

--- a/devito/mpi/halo_scheme.py
+++ b/devito/mpi/halo_scheme.py
@@ -76,13 +76,16 @@ class HaloScheme(object):
         # Track the IterationSpace offsets induced by SubDomains/SubDimensions.
         # These should be honored in the derivation of the `omapper`
         self._honored = {}
-        for i in ispace.intervals:
-            if not i.dim._defines & set(self.dimensions):
-                continue
-            elif i.dim.is_Sub and not i.dim.local:
-                ltk, _ = i.dim.thickness.left
-                rtk, _ = i.dim.thickness.right
-                self._honored[i.dim.root] = frozenset([(ltk, rtk)])
+        # SubDimensions are not necessarily included in directloy in
+        # ispace.dimensions and hence we need to first utilize the `_defines` method
+        dims = set().union(*[d._defines for d in ispace.dimensions])
+        dims.difference_update([d for d in ispace.dimensions if
+                                not d._defines & set(self.dimensions)])
+        subdims = [d for d in dims if d.is_Sub and not d.local]
+        for i in subdims:
+            ltk, _ = i.thickness.left
+            rtk, _ = i.thickness.right
+            self._honored[i.root] = frozenset([(ltk, rtk)])
         self._honored = frozendict(self._honored)
 
     def __repr__(self):

--- a/tests/test_subdomains.py
+++ b/tests/test_subdomains.py
@@ -288,7 +288,7 @@ class TestSubdomains(object):
 
         assert((np.array(f.data[:]+g.data[:]) == expected).all())
 
-    @pytest.mark.parallel(mode=4)
+    @pytest.mark.parallel(mode=[(4, 'basic'), (4, 'overlap')])
     def test_subdomainset_mpi(self):
 
         n_domains = 5


### PR DESCRIPTION
Fix for `SubDim`'s thickness not correctly being picked up with `DEVITO_MPI=overlap` or 'greater' when spatial blocking is involved. 

Fix for issue #1309. Suitable 3D test added.