### PR TITLE
`Data` tweaks

### DIFF
--- a/devito/data/data.py
+++ b/devito/data/data.py
@@ -5,6 +5,7 @@ import numpy as np
 
 from devito.data.allocators import ALLOC_FLAT
 from devito.data.utils import *
+from devito.logger import warning
 from devito.parameters import configuration
 from devito.tools import Tag, as_tuple, as_list, is_integer
 
@@ -77,7 +78,8 @@ class Data(np.ndarray):
         self._memfree_args = None
 
     def __reduce__(self):
-        raise NotImplementedError("Pickling of `Data` objects is not supported")
+        warning("Pickling of `Data` objects is not supported. Casting to `numpy.ndarray`")
+        return np.array(self).__reduce__()
 
     def __array_finalize__(self, obj):
         # `self` is the newly created object

--- a/devito/data/data.py
+++ b/devito/data/data.py
@@ -76,6 +76,9 @@ class Data(np.ndarray):
         self._allocator.free(*self._memfree_args)
         self._memfree_args = None
 
+    def __reduce__(self):
+        raise NotImplementedError("Pickling of `Data` objects is not supported")
+
     def __array_finalize__(self, obj):
         # `self` is the newly created object
         # `obj` is the object from which `self` was created


### PR DESCRIPTION
Start of a PR to address some of the issues raised in #1184.

Currently only a `__reduce__` override has been introduced to raise an error is directly pickling a `Data` object.

In #1184 @tjb900  also states:

> I read this to mean that you cannot rely even on __new__ being called, which means the self._memfree_args reference in __del__ causes an error. This is a simple case of setting _memfree_args to None in __array_finalize__.

But `_memfree_args` is set to None here: https://github.com/devitocodes/devito/blob/c55e7a7fe534124f0a4b4d2b48ccc5a6cc169d07/devito/data/data.py#L95

So I'm probably missing something?

