### PR TITLE
enforce user provided x0

### DIFF
--- a/devito/finite_differences/derivative.py
+++ b/devito/finite_differences/derivative.py
@@ -269,7 +269,8 @@ class Derivative(sympy.Derivative, Differentiable):
         setup where one could have Eq(u(x + h_x/2), v(x).dx)) in which case v(x).dx
         has to be computed at x=x + h_x/2.
         """
-        x0 = dict(func.indices_ref._getters)
+        # If an x0 already exists do not overwrite it
+        x0 = self.x0 or dict(func.indices_ref._getters)
         if self.expr.is_Add:
             # Derivatives are linear and  the derivative of an Add can be treated as an
             # Add of derivatives which makes (u(x + h_x/2) + v(x)).dx` easier to handle

--- a/devito/types/basic.py
+++ b/devito/types/basic.py
@@ -950,7 +950,7 @@ class AbstractFunction(sympy.Function, Basic, Cached, Pickable, Evaluable):
         # Indices after substitutions
         indices = [(a - o + f).xreplace(s) for a, o, f, s in
                    zip(self.args, self.origin, shift, subs)]
-
+        indices = [i.xreplace({k: int(k) for k in i.atoms(sympy.Float)}) for i in indices]
         return self.indexed[indices]
 
     def __getitem__(self, index):

--- a/tests/test_derivatives.py
+++ b/tests/test_derivatives.py
@@ -329,6 +329,16 @@ class TestFD(object):
         # half shifted compare to explicit coeffs (Forneberg)
         assert str(u.dx(x0=x - .5 * x.spacing).evaluate) == expected
 
+    def test_new_x0_eval_at(self):
+        """
+        Make sure that explicitly set x0 does not get overwritten by eval_at.
+        """
+        grid = Grid((10,))
+        x = grid.dimensions[0]
+        u = Function(name="u", grid=grid, space_order=2)
+        v = Function(name="v", grid=grid, space_order=2)
+        assert u.dx(x0=x - x.spacing/2)._eval_at(v).x0 == {x: x - x.spacing/2}
+
     def test_fd_new_lo(self):
         grid = Grid((10,))
         x = grid.dimensions[0]


### PR DESCRIPTION
Small fix that makes sure `eval_at` does not overwritte user provided x0 (via `u.dx(x0=....)`)