### PR TITLE
Prevent sympy cache blowup

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -64,6 +64,7 @@ jobs:
         python examples/seismic/tti/tti_example.py -a basic
         python examples/seismic/tti/tti_example.py -a basic --noazimuth
         python examples/seismic/tti/tti_example.py -k staggered
+        python examples/seismic/tti/tti_example.py --full -so 12
 
     - name: Seismic elastic examples
       shell: bash -l {0}

--- a/devito/types/basic.py
+++ b/devito/types/basic.py
@@ -502,7 +502,6 @@ class AbstractTensor(sympy.ImmutableDenseMatrix, Basic, Cached, Pickable, Evalua
             return newobj
 
         name = kwargs.get('name')
-        # Number of dimensions
         indices, _ = cls.__indices_setup__(**kwargs)
 
         # Create new, unique type instance from cls and the symbol name
@@ -519,6 +518,7 @@ class AbstractTensor(sympy.ImmutableDenseMatrix, Basic, Cached, Pickable, Evalua
 
         # Store new instance in symbol cache
         Cached.__init__(newobj, newcls)
+
         return newobj
 
     __hash__ = Cached.__hash__
@@ -627,7 +627,7 @@ class AbstractFunction(sympy.Function, Basic, Cached, Pickable, Evaluable):
         if obj is not None:
             newobj = sympy.Function.__new__(cls, *args, **options)
             newobj.__init_cached__(cls)
-            Cached.__init__(newobj, key, alias=cls)
+            Cached.__init__(newobj, key)
             return newobj
 
         # Not in cache. Create a new Function via sympy.Function
@@ -653,8 +653,10 @@ class AbstractFunction(sympy.Function, Basic, Cached, Pickable, Evaluable):
         # object will point to `newobj`, the "actual Function".
         newobj.function = newobj
 
-        # Cache with indices as well to avoid recreating the base function
-        Cached.__init__(newobj, (newcls, indices), alias=newcls)
+        # Store new instance in symbol cache
+        key = (newcls, indices)
+        Cached.__init__(newobj, key, newcls)
+
         return newobj
 
     def __init__(self, *args, **kwargs):

--- a/devito/types/basic.py
+++ b/devito/types/basic.py
@@ -630,6 +630,9 @@ class AbstractFunction(sympy.Function, Basic, Cached, Pickable, Evaluable):
             Cached.__init__(newobj, key)
             return newobj
 
+        # Preprocess arguments
+        args, kwargs = cls.__args_setup__(*args, **kwargs)
+
         # Not in cache. Create a new Function via sympy.Function
         name = kwargs.get('name')
         dimensions, indices = cls.__indices_setup__(**kwargs)
@@ -670,6 +673,17 @@ class AbstractFunction(sympy.Function, Basic, Cached, Pickable, Evaluable):
         self._padding = self.__padding_setup__(**kwargs)
 
     __hash__ = Cached.__hash__
+
+    @classmethod
+    def __args_setup__(cls, *args, **kwargs):
+        """
+        Preprocess *args and **kwargs before object initialization.
+
+        Notes
+        -----
+        This stub is invoked only if a look up in the cache fails.
+        """
+        return args, kwargs
 
     @classmethod
     def __indices_setup__(cls, **kwargs):

--- a/devito/types/caching.py
+++ b/devito/types/caching.py
@@ -26,17 +26,6 @@ class Cached(object):
     """
 
     @classmethod
-    def _cache_key(cls, *args, **kwargs):
-        """
-        A unique, deterministic cache key from the input arguments.
-
-        Notes
-        -----
-        To be implemented by subclasses.
-        """
-        raise NotImplementedError
-
-    @classmethod
     def _cache_get(cls, key):
         """
         Retrieve the object corresponding to a given key. If the key is not in
@@ -59,7 +48,7 @@ class Cached(object):
         else:
             return None
 
-    def __init__(self, key):
+    def __init__(self, key, alias=None):
         """
         Store `self` in the symbol cache.
 
@@ -68,11 +57,14 @@ class Cached(object):
         key : object
             The cache key. It must be hashable.
         """
-        # Precompute hash. This uniquely depends on the cache key
-        self._cache_key_hash = hash(key)
+        # Precompute hash. This uniquely depends on the cache key and is not modified
+        # by an alias
+        self._cache_key_hash = hash(alias or key)
 
         # Add ourselves to the symbol cache
         _SymbolCache[key] = AugmentedWeakRef(self, self._cache_meta())
+        if alias and alias not in _SymbolCache:
+            _SymbolCache[alias] = AugmentedWeakRef(self, self._cache_meta())
 
     def __init_cached__(self, key):
         """

--- a/devito/types/caching.py
+++ b/devito/types/caching.py
@@ -26,15 +26,33 @@ class Cached(object):
     """
 
     @classmethod
+    def _cache_key(cls, *args, **kwargs):
+        """
+        A unique, deterministic key from the input arguments.
+
+        Notes
+        -----
+        To be implemented by subclasses.
+
+        Returns
+        -------
+        The cache key. It must be hashable.
+        """
+        raise NotImplementedError("Subclass must implement _cache_key")
+
+    @classmethod
     def _cache_get(cls, key):
         """
-        Retrieve the object corresponding to a given key. If the key is not in
-        the symbol cache or if the mapped object is not alive anymore, returns None.
+        Look up the cache for a given key.
 
         Parameters
         ----------
         key : object
             The cache key. It must be hashable.
+
+        Returns
+        -------
+        The object if in the cache and alive, otherwise None.
         """
         if key in _SymbolCache:
             # There is indeed an object mapped to `key`. But is it still alive?

--- a/devito/types/dense.py
+++ b/devito/types/dense.py
@@ -1004,9 +1004,9 @@ class Function(DiscreteFunction):
             for s in as_tuple(staggered):
                 c, s = s.as_coeff_Mul()
                 mapper.update({s: s + c * s.spacing/2})
+            staggered_indices = mapper.values()
 
-            staggered_indices = tuple(mapper.values())
-        return tuple(dimensions), staggered_indices
+        return tuple(dimensions), tuple(staggered_indices)
 
     @property
     def is_Staggered(self):

--- a/devito/types/sparse.py
+++ b/devito/types/sparse.py
@@ -9,7 +9,8 @@ from devito.finite_differences import generate_fd_shortcuts
 from devito.mpi import MPI, SparseDistributor
 from devito.operations import LinearInterpolator, PrecomputedInterpolator
 from devito.symbolics import INT, cast_mapper, indexify, retrieve_function_carriers
-from devito.tools import ReducerMap, flatten, prod, filter_ordered, memoized_meth
+from devito.tools import (ReducerMap, as_tuple, flatten, prod, filter_ordered,
+                          memoized_meth)
 from devito.types.dense import DiscreteFunction, Function, SubFunction
 from devito.types.dimension import Dimension, ConditionalDimension
 from devito.types.basic import Symbol, Scalar
@@ -44,12 +45,10 @@ class AbstractSparseFunction(DiscreteFunction):
 
     @classmethod
     def __indices_setup__(cls, **kwargs):
-        dimensions = kwargs.get('dimensions')
-        if dimensions is not None:
-            return dimensions, dimensions
-        else:
+        dimensions = as_tuple(kwargs.get('dimensions'))
+        if not dimensions:
             dimensions = (Dimension(name='p_%s' % kwargs["name"]),)
-            return dimensions, dimensions
+        return dimensions, dimensions
 
     @classmethod
     def __shape_setup__(cls, **kwargs):
@@ -360,12 +359,11 @@ class AbstractSparseTimeFunction(AbstractSparseFunction):
 
     @classmethod
     def __indices_setup__(cls, **kwargs):
-        dimensions = kwargs.get('dimensions')
-        if dimensions is not None:
-            return dimensions, dimensions
-        else:
-            dims = (kwargs['grid'].time_dim, Dimension(name='p_%s' % kwargs["name"]))
-            return dims, dims
+        dimensions = as_tuple(kwargs.get('dimensions'))
+        if not dimensions:
+            dimensions = (kwargs['grid'].time_dim,
+                          Dimension(name='p_%s' % kwargs["name"]))
+        return dimensions, dimensions
 
     @classmethod
     def __shape_setup__(cls, **kwargs):

--- a/examples/seismic/plotting.py
+++ b/examples/seismic/plotting.py
@@ -47,7 +47,7 @@ def plot_perturbation(model, model1, colorbar=True):
     plt.show()
 
 
-def plot_velocity(model, source=None, receiver=None, colorbar=True):
+def plot_velocity(model, source=None, receiver=None, colorbar=True, cmap="jet"):
     """
     Plot a two-dimensional velocity field from a seismic `Model`
     object. Optionally also includes point markers for sources and receivers.
@@ -69,7 +69,7 @@ def plot_velocity(model, source=None, receiver=None, colorbar=True):
 
     slices = tuple(slice(model.nbl, -model.nbl) for _ in range(2))
     field = (getattr(model, 'vp', None) or getattr(model, 'lam')).data[slices]
-    plot = plt.imshow(np.transpose(field), animated=True, cmap=cm.jet,
+    plot = plt.imshow(np.transpose(field), animated=True, cmap=cmap,
                       vmin=np.min(field), vmax=np.max(field),
                       extent=extent)
     plt.xlabel('X position (km)')

--- a/examples/seismic/source.py
+++ b/examples/seismic/source.py
@@ -107,12 +107,11 @@ class PointSource(SparseTimeFunction):
     def __new__(cls, *args, **kwargs):
         options = kwargs.get('options', {})
 
-        key = cls._cache_key(*args, **kwargs)
-        obj = cls._cache_get(key)
+        obj = cls._cache_get(cls)
 
         if obj is not None:
             newobj = sympy.Function.__new__(cls, *args, **options)
-            newobj.__init_cached__(key)
+            newobj.__init_cached__(cls)
             return newobj
 
         # Not in cache. Create a new PointSouce via devito.SparseTimeFunction
@@ -220,12 +219,11 @@ class WaveletSource(PointSource):
     def __new__(cls, *args, **kwargs):
         options = kwargs.get('options', {})
 
-        key = cls._cache_key(*args, **kwargs)
-        obj = cls._cache_get(key)
+        obj = cls._cache_get(cls)
 
         if obj is not None:
             newobj = sympy.Function.__new__(cls, *args, **options)
-            newobj.__init_cached__(key)
+            newobj.__init_cached__(cls)
             return newobj
 
         # Not in cache. Create a new WaveletSouce via PointSource

--- a/examples/seismic/source.py
+++ b/examples/seismic/source.py
@@ -1,5 +1,3 @@
-import sympy
-
 from scipy import interpolate
 from cached_property import cached_property
 import numpy as np
@@ -8,7 +6,7 @@ try:
 except:
     plt = None
 
-from devito.types import Dimension, SparseTimeFunction
+from devito.types import SparseTimeFunction
 
 __all__ = ['PointSource', 'Receiver', 'Shot', 'WaveletSource',
            'RickerSource', 'GaborSource', 'DGaussSource', 'TimeAxis']
@@ -104,48 +102,32 @@ class PointSource(SparseTimeFunction):
         Represents the number of points in this source.
     """
 
-    def __new__(cls, *args, **kwargs):
-        options = kwargs.get('options', {})
+    @classmethod
+    def __args_setup__(cls, *args, **kwargs):
+        kwargs['nt'] = kwargs['time_range'].num
 
-        key = cls._cache_key(*args, **kwargs)
-        obj = cls._cache_get(key)
-
-        if obj is not None:
-            newobj = sympy.Function.__new__(cls, *args, **options)
-            newobj.__init_cached__(key)
-            return newobj
-
-        # Not in cache. Create a new PointSouce via devito.SparseTimeFunction
-
-        name = kwargs.pop('name')
-        grid = kwargs.pop('grid')
-        time_range = kwargs.pop('time_range')
-        time_order = kwargs.pop('time_order', 2)
-        p_dim = kwargs.pop('dimension', Dimension(name='p_%s' % name))
-
-        coordinates = kwargs.pop('coordinates', kwargs.pop('coordinates_data', None))
         # Either `npoint` or `coordinates` must be provided
-        npoint = kwargs.pop('npoint', None)
+        npoint = kwargs.get('npoint')
         if npoint is None:
+            coordinates = kwargs.get('coordinates', kwargs.get('coordinates_data'))
             if coordinates is None:
                 raise TypeError("Need either `npoint` or `coordinates`")
-            npoint = coordinates.shape[0]
+            kwargs['npoint'] = coordinates.shape[0]
 
-        # Create the underlying SparseTimeFunction object
-        obj = SparseTimeFunction.__new__(cls, name=name, grid=grid,
-                                         dimensions=(grid.time_dim, p_dim),
-                                         npoint=npoint, nt=time_range.num,
-                                         time_order=time_order,
-                                         coordinates=coordinates, **kwargs)
+        return args, kwargs
 
-        obj._time_range = time_range._rebuild()
+    def __init_finalize__(self, *args, **kwargs):
+        time_range = kwargs.pop('time_range')
+        data = kwargs.pop('data', None)
+
+        kwargs.setdefault('time_order', 2)
+        super(PointSource, self).__init_finalize__(*args, **kwargs)
+
+        self._time_range = time_range._rebuild()
 
         # If provided, copy initial data into the allocated buffer
-        data = kwargs.get('data')
         if data is not None:
-            obj.data[:] = data
-
-        return obj
+            self.data[:] = data
 
     @cached_property
     def time_values(self):
@@ -197,6 +179,7 @@ Shot = PointSource
 
 
 class WaveletSource(PointSource):
+
     """
     Abstract base class for symbolic objects that encapsulate a set of
     sources with a pre-defined source signal wavelet.
@@ -217,38 +200,25 @@ class WaveletSource(PointSource):
         Firing time (defaults to 1 / f0)
     """
 
-    def __new__(cls, *args, **kwargs):
-        options = kwargs.get('options', {})
+    @classmethod
+    def __args_setup__(cls, *args, **kwargs):
+        kwargs.setdefault('npoint', 1)
 
-        key = cls._cache_key(*args, **kwargs)
-        obj = cls._cache_get(key)
+        return super(WaveletSource, cls).__args_setup__(*args, **kwargs)
 
-        if obj is not None:
-            newobj = sympy.Function.__new__(cls, *args, **options)
-            newobj.__init_cached__(key)
-            return newobj
+    def __init_finalize__(self, *args, **kwargs):
+        super(WaveletSource, self).__init_finalize__(*args, **kwargs)
 
-        # Not in cache. Create a new WaveletSouce via PointSource
-        npoint = kwargs.pop('npoint', 1)
-        obj = PointSource.__new__(cls, npoint=npoint, **kwargs)
-        obj.f0 = kwargs.get('f0')
-        obj.a = kwargs.get('a')
-        obj.t0 = kwargs.get('t0')
-        for p in range(npoint):
-            obj.data[:, p] = obj.wavelet
+        self.f0 = kwargs.get('f0')
+        self.a = kwargs.get('a')
+        self.t0 = kwargs.get('t0')
+        for p in range(kwargs['npoint']):
+            self.data[:, p] = self.wavelet
 
-        return obj
-
-    def wavelet(self, f0, t):
+    @property
+    def wavelet(self):
         """
-        Returns a wavelet with a peak frequency f0 at time t.
-
-        Parameters
-        ----------
-        f0 : float
-            Peak frequency in kHz.
-        t : TimeAxis
-            Discretized values of time in ms.
+        Return a wavelet with a peak frequency ``f0`` at time ``t0``.
         """
         raise NotImplementedError('Wavelet not defined')
 
@@ -262,8 +232,6 @@ class WaveletSource(PointSource):
             Index of the source point for which to plot wavelet.
         wavelet : ndarray or callable
             Prescribed wavelet instead of one from this symbol.
-        time : TimeAxis
-            Prescribed time instead of time from this symbol.
         """
         wavelet = wavelet or self.data[:, idx]
         plt.figure()
@@ -274,10 +242,11 @@ class WaveletSource(PointSource):
         plt.show()
 
     # Pickling support
-    _pickle_kwargs = PointSource._pickle_kwargs + ['f0']
+    _pickle_kwargs = PointSource._pickle_kwargs + ['f0', 'a', 'f0']
 
 
 class RickerSource(WaveletSource):
+
     """
     Symbolic object that encapsulate a set of sources with a
     pre-defined Ricker wavelet:
@@ -302,16 +271,6 @@ class RickerSource(WaveletSource):
 
     @property
     def wavelet(self):
-        """
-        Returns a Ricker wavelet with a peak frequency f0 at time t.
-
-        Parameters
-        ----------
-        f0 : float
-            Peak frequency in kHz.
-        t : TimeAxis
-            Discretized values of time in ms.
-        """
         t0 = self.t0 or 1 / self.f0
         a = self.a or 1
         r = (np.pi * self.f0 * (self.time_values - t0))
@@ -319,6 +278,7 @@ class RickerSource(WaveletSource):
 
 
 class GaborSource(WaveletSource):
+
     """
     Symbolic object that encapsulate a set of sources with a
     pre-defined Gabor wavelet:
@@ -343,16 +303,6 @@ class GaborSource(WaveletSource):
 
     @property
     def wavelet(self):
-        """
-        Returns a Gabor wavelet with a peak frequency f0 at time t.
-
-        Parameters
-        ----------
-        f0 : float
-            Peak frequency in kHz.
-        t : TimeAxis
-            Discretized values of time in ms.
-        """
         agauss = 0.5 * self.f0
         tcut = self.t0 or 1.5 / agauss
         s = (self.time_values - tcut) * agauss
@@ -361,9 +311,10 @@ class GaborSource(WaveletSource):
 
 
 class DGaussSource(WaveletSource):
+
     """
     Symbolic object that encapsulate a set of sources with a
-    pre-defined 1st derivative wavelet of a Gaussian Source:
+    pre-defined 1st derivative wavelet of a Gaussian Source.
 
     Notes
     -----
@@ -388,24 +339,12 @@ class DGaussSource(WaveletSource):
         Discretized values of time in ms.
 
     Returns
-    ----------
-    The 1st order derivative of the Gaussian wavelet
+    -------
+    The 1st order derivative of the Gaussian wavelet.
     """
 
     @property
     def wavelet(self):
-        """
-        Returns the 1st derivative of a Gaussian wavelet.
-
-        Parameters
-        ----------
-        f0 : float
-            Peak frequency in kHz.
-        t : TimeAxis
-            Discretized values of time in ms.
-        a : float
-            Maximum amplitude.
-        """
         t0 = self.t0 or 1 / self.f0
         a = self.a or 1
         time = (self.time_values - t0)

--- a/examples/seismic/source.py
+++ b/examples/seismic/source.py
@@ -107,11 +107,12 @@ class PointSource(SparseTimeFunction):
     def __new__(cls, *args, **kwargs):
         options = kwargs.get('options', {})
 
-        obj = cls._cache_get(cls)
+        key = cls._cache_key(*args, **kwargs)
+        obj = cls._cache_get(key)
 
         if obj is not None:
             newobj = sympy.Function.__new__(cls, *args, **options)
-            newobj.__init_cached__(cls)
+            newobj.__init_cached__(key)
             return newobj
 
         # Not in cache. Create a new PointSouce via devito.SparseTimeFunction
@@ -219,11 +220,12 @@ class WaveletSource(PointSource):
     def __new__(cls, *args, **kwargs):
         options = kwargs.get('options', {})
 
-        obj = cls._cache_get(cls)
+        key = cls._cache_key(*args, **kwargs)
+        obj = cls._cache_get(key)
 
         if obj is not None:
             newobj = sympy.Function.__new__(cls, *args, **options)
-            newobj.__init_cached__(cls)
+            newobj.__init_cached__(key)
             return newobj
 
         # Not in cache. Create a new WaveletSouce via PointSource

--- a/examples/seismic/tti/operators.py
+++ b/examples/seismic/tti/operators.py
@@ -73,7 +73,6 @@ def Gzz_centered(model, field, costheta, sintheta, cosphi, sinphi, space_order):
     Rotated second order derivative w.r.t. z.
     """
     order1 = space_order // 2
-    x, y, z = model.space_dimensions
     Gz = -(sintheta * cosphi * field.dx(fd_order=order1) +
            sintheta * sinphi * field.dy(fd_order=order1) +
            costheta * field.dz(fd_order=order1))
@@ -107,7 +106,6 @@ def Gzz_centered_2d(model, field, costheta, sintheta, space_order):
     Rotated second order derivative w.r.t. z.
     """
     order1 = space_order // 2
-    x, y = model.space_dimensions[:2]
     Gz = -(sintheta * field.dx(fd_order=order1) +
            costheta * field.dy(fd_order=order1))
     Gzz = ((Gz * sintheta).dx(fd_order=order1).T +

--- a/examples/seismic/tti/tti_example.py
+++ b/examples/seismic/tti/tti_example.py
@@ -17,13 +17,16 @@ def tti_setup(shape=(50, 50, 50), spacing=(20.0, 20.0, 20.0), tn=250.0,
 
 def run(shape=(50, 50, 50), spacing=(20.0, 20.0, 20.0), tn=250.0,
         autotune=False, time_order=2, space_order=4, nbl=10,
-        kernel='centered', **kwargs):
+        kernel='centered', full_run=False, **kwargs):
 
     solver = tti_setup(shape, spacing, tn, space_order, nbl, **kwargs)
 
     rec, u, v, summary = solver.forward(autotune=autotune, kernel=kernel)
 
-    return summary.gflopss, summary.oi, summary.timings, [rec, u, v]
+    if not full_run:
+        return summary.gflopss, summary.oi, summary.timings, [rec, u, v]
+
+    solver.adjoint(rec, autotune=autotune, kernel=kernel)
 
 
 if __name__ == "__main__":
@@ -45,4 +48,4 @@ if __name__ == "__main__":
 
     run(shape=shape, spacing=spacing, nbl=args.nbl, tn=tn,
         space_order=args.space_order, autotune=args.autotune,
-        opt=args.opt, kernel=kernel, preset=preset)
+        opt=args.opt, kernel=kernel, preset=preset, full_run=args.full)

--- a/examples/seismic/tti/wavesolver.py
+++ b/examples/seismic/tti/wavesolver.py
@@ -1,5 +1,5 @@
 # coding: utf-8
-from devito import TimeFunction, warning, error
+from devito import TimeFunction, warning
 from devito.tools import memoized_meth
 from examples.seismic.tti.operators import ForwardOperator, AdjointOperator
 from examples.seismic.tti.operators import particle_velocity_fields
@@ -170,8 +170,9 @@ class AnisotropicWaveSolver(object):
         -------
         Adjoint source, wavefield and performance summary.
         """
-        if not kernel is 'centered':
-            error('Only centered kernel is supported for the adjoint')
+        if kernel != 'centered':
+            raise RuntimeError('Only centered kernel is supported for the adjoint')
+
         time_order = 2
         stagg_p = stagg_r = None
         # Source term is read-only, so re-use the default

--- a/examples/seismic/tti/wavesolver.py
+++ b/examples/seismic/tti/wavesolver.py
@@ -1,5 +1,5 @@
 # coding: utf-8
-from devito import TimeFunction, warning
+from devito import TimeFunction, warning, error
 from devito.tools import memoized_meth
 from examples.seismic.tti.operators import ForwardOperator, AdjointOperator
 from examples.seismic.tti.operators import particle_velocity_fields
@@ -141,7 +141,7 @@ class AnisotropicWaveSolver(object):
 
     def adjoint(self, rec, srca=None, p=None, r=None, vp=None,
                 epsilon=None, delta=None, theta=None, phi=None,
-                save=None, **kwargs):
+                save=None, kernel='centered', **kwargs):
         """
         Adjoint modelling function that creates the necessary
         data objects for running an adjoint modelling operator.
@@ -170,7 +170,8 @@ class AnisotropicWaveSolver(object):
         -------
         Adjoint source, wavefield and performance summary.
         """
-
+        if not kernel is 'centered':
+            error('Only centered kernel is supported for the adjoint')
         time_order = 2
         stagg_p = stagg_r = None
         # Source term is read-only, so re-use the default

--- a/tests/test_caching.py
+++ b/tests/test_caching.py
@@ -434,8 +434,8 @@ class TestCaching(object):
             assert(len(_SymbolCache) == cache_size)
 
             Function(name='u', grid=grid, space_order=2)
-
-            assert(len(_SymbolCache) == cache_size + 1)
+            # Both u and u(inds) added to cache
+            assert(len(_SymbolCache) == cache_size + 2)
 
             clear_cache()
 
@@ -492,8 +492,8 @@ class TestCaching(object):
 
         u = SparseFunction(name='u', grid=grid, npoint=1, nt=10)
 
-        # created: u, p_u, h_p_u, u_coords, d, h_d
-        ncreated = 6
+        # created: u, u(inds), p_u, h_p_u, u_coords, u_coords(inds), d, h_d
+        ncreated = 8
         assert len(_SymbolCache) == cur_cache_size + ncreated
 
         cur_cache_size = len(_SymbolCache)
@@ -521,7 +521,7 @@ class TestCaching(object):
         # ii_u_* Symbols are still alive, as well as p_u and h_p_u. This is because
         # in the first clear_cache they were still referenced by their "parent" objects
         # (e.g., ii_u_* by ConditionalDimensions, through `condition`)
-        assert len(_SymbolCache) == init_cache_size + 6
+        assert len(_SymbolCache) == init_cache_size + 8
         clear_cache()
         # Now we should be back to the original state
         assert len(_SymbolCache) == init_cache_size
@@ -670,12 +670,15 @@ class TestMemoryLeaks(object):
         del eqn
         del grid
 
+        # Only deleted `u` shift reference still existing
         # `u` points to the various Dimensions, the Dimensions point to the various
-        # spacing symbols, hence, we need three sweeps to clear up the cache
-        assert len(_SymbolCache) == 12
+        # spacing symbols, hence, we need four sweeps to clear up the cache
+        assert len(_SymbolCache) == 16
         clear_cache()
-        assert len(_SymbolCache) == 8
+        assert len(_SymbolCache) == 9
         clear_cache()
-        assert len(_SymbolCache) == 2
+        assert len(_SymbolCache) == 3
+        clear_cache()
+        assert len(_SymbolCache) == 1
         clear_cache()
         assert len(_SymbolCache) == 0

--- a/tests/test_caching.py
+++ b/tests/test_caching.py
@@ -670,9 +670,11 @@ class TestMemoryLeaks(object):
         del eqn
         del grid
 
-        # Only deleted `u` shift reference still existing
-        # `u` points to the various Dimensions, the Dimensions point to the various
-        # spacing symbols, hence, we need four sweeps to clear up the cache
+        # We only deleted `u`, however we also cache shifted version created by the
+        # finite difference (u.dt, u.dx2). In this case we have three extra references
+        # to u(t + dt), u(x - h_x) and u(x + h_x) that have to be cleared.
+        # Then `u` points to the various Dimensions, the Dimensions point to the various
+        # spacing symbols, hence, we need five sweeps to clear up the cache.
         assert len(_SymbolCache) == 16
         clear_cache()
         assert len(_SymbolCache) == 9

--- a/tests/test_dse.py
+++ b/tests/test_dse.py
@@ -1411,7 +1411,7 @@ class TestTTI(object):
 
     @switchconfig(profiling='advanced')
     @pytest.mark.parametrize('space_order,expected', [
-        (8, 173), (16, 309)
+        (8, 173), (16, 307)
     ])
     def test_opcounts(self, space_order, expected):
         op = self.tti_operator(opt='advanced', space_order=space_order)


### PR DESCRIPTION
Small change to AbstractFunction caching that prevents creating duplicates of function by caching on indices as well. 