### PR TITLE
Tests: update checkpointing test to single precision

### DIFF
--- a/tests/test_gradient.py
+++ b/tests/test_gradient.py
@@ -29,7 +29,7 @@ class TestGradient(object):
         with F the Forward modelling operator.
         """
         spacing = tuple(10. for _ in shape)
-        wave = setup(shape=shape, spacing=spacing, dtype=np.float64,
+        wave = setup(shape=shape, spacing=spacing, dtype=np.float32,
                      kernel=kernel, space_order=space_order,
                      nbl=40)
 

--- a/tests/test_gradient.py
+++ b/tests/test_gradient.py
@@ -14,24 +14,14 @@ class TestGradient(object):
     @pytest.mark.parametrize('shape', [(70, 80)])
     def test_gradient_checkpointing(self, shape, kernel, space_order):
         r"""
-        This test ensures that the FWI gradient computed with devito
-        satisfies the Taylor expansion property:
-        .. math::
-            \Phi(m0 + h dm) = \Phi(m0) + \O(h) \\
-            \Phi(m0 + h dm) = \Phi(m0) + h \nabla \Phi(m0) + \O(h^2) \\
-            \Phi(m0) = .5* || F(m0 + h dm) - D ||_2^2
-
-        where
-        .. math::
-            \nabla \Phi(m0) = <J^T \delta d, dm> \\
-            \delta d = F(m0+ h dm) - D \\
-
-        with F the Forward modelling operator.
+        This test ensures that the FWI gradient computed with checkpointing matches
+        the one without checkpointing. Note that this test fails with dynamic openmp
+        scheduling enabled so this test disables it.
         """
         spacing = tuple(10. for _ in shape)
         wave = setup(shape=shape, spacing=spacing, dtype=np.float32,
                      kernel=kernel, space_order=space_order,
-                     nbl=40)
+                     nbl=40, opt=('noop', {'openmp': True, 'par-dynamic-work': 1000}))
 
         v0 = Function(name='v0', grid=wave.model.grid, space_order=space_order)
         smooth(v0, wave.model.vp)


### PR DESCRIPTION
Addresses #1399 by changing the test to use single precision - this now fails with dynamic openmp scheduling (expected). So this PR disables dynamic scheduling for the operator in the test to make it pass. 