### PR TITLE
Buffer: remove unused  from args to allow multi buffers

### DIFF
--- a/devito/types/dimension.py
+++ b/devito/types/dimension.py
@@ -803,7 +803,7 @@ class SteppingDimension(DerivedDimension):
     def _arg_names(self):
         return (self.min_name, self.max_name, self.name) + self.parent._arg_names
 
-    def _arg_defaults(self, _min=None, size=None, **kwargs):
+    def _arg_defaults(self, _min=None, **kwargs):
         """
         A map of default argument values defined by this dimension.
 
@@ -811,14 +811,13 @@ class SteppingDimension(DerivedDimension):
         ----------
         _min : int, optional
             Minimum point as provided by data-carrying objects.
-        size : int, optional
-            Size as provided by data-carrying symbols.
 
         Notes
         -----
-        A SteppingDimension does not know its max point.
+        A SteppingDimension does not know its max point and therefore
+        does not have a size argument.
         """
-        return {self.parent.min_name: _min, self.size_name: size}
+        return {self.parent.min_name: _min}
 
     def _arg_values(self, *args, **kwargs):
         """


### PR DESCRIPTION
Small change to `SteppingDimension` that was returning multiple `t_sizes` into `arguments` that was unsuded but was preventing multiple functions with different buffer sizes. Added test for fix.