### PR TITLE
Added origin_map attribute to Grid

### DIFF
--- a/devito/types/grid.py
+++ b/devito/types/grid.py
@@ -168,8 +168,7 @@ class Grid(ArgProvider):
     @property
     def origin_map(self):
         """Map between origin symbols and their values"""
-        origin_pos = [i.data for i in self.origin]
-        return dict(zip(self.origin, origin_pos))
+        return {o: o.data for o in self.origin}
 
     @property
     def dimensions(self):

--- a/devito/types/grid.py
+++ b/devito/types/grid.py
@@ -166,6 +166,12 @@ class Grid(ArgProvider):
         return self._origin
 
     @property
+    def origin_map(self):
+        """Map between origin symbols and their values"""
+        origin_pos = [i.data for i in self.origin]
+        return dict(zip(self.origin, origin_pos))
+
+    @property
     def dimensions(self):
         """Spatial dimensions of the computational domain."""
         return self._dimensions


### PR DESCRIPTION
Added and origin_map analogous to spacing_map. The idea is to have a shortcut to obtain the float values of the tuple rather than having to do [i.data for i in grid.origin]