### PR TITLE
MPI minor bug fixes

### DIFF
--- a/devito/mpi/distributed.py
+++ b/devito/mpi/distributed.py
@@ -304,14 +304,14 @@ class Distributor(AbstractDistributor):
             The index, or list of indices, for which the owning MPI rank(s) is
             retrieved.
         """
-        if isinstance(index, (tuple, list)):
-            if len(index) == 0:
-                return None
-            elif is_integer(index[0]):
-                # `index` is a single point
-                indices = [index]
-            else:
-                indices = index
+        assert isinstance(index, (tuple, list))
+        if len(index) == 0:
+            return None
+        elif is_integer(index[0]):
+            # `index` is a single point
+            indices = [index]
+        else:
+            indices = index
         ret = []
         for i in indices:
             assert len(i) == self.ndim
@@ -322,7 +322,7 @@ class Distributor(AbstractDistributor):
                     found = True
                     break
             assert found
-        return tuple(ret) if len(indices) > 1 else ret[0]
+        return as_tuple(ret)
 
     @property
     def neighborhood(self):

--- a/devito/types/dense.py
+++ b/devito/types/dense.py
@@ -331,7 +331,7 @@ class DiscreteFunction(AbstractFunction, ArgProvider, Differentiable):
                 else:
                     for i, j, k, l in zip(left, right, self._distributor.mycoords,
                                           self._distributor.topology):
-                        if j > 0 and k == 0 or i > 0 and k == l-1:
+                        if l > 1 and ((j > 0 and k == 0) or (i > 0 and k == l-1)):
                             warning(warning_msg)
                             break
             except AttributeError:


### PR DESCRIPTION
- Fixes a bug where `glb_to_rank` in `distributed.py` returned an integer (instead of `tuple`) in 1d. Test updated appropriately.
- Fixes incorrect instances of a halo warning in `dense.py`.