### PR TITLE
tests: Fix args and test viscoacoustic

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -57,6 +57,9 @@ jobs:
         python examples/seismic/acoustic/acoustic_example.py --fs
         python examples/seismic/inversion/fwi.py
         python examples/seismic/self_adjoint/example_iso.py
+        python examples/seismic/viscoacoustic/viscoacoustic_example.py
+        python examples/seismic/viscoacoustic/viscoacoustic_example.py -k ren
+        python examples/seismic/viscoacoustic/viscoacoustic_example.py -k deng_mcmechan
 
     - name: Seismic tti examples
       shell: bash -l {0}

--- a/examples/seismic/acoustic/acoustic_example.py
+++ b/examples/seismic/acoustic/acoustic_example.py
@@ -82,6 +82,9 @@ if __name__ == "__main__":
     parser = seismic_args(description)
     parser.add_argument('--fs', dest='fs', default=False, action='store_true',
                         help="Whether or not to use a freesurface")
+    parser.add_argument("-k", dest="kernel", default='OT2',
+                        choices=['OT2', 'OT4'],
+                        help="Choice of finite-difference kernel")
     args = parser.parse_args()
 
     # 3D preset parameters

--- a/examples/seismic/acoustic/acoustic_example.py
+++ b/examples/seismic/acoustic/acoustic_example.py
@@ -64,10 +64,11 @@ def run(shape=(50, 50, 50), spacing=(20.0, 20.0, 20.0), tn=1000.0,
 
 
 @pytest.mark.parametrize('ndim', [1, 2, 3])
-def test_isoacoustic_stability(ndim):
+@pytest.mark.parametrize('k', ['OT2', 'OT4'])
+def test_isoacoustic_stability(ndim, k):
     shape = tuple([11]*ndim)
     spacing = tuple([20]*ndim)
-    _, _, _, [rec, _] = run(shape=shape, spacing=spacing, tn=20000.0, nbl=0)
+    _, _, _, [rec, _] = run(shape=shape, spacing=spacing, tn=20000.0, nbl=0, kernel=k)
     assert np.isfinite(norm(rec))
 
 

--- a/examples/seismic/tti/tti_example.py
+++ b/examples/seismic/tti/tti_example.py
@@ -57,10 +57,12 @@ if __name__ == "__main__":
     parser = seismic_args(description)
     parser.add_argument('--noazimuth', dest='azi', default=False, action='store_true',
                         help="Whether or not to use an azimuth angle")
+    parser.add_argument("-k", dest="kernel", default='centered',
+                        choices=['centered', 'staggered'],
+                        help="Choice of finite-difference kernel")
     args = parser.parse_args()
 
     # Switch to TTI kernel if input is acoustic kernel
-    kernel = 'centered' if args.kernel in ['OT2', 'OT4'] else args.kernel
     preset = 'layers-tti-noazimuth' if args.azi else 'layers-tti'
 
     # Preset parameters
@@ -71,4 +73,4 @@ if __name__ == "__main__":
 
     run(shape=shape, spacing=spacing, nbl=args.nbl, tn=tn,
         space_order=args.space_order, autotune=args.autotune,
-        opt=args.opt, kernel=kernel, preset=preset, full_run=args.full)
+        opt=args.opt, kernel=args.kernel, preset=preset, full_run=args.full)

--- a/examples/seismic/tti/tti_example.py
+++ b/examples/seismic/tti/tti_example.py
@@ -1,3 +1,9 @@
+import numpy as np
+import pytest
+
+from devito import norm
+from devito.logger import info
+
 from examples.seismic import demo_model, setup_geometry, seismic_args
 from examples.seismic.tti import AnisotropicWaveSolver
 
@@ -19,14 +25,31 @@ def run(shape=(50, 50, 50), spacing=(20.0, 20.0, 20.0), tn=250.0,
         autotune=False, time_order=2, space_order=4, nbl=10,
         kernel='centered', full_run=False, **kwargs):
 
-    solver = tti_setup(shape, spacing, tn, space_order, nbl, **kwargs)
+    solver = tti_setup(shape=shape, spacing=spacing, tn=tn, space_order=space_order,
+                       nbl=nbl, **kwargs)
+    info("Applying Forward")
+    # Whether or not we save the whole time history. We only need the full wavefield
+    # with 'save=True' if we compute the gradient without checkpointing, if we use
+    # checkpointing, PyRevolve will take care of the time history
 
     rec, u, v, summary = solver.forward(autotune=autotune, kernel=kernel)
 
     if not full_run:
         return summary.gflopss, summary.oi, summary.timings, [rec, u, v]
 
-    solver.adjoint(rec, autotune=autotune, kernel=kernel)
+    info("Applying Adjoint")
+    solver.adjoint(rec, autotune=autotune)
+    return summary.gflopss, summary.oi, summary.timings, [rec, u, v]
+
+
+@pytest.mark.parametrize('kernel', ['centered', 'staggered'])
+@pytest.mark.parametrize('ndim', [2, 3])
+def test_tti_stability(kernel, ndim):
+    shape = tuple([11]*ndim)
+    spacing = tuple([20]*ndim)
+    _, _, _, [rec, _, _] = run(shape=shape, spacing=spacing, kernel=kernel,
+                               tn=16000.0, nbl=0)
+    assert np.isfinite(norm(rec))
 
 
 if __name__ == "__main__":

--- a/examples/seismic/utils.py
+++ b/examples/seismic/utils.py
@@ -192,7 +192,8 @@ def seismic_args(description):
     parser.add_argument("--nbl", default=40,
                         type=int, help="Number of boundary layers around the domain")
     parser.add_argument("-k", dest="kernel", default='OT2',
-                        choices=['OT2', 'OT4', 'centered', 'staggered'],
+                        choices=['OT2', 'OT4', 'centered', 'staggered',
+                                 'blanch_symes', 'ren', 'deng_mcmechan'],
                         help="Choice of finite-difference kernel")
     parser.add_argument("--constant", default=False, action='store_true',
                         help="Constant velocity model, default is a two layer model")

--- a/examples/seismic/utils.py
+++ b/examples/seismic/utils.py
@@ -192,8 +192,7 @@ def seismic_args(description):
     parser.add_argument("--nbl", default=40,
                         type=int, help="Number of boundary layers around the domain")
     parser.add_argument("-k", dest="kernel", default='OT2',
-                        choices=['OT2', 'OT4', 'centered', 'staggered',
-                                 'blanch_symes', 'ren', 'deng_mcmechan'],
+                        choices=['OT2', 'OT4', 'centered', 'staggered'],
                         help="Choice of finite-difference kernel")
     parser.add_argument("--constant", default=False, action='store_true',
                         help="Constant velocity model, default is a two layer model")

--- a/examples/seismic/utils.py
+++ b/examples/seismic/utils.py
@@ -191,9 +191,6 @@ def seismic_args(description):
                         type=int, help="Space order of the simulation")
     parser.add_argument("--nbl", default=40,
                         type=int, help="Number of boundary layers around the domain")
-    parser.add_argument("-k", dest="kernel", default='OT2',
-                        choices=['OT2', 'OT4', 'centered', 'staggered'],
-                        help="Choice of finite-difference kernel")
     parser.add_argument("--constant", default=False, action='store_true',
                         help="Constant velocity model, default is a two layer model")
     parser.add_argument("--checkpointing", default=False, action='store_true',

--- a/examples/seismic/viscoacoustic/viscoacoustic_example.py
+++ b/examples/seismic/viscoacoustic/viscoacoustic_example.py
@@ -1,4 +1,6 @@
 import numpy as np
+import pytest
+
 from devito.logger import info
 from devito import norm
 from examples.seismic.viscoacoustic import ViscoacousticWaveSolver
@@ -39,6 +41,14 @@ def run(shape=(50, 50), spacing=(20.0, 20.0), tn=1000.0,
 def test_viscoacoustic():
     _, _, _, [rec] = run()
     assert np.isclose(norm(rec), 18.7749, atol=1e-3, rtol=0)
+
+
+@pytest.mark.parametrize('ndim', [1, 2, 3])
+def test_viscoacoustic_stability(ndim):
+    shape = tuple([11]*ndim)
+    spacing = tuple([20]*ndim)
+    _, _, _, [rec] = run(shape=shape, spacing=spacing, tn=20000.0, nbl=0)
+    assert np.isfinite(norm(rec))
 
 
 if __name__ == "__main__":

--- a/examples/seismic/viscoacoustic/viscoacoustic_example.py
+++ b/examples/seismic/viscoacoustic/viscoacoustic_example.py
@@ -53,8 +53,11 @@ def test_viscoacoustic_stability(ndim):
 
 if __name__ == "__main__":
     description = ("Example script for a set of viscoacoustic operators.")
-    args = seismic_args(description).parse_args()
-
+    parser = seismic_args(description)
+    parser.add_argument("-k", dest="kernel", default='blanch_symes',
+                        choices=['blanch_symes', 'ren', 'deng_mcmechan'],
+                        help="Choice of finite-difference kernel")
+    args = parser.parse_args()
     # Preset parameters
     ndim = args.ndim
     shape = args.shape[:args.ndim]

--- a/examples/seismic/viscoacoustic/viscoacoustic_example.py
+++ b/examples/seismic/viscoacoustic/viscoacoustic_example.py
@@ -44,10 +44,11 @@ def test_viscoacoustic():
 
 
 @pytest.mark.parametrize('ndim', [1, 2, 3])
-def test_viscoacoustic_stability(ndim):
+@pytest.mark.parametrize('kernel', ['blanch_symes', 'ren', 'deng_mcmechan'])
+def test_viscoacoustic_stability(ndim, kernel):
     shape = tuple([11]*ndim)
     spacing = tuple([20]*ndim)
-    _, _, _, [rec] = run(shape=shape, spacing=spacing, tn=20000.0, nbl=0)
+    _, _, _, [rec] = run(shape=shape, spacing=spacing, tn=20000.0, nbl=0, kernel=kernel)
     assert np.isfinite(norm(rec))
 
 

--- a/examples/seismic/viscoacoustic/wavesolver.py
+++ b/examples/seismic/viscoacoustic/wavesolver.py
@@ -1,4 +1,4 @@
-from devito import VectorTimeFunction, TimeFunction, NODE
+from devito import VectorTimeFunction, TimeFunction, NODE, warning
 from devito.tools import memoized_meth
 from examples.seismic import Receiver
 from examples.seismic.viscoacoustic.operators import ForwardOperator
@@ -31,6 +31,10 @@ class ViscoacousticWaveSolver(object):
         self.geometry = geometry
 
         self.space_order = space_order
+        self.dt = self.model.critical_dt
+        if kernel not in {'blanch_symes', 'ren', 'deng_mcmechan'}:
+            kernel = 'blanch_symes'
+            warning("Using default kernel `%s`" % str(kernel))
         self.kernel = kernel
         # Cache compiler options
         self._kwargs = kwargs

--- a/examples/seismic/viscoacoustic/wavesolver.py
+++ b/examples/seismic/viscoacoustic/wavesolver.py
@@ -1,4 +1,4 @@
-from devito import VectorTimeFunction, TimeFunction, NODE, warning
+from devito import VectorTimeFunction, TimeFunction, NODE
 from devito.tools import memoized_meth
 from examples.seismic import Receiver
 from examples.seismic.viscoacoustic.operators import ForwardOperator
@@ -31,10 +31,6 @@ class ViscoacousticWaveSolver(object):
         self.geometry = geometry
 
         self.space_order = space_order
-        self.dt = self.model.critical_dt
-        if kernel not in {'blanch_symes', 'ren', 'deng_mcmechan'}:
-            kernel = 'blanch_symes'
-            warning("Using default kernel `%s`" % str(kernel))
         self.kernel = kernel
         # Cache compiler options
         self._kwargs = kwargs


### PR DESCRIPTION
Viscoacoustic examples is currently failing by default as its kernels are not in the usual ones. Adding explicit tests for them and restoring its working status.