### PR TITLE
Restrict pytest to < 6.0

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -67,7 +67,7 @@ jobs:
       fail-fast: false
       matrix:
         #im-name: [cpu-dev, cpu-latest]
-        im-name: cpu-dev
+        im-name: [cpu-dev]
 
     steps:
         - name: Run simple test

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ pip>=9.0.1
 numpy>1.16
 sympy<1.6
 scipy
-pytest>=3.6
+pytest>=3.6,<6.0
 pytest-runner
 flake8>=2.1.0
 nbval


### PR DESCRIPTION
With the release of pytest 6.0.0 a previous warning seems to now be an error. See [here](https://github.com/computationalmodelling/nbval/issues/139) who have also noted this issue. Latest pytest issues [here](https://github.com/pytest-dev/pytest/issues).