### PR TITLE
Single precision interpolation

### DIFF
--- a/devito/ir/equations/algorithms.py
+++ b/devito/ir/equations/algorithms.py
@@ -1,5 +1,4 @@
 from collections.abc import Iterable
-
 from operator import attrgetter
 
 from devito.symbolics import (retrieve_functions, retrieve_indexed, split_affine,

--- a/devito/operations/interpolators.py
+++ b/devito/operations/interpolators.py
@@ -187,11 +187,16 @@ class LinearInterpolator(GenericInterpolator):
             # Track Indexed substitutions
             idx_subs.append(mapper)
 
-        # Temporaries for the indirection dimensions
+        # Temporaries for the position
         temps = [Eq(v, k, implicit_dims=self.sfunction.dimensions)
-                 for k, v in points.items()]
+                 for k, v in self.sfunction._position_map.items()]
+        # Temporaries for the indirection dimensions
+        temps.extend([Eq(v, k.subs(self.sfunction._position_map),
+                         implicit_dims=self.sfunction.dimensions)
+                      for k, v in points.items()])
         # Temporaries for the coefficients
-        temps.extend([Eq(p, c, implicit_dims=self.sfunction.dimensions)
+        temps.extend([Eq(p, c.subs(self.sfunction._position_map),
+                         implicit_dims=self.sfunction.dimensions)
                       for p, c in zip(self.sfunction._point_symbols,
                                       self.sfunction._coordinate_bases(field_offset))])
 

--- a/tests/test_caching.py
+++ b/tests/test_caching.py
@@ -523,8 +523,8 @@ class TestCaching(object):
         i = u.inject(expr=u, field=u)
 
         # created: ii_u_0*2 (Symbol and ConditionalDimension), ii_u_1*2, ii_u_2*2,
-        # ii_u_3*2, px, py, u_coords (as indexified),
-        ncreated = 2+2+2+2+1+1+1
+        # ii_u_3*2, px, py, posx, posy, u_coords (as indexified),
+        ncreated = 2+2+2+2+2+1+1+1
         # Note that injection is now lazy so no new symbols should be created
         assert len(_SymbolCache) == cur_cache_size
         i.evaluate

--- a/tests/test_interpolation.py
+++ b/tests/test_interpolation.py
@@ -472,3 +472,24 @@ def test_position(shape):
                                  o_x=ox_g, o_y=oy_g, o_z=oz_g)
 
     assert(np.allclose(rec.data, rec1.data, atol=1e-5))
+
+
+def test_edge_sparse():
+    """
+    Test that interpolation uses the correct point for the edge case
+    wehre the sparse point is at the origin with non rational grid spacing.
+    Due to round up error the unterpolatin would use the halo point instead of
+    the point (0, 0) without the factorizaion of the expressions.
+    """
+    grid = Grid(shape=(16, 16), extent=(225., 225.), origin=(25., 35.))
+    u = unit_box(shape=(16, 16), grid=grid)
+    u._data_with_outhalo[:u.space_order, :] = -1
+    u._data_with_outhalo[:, :u.space_order] = -1
+    sf1 = SparseFunction(name='s', grid=u.grid, npoint=1)
+    sf1.coordinates.data[0, :] = (25.0, 35.0)
+
+    expr = sf1.interpolate(u)
+    subs = {d.spacing: v for d, v in zip(u.grid.dimensions, u.grid.spacing)}
+    op = Operator(expr, subs=subs)
+    op()
+    assert sf1.data[0] == 0

--- a/tests/test_interpolation.py
+++ b/tests/test_interpolation.py
@@ -477,8 +477,8 @@ def test_position(shape):
 def test_edge_sparse():
     """
     Test that interpolation uses the correct point for the edge case
-    wehre the sparse point is at the origin with non rational grid spacing.
-    Due to round up error the unterpolatin would use the halo point instead of
+    where the sparse point is at the origin with non rational grid spacing.
+    Due to round up error the interpolation would use the halo point instead of
     the point (0, 0) without the factorizaion of the expressions.
     """
     grid = Grid(shape=(16, 16), extent=(225., 225.), origin=(25., 35.))


### PR DESCRIPTION
Fixes interpolation using the wrong points with MPI (or without MPI and no BCs) due to rounding errors around zero in single precision.

- Added test for it

Fixes #1357 

Should fix #1251 