### PR TITLE
Dummy PR to demonstrate that we are relying on memoization for correctness

### DIFF
--- a/devito/types/sparse.py
+++ b/devito/types/sparse.py
@@ -273,7 +273,6 @@ class AbstractSparseFunction(DiscreteFunction, Differentiable):
         """
         raise NotImplementedError
 
-    @memoized_meth
     def _arg_defaults(self, alias=None):
         key = alias or self
         mapper = {self: key}


### PR DESCRIPTION
Not a real PR - I expect will fail CI.

Filing to trigger a CI run and show crashes/incorrect results when we remove memoization from AbstractSparseFunction._arg_defaults

Relates to #1316