### PR TITLE
Run docker test

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -70,6 +70,7 @@ jobs:
     steps:
         - name: Run simple test
           run: |
+             docker pull 'devitocodes/devito:${{ matrix.im-name }}'
              docker run --rm --name testrun 'devitocodes/devito:${{ matrix.im-name }}' pytest tests/test_operator.py
 
   test-gpu-image:
@@ -84,4 +85,5 @@ jobs:
     steps:
         - name: Run simple test
           run: |
+             docker pull 'devitocodes/devito:${{ matrix.im-name }}'
              docker run --rm --name testrun 'devitocodes/devito:${{ matrix.im-name }}' pytest tests/test_gpu_openacc.py

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 pip>=9.0.1
-numpy>=1.14
+numpy>1.16
 sympy<1.6
 scipy
 pytest>=3.6


### PR DESCRIPTION
Last change.

- run created docker images (has to fore pull here for some reason)

WARNING: THis CI will still fail until the next release as the `devito:x-latest` does not exist currently.