### PR TITLE
Tensor grid fixup

### DIFF
--- a/devito/passes/equations/linearity.py
+++ b/devito/passes/equations/linearity.py
@@ -52,7 +52,19 @@ def _(c, deriv):
 
 @_is_const_coeff.register(sympy.Function)
 def _(c, deriv):
-    return not set(deriv.dims) & c.free_symbols
+    is_const = not set(deriv.dims) & c.free_symbols
+    try:
+        is_const &= not set([d.parent for d in deriv.dims]) & c.free_symbols
+    except AttributeError:
+        pass
+    # Need to check that there isn't any sub/super-dimension of deriv.dims
+    # in c
+    for c in c.free_symbols:
+        try:
+            is_const &= not set(deriv.dims) & {c.parent}
+        except AttributeError:
+            pass
+    return is_const
 
 
 @_is_const_coeff.register(sympy.Expr)

--- a/devito/passes/equations/linearity.py
+++ b/devito/passes/equations/linearity.py
@@ -52,19 +52,9 @@ def _(c, deriv):
 
 @_is_const_coeff.register(sympy.Function)
 def _(c, deriv):
-    is_const = not set(deriv.dims) & c.free_symbols
-    try:
-        is_const &= not set([d.parent for d in deriv.dims]) & c.free_symbols
-    except AttributeError:
-        pass
-    # Need to check that there isn't any sub/super-dimension of deriv.dims
-    # in c
-    for c in c.free_symbols:
-        try:
-            is_const &= not set(deriv.dims) & {c.parent}
-        except AttributeError:
-            pass
-    return is_const
+    c_dims = set().union(*[getattr(i, '_defines', i) for i in c.free_symbols])
+    deriv_dims = set().union(*[d._defines for d in deriv.dims])
+    return not c_dims & deriv_dims
 
 
 @_is_const_coeff.register(sympy.Expr)

--- a/devito/types/equation.py
+++ b/devito/types/equation.py
@@ -91,6 +91,7 @@ class Eq(sympy.Eq, Evaluable):
         eq = self.func(lhs, rhs, subdomain=self.subdomain,
                        coefficients=self.substitutions,
                        implicit_dims=self._implicit_dims)
+
         if eq._uses_symbolic_coefficients:
             # NOTE: As Coefficients.py is expanded we will not want
             # all rules to be expunged during this procress.

--- a/devito/types/tensor.py
+++ b/devito/types/tensor.py
@@ -317,13 +317,10 @@ class VectorFunction(TensorFunction):
         """
         Laplacian of the VectorFunction, creates the Laplacian VectorFunction.
         """
-        comps = []
-        to = getattr(self, 'time_order', 0)
         func = vec_func(self, self)
         comps = [sum([getattr(s, 'd%s2' % d.name) for d in self.space_dimensions])
                  for s in self]
-        return func(name='lap_%s' % self.name, space_order=self.space_order,
-                    components=comps, time_order=to)
+        return func._new(comps)
 
     @property
     def curl(self):

--- a/devito/types/tensor.py
+++ b/devito/types/tensor.py
@@ -7,7 +7,6 @@ from sympy.core.decorators import call_highest_priority
 from sympy.core.sympify import converter as sympify_converter
 
 from devito.finite_differences import Differentiable
-from devito.tools import flatten
 from devito.types.basic import AbstractTensor
 from devito.types.dense import Function, TimeFunction
 from devito.types.utils import NODE
@@ -76,13 +75,8 @@ class TensorFunction(AbstractTensor):
     _op_priority = Differentiable._op_priority + 1.
 
     def __init_finalize__(self, *args, **kwargs):
-        if args:
-            comps = flatten(args[2])
-            grid = comps[0].grid
-            dimensions = None if grid else comps[0].dimensions
-        else:
-            grid = kwargs.get('grid')
-            dimensions = kwargs.get('dimensions')
+        grid = kwargs.get('grid')
+        dimensions = kwargs.get('dimensions')
         inds, _ = Function.__indices_setup__(grid=grid,
                                              dimensions=dimensions)
         self._space_dimensions = inds
@@ -181,6 +175,10 @@ class TensorFunction(AbstractTensor):
     def __indices_setup__(cls, **kwargs):
         return Function.__indices_setup__(grid=kwargs.get('grid'),
                                           dimensions=kwargs.get('dimensions'))
+
+    @property
+    def _symbolic_functions(self):
+        return frozenset().union(*[a._symbolic_functions for a in self.values()])
 
     @property
     def is_TimeDependent(self):
@@ -324,8 +322,8 @@ class VectorFunction(TensorFunction):
         func = vec_func(self, self)
         comps = [sum([getattr(s, 'd%s2' % d.name) for d in self.space_dimensions])
                  for s in self]
-        return func(name='lap_%s' % self.name, grid=self.grid,
-                    space_order=self.space_order, components=comps, time_order=to)
+        return func(name='lap_%s' % self.name, space_order=self.space_order,
+                    components=comps, time_order=to)
 
     @property
     def curl(self):

--- a/tests/test_exprs_lowering.py
+++ b/tests/test_exprs_lowering.py
@@ -1,0 +1,41 @@
+from devito import Grid, TimeFunction, Function, Operator, Eq
+from devito.passes.equations.linearity import _is_const_coeff
+from devito.tools import timed_region
+
+
+class TestCollectDerivatives():
+    """
+    Testing Derivatives and expressions of Derivatives collection.
+    """
+
+    def test_is_const_coeff_time(self):
+        """
+        test that subdimension and parent are not miss-interpreted as
+        constants.
+        """
+        grid = Grid((10,))
+        f = TimeFunction(name="f", grid=grid, save=10)
+        g = TimeFunction(name="g", grid=grid)
+        assert not _is_const_coeff(g, f.dt)
+        assert not _is_const_coeff(f, g.dt)
+
+    def test_expr_collection(self):
+        """
+        Test that expressions with different time dimensions are not collected.
+        """
+        grid = Grid((10,))
+        f = TimeFunction(name="f", grid=grid, save=10)
+        f2 = TimeFunction(name="f2", grid=grid, save=10)
+        g = TimeFunction(name="g", grid=grid)
+        g2 = TimeFunction(name="g2", grid=grid)
+
+        w = Function(name="w", grid=grid)
+        eq = Eq(w, f.dt*g + f2.dt*g2)
+
+        with timed_region('x'):
+            # Since all Function are time dependent, there should be no collection
+            # and produce the same result as with the pre evaluated expression
+            expr = Operator._lower_exprs([eq])[0]
+            expr2 = Operator._lower_exprs([eq.evaluate])[0]
+
+        assert expr == expr2

--- a/tests/test_tensors.py
+++ b/tests/test_tensors.py
@@ -205,3 +205,46 @@ def test_sympy_vector(func1):
     mat = sympy.Matrix(3, 3, np.random.rand(3, 3).ravel())
 
     assert all(sp - dp == 0 for sp, dp in zip(mat * f1, mat * sympy_f1))
+
+
+@pytest.mark.parametrize('func1', [TensorFunction, TensorTimeFunction])
+def test_non_devito_tens(func1):
+    grid = Grid(tuple([5]*3))
+    comps = sympy.Matrix(3, 3, [1, 2, 3, 2, 3, 6, 3, 6, 9])
+
+    f1 = func1(name="f1", grid=grid, components=comps)
+    f2 = func1(name="f2", grid=grid)
+
+    assert f1.T == f1
+    assert isinstance(f1.T, sympy.ImmutableDenseMatrix)
+    # No devito object in the matrix components, should return a pure sympy Matrix
+    assert ~isinstance(f1.T, func1)
+    # Can still multiply
+    f3 = f2*f1.T
+    assert isinstance(f3, func1)
+
+    for i in range(3):
+        for j in range(3):
+            assert f3[i, j] == sum(f2[i, k] * f1[j, k] for k in range(3))
+
+
+@pytest.mark.parametrize('func1', [TensorFunction, TensorTimeFunction])
+def test_partial_devito_tens(func1):
+    grid = Grid(tuple([5]*3))
+    f2 = func1(name="f2", grid=grid)
+
+    comps = sympy.Matrix(3, 3, [1, 2, f2[0, 0], 2, 3, 6, f2[0, 0], 6, 9])
+
+    f1 = func1(name="f1", grid=grid, components=comps)
+
+    assert f1.T == f1
+    assert isinstance(f1.T, func1)
+    # Should have original grid
+    assert f1[0, 2].grid == grid
+    # Can still multiply
+    f3 = f2*f1.T
+    assert isinstance(f3, func1)
+
+    for i in range(3):
+        for j in range(3):
+            assert f3[i, j] == sum(f2[i, k] * f1[j, k] for k in range(3))


### PR DESCRIPTION
Add robustness grid detection in the constructor. Should prevent errors when a `TensorFunction` is created with components that are not devito types.

TODO:
- Cleanup and force return sympy Matrix at first construction as well

fixes #1476