### PR TITLE
fix misspelling of openmp-targets for amdgcn-amd-amdhsa

### DIFF
--- a/devito/compiler.py
+++ b/devito/compiler.py
@@ -397,7 +397,7 @@ class ClangCompiler(Compiler):
             if language in ['C', 'openmp']:
                 self.ldflags += ['-target', 'x86_64-pc-linux-gnu']
                 self.ldflags += ['-fopenmp',
-                                 '-fopenmp-targets=amdgcn-amd-amdhs',
+                                 '-fopenmp-targets=amdgcn-amd-amdhsa',
                                  '-Xopenmp-target=amdgcn-amd-amdhsa']
                 self.ldflags += ['-march=%s' % platform.march]
         else:


### PR DESCRIPTION
Fix a typo when trying to run devito openmp-target for amdgcn-amd-amdhsa with AOMP:
error: unable to create target: 'No available targets are compatible with triple "amdgcn-amd-amdhs"'
