### PR TITLE
Patch compilation time

### DIFF
--- a/devito/ir/iet/visitors.py
+++ b/devito/ir/iet/visitors.py
@@ -536,6 +536,14 @@ class MapNodes(Visitor):
 
 class FindSymbols(Visitor):
 
+    def quick_str(o):
+        """
+        SymPy's __str__ is horribly slow so we stay away from it for as much
+        as we can. A devito.Indexed has its own overridden __str__, which
+        relies on memoization, which is acceptable.
+        """
+        return str(o) if o.is_Indexed else o.name
+
     class Retval(list):
         def __init__(self, *retvals, node=None):
             elements = []
@@ -546,7 +554,7 @@ class FindSymbols(Visitor):
                 except AttributeError:
                     pass
                 elements.extend(i)
-            elements = filter_sorted(elements, key=str)
+            elements = filter_sorted(elements, key=FindSymbols.quick_str)
             if node is not None:
                 self.mapper[node] = tuple(elements)
             super().__init__(elements)

--- a/devito/tools/utils.py
+++ b/devito/tools/utils.py
@@ -165,7 +165,14 @@ def filter_ordered(elements, key=None):
             return unordered[np.argsort(inds)].tolist()
         except:
             return sorted(list(set(elements)), key=elements.index)
-    return [e for e in elements if not (key(e) in seen or seen.add(key(e)))]
+    else:
+        ret = []
+        for e in elements:
+            k = key(e)
+            if k not in seen:
+                ret.append(e)
+                seen.add(k)
+        return ret
 
 
 def filter_sorted(elements, key=None):

--- a/devito/types/basic.py
+++ b/devito/types/basic.py
@@ -1180,6 +1180,10 @@ class Indexed(sympy.Indexed):
 
     is_Dimension = False
 
+    @memoized_meth
+    def __str__(self):
+        return super().__str__()
+
     def _hashable_content(self):
         return super(Indexed, self)._hashable_content() + (self.base.function,)
 

--- a/tests/test_visitors.py
+++ b/tests/test_visitors.py
@@ -1,12 +1,13 @@
 import cgen as c
-from sympy import Mod, Eq
+from sympy import Mod
 import pytest
 
+from devito import Grid, Eq, Function, Operator
 from devito.ir.equations import DummyEq
 from devito.ir.iet import (Block, Expression, Callable, FindSections,
                            FindSymbols, IsPerfectIteration, Transformer,
                            Conditional, printAST, Iteration)
-from devito.types import SpaceDimension, Array, Grid
+from devito.types import SpaceDimension, Array
 
 
 @pytest.fixture(scope="module")
@@ -332,3 +333,16 @@ def test_nested_transformer(exprs, iters, block2):
   <Iteration s::s::(0, 4, 1)>
     <Iteration k::k::(0, 7, 1)>
       <Expression a[i] = 8.0*a[i] + 6.0/b[i]>"""
+
+
+def test_find_symbols():
+    grid = Grid(shape=(4, 4))
+    x, y = grid.dimensions
+
+    f = Function(name='f', grid=grid)
+
+    op = Operator(Eq(f, f[x-1, y] + f[x+1, y] + 1))
+
+    symbols = FindSymbols('indexeds').visit(op)
+
+    assert len(symbols) == 3


### PR DESCRIPTION
ASV spotted a regression in compilation time, see spike [here](https://www.devitoproject.org/devito-performance/#codegen.TTI.time_forward) on https://github.com/devitocodes/devito/commit/891bfc4c 

This patch fixes it.

It also speeds-up `filter_ordered` (now `key` only computed once) and adds a simple tree visitor test