### PR TITLE
compiler: version checks avoid unreliable exception

### DIFF
--- a/devito/compiler.py
+++ b/devito/compiler.py
@@ -2,7 +2,7 @@ from functools import partial
 from hashlib import sha1
 from os import environ, path
 from distutils import version
-from subprocess import DEVNULL, CalledProcessError, check_output, check_call
+from subprocess import DEVNULL, PIPE, CalledProcessError, check_output, check_call, run
 import platform
 import warnings
 import sys
@@ -31,8 +31,11 @@ def sniff_compiler_version(cc):
         https://github.com/OP2/PyOP2/
     """
     try:
-        ver = check_output([cc, "--version"]).decode("utf-8")
-    except (CalledProcessError, UnicodeDecodeError):
+        res = run([cc, "--version"], stdout=PIPE, stderr=DEVNULL)
+        ver = res.stdout.decode("utf-8")
+        if not ver:
+            return verson.LooseVersion("unknown")
+    except UnicodeDecodeError:
         return version.LooseVersion("unknown")
     except FileNotFoundError:
         error("The `%s` compiler isn't available on this system" % cc)
@@ -55,16 +58,16 @@ def sniff_compiler_version(cc):
     if compiler in ["gcc", "icc"]:
         try:
             # gcc-7 series only spits out patch level on dumpfullversion.
-            ver = check_output([cc, "-dumpfullversion"], stderr=DEVNULL).decode("utf-8")
+            res = run([cc, "-dumpfullversion"], stdout=PIPE, stderr=DEVNULL)
+            ver = res.stdout.decode("utf-8")
             ver = '.'.join(ver.strip().split('.')[:3])
-            ver = version.StrictVersion(ver)
-        except CalledProcessError:
-            try:
-                ver = check_output([cc, "-dumpversion"], stderr=DEVNULL).decode("utf-8")
+            if not ver:
+                res = run([cc, "-dumpversion"], stdout=PIPE, stderr=DEVNULL)
+                ver = res.stdout.decode("utf-8")
                 ver = '.'.join(ver.strip().split('.')[:3])
-                ver = version.StrictVersion(ver)
-            except (CalledProcessError, UnicodeDecodeError):
-                pass
+                if not ver:
+                    return version.LooseVersion("unknown")
+            ver = version.StrictVersion(ver)
         except UnicodeDecodeError:
             pass
 

--- a/devito/compiler.py
+++ b/devito/compiler.py
@@ -34,7 +34,7 @@ def sniff_compiler_version(cc):
         res = run([cc, "--version"], stdout=PIPE, stderr=DEVNULL)
         ver = res.stdout.decode("utf-8")
         if not ver:
-            return verson.LooseVersion("unknown")
+            return version.LooseVersion("unknown")
     except UnicodeDecodeError:
         return version.LooseVersion("unknown")
     except FileNotFoundError:


### PR DESCRIPTION
Compiler version code now checks for empty output of version tests rather than expecting an exception for unsupported arguments. This allows devito to be imported and used inside a process that has ignored SIGCHLD.

If SIGCHLD has been ignored then subprocess.check_output will always see a zero return value and never throw a CalledProcessError exception. This results in StrictVersion being incorrectly initialized and causes 'import devito' to fail.

See also: https://bugs.python.org/issue15756 where subprocess calls were changed to return 0 when SIGCHLD is ignored



