### PR TITLE
Tweak CIRE for GPUs

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -58,32 +58,34 @@ jobs:
           dockerfile: ./docker/Dockerfile.nvidia
           tags: gpu-latest,'gpu-${{ github.event.release.tag_name }}'
 
-  test-cpu-image:
-    needs: deploy-docker
-    runs-on: ubuntu-latest
+  # Comment out until next release
+  #test-cpu-image:
+    #needs: deploy-docker
+    #runs-on: ubuntu-latest
 
-    strategy:
-      fail-fast: false
-      matrix: 
-        im-name: [cpu-dev, cpu-latest]
+    #strategy:
+      #fail-fast: false
+      #matrix:
+        #im-name: [cpu-dev, cpu-latest]
 
-    steps:
-        - name: Run simple test
-          run: |
-             docker pull 'devitocodes/devito:${{ matrix.im-name }}'
-             docker run --rm --name testrun 'devitocodes/devito:${{ matrix.im-name }}' pytest tests/test_operator.py
+    #steps:
+        #- name: Run simple test
+          #run: |
+             #docker pull 'devitocodes/devito:${{ matrix.im-name }}'
+             #docker run --rm --name testrun 'devitocodes/devito:${{ matrix.im-name }}' pytest tests/test_operator.py
 
-  test-gpu-image:
-    needs: deploy-docker
-    runs-on: [self-hosted, gpu]
+  # Comment out until gpu docker image problem resolved
+  #test-gpu-image:
+    #needs: deploy-docker
+    #runs-on: [self-hosted, gpu]
 
-    strategy:
-      fail-fast: false
-      matrix: 
-        im-name: [gpu-dev, gpu-latest]
+    #strategy:
+      #fail-fast: false
+      #matrix:
+        #im-name: [gpu-dev, gpu-latest]
 
-    steps:
-        - name: Run simple test
-          run: |
-             docker pull 'devitocodes/devito:${{ matrix.im-name }}'
-             docker run --rm --name testrun 'devitocodes/devito:${{ matrix.im-name }}' pytest tests/test_gpu_openacc.py
+    #steps:
+        #- name: Run simple test
+          #run: |
+             #docker pull 'devitocodes/devito:${{ matrix.im-name }}'
+             #docker run --rm --name testrun 'devitocodes/devito:${{ matrix.im-name }}' pytest tests/test_gpu_openacc.py

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -58,21 +58,22 @@ jobs:
           dockerfile: ./docker/Dockerfile.nvidia
           tags: gpu-latest,'gpu-${{ github.event.release.tag_name }}'
 
-  # Comment out until next release
-  #test-cpu-image:
-    #needs: deploy-docker
-    #runs-on: ubuntu-latest
+  # Comment out 'cpu-latest' until next release
+  test-cpu-image:
+    needs: deploy-docker
+    runs-on: ubuntu-latest
 
-    #strategy:
-      #fail-fast: false
-      #matrix:
+    strategy:
+      fail-fast: false
+      matrix:
         #im-name: [cpu-dev, cpu-latest]
+        im-name: cpu-dev
 
-    #steps:
-        #- name: Run simple test
-          #run: |
-             #docker pull 'devitocodes/devito:${{ matrix.im-name }}'
-             #docker run --rm --name testrun 'devitocodes/devito:${{ matrix.im-name }}' pytest tests/test_operator.py
+    steps:
+        - name: Run simple test
+          run: |
+             docker pull 'devitocodes/devito:${{ matrix.im-name }}'
+             docker run --rm --name testrun 'devitocodes/devito:${{ matrix.im-name }}' pytest tests/test_operator.py
 
   # Comment out until gpu docker image problem resolved
   #test-gpu-image:

--- a/devito/core/cpu.py
+++ b/devito/core/cpu.py
@@ -91,6 +91,7 @@ class CPU64NoopOperator(OperatorCore):
 
         # CIRE
         o['min-storage'] = oo.pop('min-storage', False)
+        o['cire-maxpar'] = oo.pop('cire-maxpar', False)
         o['cire-repeats'] = {
             'invariants': oo.pop('cire-repeats-inv', cls.CIRE_REPEATS_INV),
             'sops': oo.pop('cire-repeats-sops', cls.CIRE_REPEATS_SOPS)

--- a/devito/core/gpu_openmp.py
+++ b/devito/core/gpu_openmp.py
@@ -248,6 +248,7 @@ class DeviceOpenMPNoopOperator(OperatorCore):
 
         # CIRE
         o['min-storage'] = False
+        o['cire-maxpar'] = oo.pop('cire-maxpar', True)
         o['cire-repeats'] = {
             'invariants': oo.pop('cire-repeats-inv', cls.CIRE_REPEATS_INV),
             'sops': oo.pop('cire-repeats-sops', cls.CIRE_REPEATS_SOPS)

--- a/devito/ir/clusters/cluster.py
+++ b/devito/ir/clusters/cluster.py
@@ -111,6 +111,10 @@ class Cluster(object):
         return self.ispace.sub_iterators
 
     @property
+    def directions(self):
+        return self.ispace.directions
+
+    @property
     def dspace(self):
         return self._dspace
 

--- a/examples/performance/00_overview.ipynb
+++ b/examples/performance/00_overview.ipynb
@@ -1289,6 +1289,86 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "#### The `cire-maxpar` option\n",
+    "\n",
+    "Sometimes it's possible to trade storage for parallelism (i.e., for more parallel dimensions). For this, Devito provides the `cire-maxpar` option which is by default set to:\n",
+    "\n",
+    "* False on CPU backends\n",
+    "* True on GPU backends\n",
+    "\n",
+    "Let's see what happens when we switch it on"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "float (*r3)[y_size + 1][z_size];\n",
+      "posix_memalign((void**)&r3, 64, sizeof(float[x_size][y_size + 1][z_size]));\n",
+      "\n",
+      "for (int time = time_m, t0 = (time)%(2), t1 = (time + 1)%(2); time <= time_M; time += 1, t0 = (time)%(2), t1 = (time + 1)%(2))\n",
+      "{\n",
+      "  struct timeval start_section0, end_section0;\n",
+      "  gettimeofday(&start_section0, NULL);\n",
+      "  /* Begin section0 */\n",
+      "  #pragma omp parallel num_threads(nthreads)\n",
+      "  {\n",
+      "    #pragma omp for collapse(3) schedule(static,1)\n",
+      "    for (int x = x_m; x <= x_M; x += 1)\n",
+      "    {\n",
+      "      for (int y = y_m - 1; y <= y_M; y += 1)\n",
+      "      {\n",
+      "        for (int z = z_m; z <= z_M; z += 1)\n",
+      "        {\n",
+      "          r3[x][y + 1][z] = -u[t0][x + 2][y + 3][z + 2]/h_y + u[t0][x + 2][y + 4][z + 2]/h_y;\n",
+      "        }\n",
+      "      }\n",
+      "    }\n",
+      "  }\n",
+      "  #pragma omp parallel num_threads(nthreads)\n",
+      "  {\n",
+      "    #pragma omp for collapse(3) schedule(static,1)\n",
+      "    for (int x = x_m; x <= x_M; x += 1)\n",
+      "    {\n",
+      "      for (int y = y_m; y <= y_M; y += 1)\n",
+      "      {\n",
+      "        for (int z = z_m; z <= z_M; z += 1)\n",
+      "        {\n",
+      "          u[t1][x + 2][y + 2][z + 2] = (-r3[x][y][z]/h_y + r3[x][y + 1][z]/h_y)*sin(f[x + 1][y + 1][z + 1])*pow(f[x + 1][y + 1][z + 1], 2);\n",
+      "        }\n",
+      "      }\n",
+      "    }\n",
+      "  }\n",
+      "  /* End section0 */\n",
+      "  gettimeofday(&end_section0, NULL);\n",
+      "  timers->section0 += (double)(end_section0.tv_sec-start_section0.tv_sec)+(double)(end_section0.tv_usec-start_section0.tv_usec)/1000000;\n",
+      "}\n",
+      "\n",
+      "free(r3);\n"
+     ]
+    }
+   ],
+   "source": [
+    "op13_omp = Operator(eq, opt=('cire-sops', {'openmp': True, 'cire-maxpar': True}))\n",
+    "print_kernel(op13_omp)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The generated code uses a three-dimensional temporary that gets written and subsequently read in two separate `x-y-z` loop nests. Now, both loops can safely be openmp-collapsed, which is vital when running on GPUs."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "#### All optimizations together\n",
     "\n",
     "The `advanced` mode triggers all of the passes we've seen so far... and in fact, many more! Some of them, however, aren't visible in our running example (e.g., all of the MPI-related optimizations). These will be treated in a future notebook.\n",
@@ -1298,7 +1378,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 23,
    "metadata": {
     "scrolled": true
    },
@@ -1445,9 +1525,9 @@
     }
    ],
    "source": [
-    "op13_omp = Operator(eq, openmp=True)\n",
-    "print(op13_omp)\n",
-    "# op14_omp = Operator(eq, opt=('advanced', {'min-storage': True}))"
+    "op14_omp = Operator(eq, openmp=True)\n",
+    "print(op14_omp)\n",
+    "# op14_b0_omp = Operator(eq, opt=('advanced', {'min-storage': True}))"
    ]
   },
   {
@@ -1468,7 +1548,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 24,
    "metadata": {},
    "outputs": [
     {
@@ -1608,8 +1688,8 @@
     }
    ],
    "source": [
-    "op14_omp = Operator(eq, opt=('advanced-fsg', {'openmp': True}))\n",
-    "print(op14_omp)"
+    "op15_omp = Operator(eq, opt=('advanced-fsg', {'openmp': True}))\n",
+    "print(op15_omp)"
    ]
   },
   {
@@ -1621,7 +1701,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 25,
    "metadata": {
     "scrolled": true
    },
@@ -1791,8 +1871,8 @@
    ],
    "source": [
     "eq = Eq(u.forward, f**2*sin(f)*(u.dy.dy + u.dx.dx))\n",
-    "op14_b0 = Operator(eq, opt=('advanced-fsg', {'openmp': True}))\n",
-    "print(op14_b0)"
+    "op15_b0 = Operator(eq, opt=('advanced-fsg', {'openmp': True}))\n",
+    "print(op15_b0)"
    ]
   },
   {

--- a/examples/performance/README.md
+++ b/examples/performance/README.md
@@ -18,6 +18,7 @@
     * `blocklevels` (int, 1): 1 => classic loop blocking; 2 for two-level hierarchical blocking; etc.
   * CIRE:
     * `min-storage` (boolean, False): enable/disable dimension contraction for working set size reduction
+    * `cire-maxpar` (boolean, False): trade storage for parallelism
     * `cire-repeats-sops` (int, 5): control detection of sum-of-products
     * `cire-mincost-sops` (int, 10): minimum cost of a sum-of-product candidate
     * `cire-repeats-inv` (int, 1): control detection of dimension-invariants
@@ -49,6 +50,7 @@
 |                     |        CPU          |         GPU        |
 |---------------------|---------------------|--------------------|
 | minstorage          | :heavy_check_mark:  |         :x:        |
+| cire-maxpar         | :heavy_check_mark:  | :heavy_check_mark: |
 | cire-repeats-sops   | :heavy_check_mark:  | :heavy_check_mark: |
 | cire-mincost-sops   | :heavy_check_mark:  | :heavy_check_mark: |
 | cire-repeats-inv    | :heavy_check_mark:  | :heavy_check_mark: |

--- a/tests/test_gpu_common.py
+++ b/tests/test_gpu_common.py
@@ -1,11 +1,34 @@
+from devito import Eq, Grid, TimeFunction, Operator
 from devito.archinfo import get_gpu_info
+from devito.ir.iet import retrieve_iteration_tree
 
 from conftest import skipif
+
+pytestmark = skipif(['nodevice'], whole_module=True)
 
 
 class TestGPUInfo(object):
 
-    @skipif('nodevice')
     def test_get_gpu_info(self):
         info = get_gpu_info()
         assert 'tesla' in info['architecture'].lower()
+
+
+class TestCodeGeneration(object):
+
+    def test_maxpar_option(self):
+        """
+        Make sure the `cire-maxpar` option is set to True by default.
+        """
+        grid = Grid(shape=(10, 10, 10))
+
+        u = TimeFunction(name='u', grid=grid, space_order=2)
+
+        eq = Eq(u.forward, u.dy.dy)
+
+        op = Operator(eq)
+
+        trees = retrieve_iteration_tree(op)
+        assert len(trees) == 2
+        assert trees[0][0] is trees[1][0]
+        assert trees[0][1] is not trees[1][1]


### PR DESCRIPTION
The new `cire-maxpar` option is to be used to tradeoff storage for parallelism.

Defaults: true on GPU backends, false on CPU backends.

when on, generates:
```
for x
  for y
    r[x,y] = ...
for x
  for y
    ... = ... r[x, y+1] ...
```

instead of
```
for x
  for y
    r[y] = ...
  for y 
    ... = ... r[y+1] ...
```