### PR TITLE
Function globabl size method

### DIFF
--- a/devito/types/dense.py
+++ b/devito/types/dense.py
@@ -299,6 +299,15 @@ class DiscreteFunction(AbstractFunction, ArgProvider, Differentiable):
             retval.append(size.glb if size is not None else s)
         return tuple(retval)
 
+    @property
+    def size_global(self):
+        """
+        The global number of elements this object is expected to store in memory.
+        Note that this would need to be combined with self.dtype to give the actual
+        size in bytes.
+        """
+        return reduce(mul, self.shape_global)
+
     _offset_inhalo = AbstractFunction._offset_halo
     _size_inhalo = AbstractFunction._size_halo
 

--- a/tests/test_mpi.py
+++ b/tests/test_mpi.py
@@ -28,6 +28,7 @@ class TestDistributor(object):
             4: [(8, 8), (8, 7), (7, 8), (7, 7)]
         }
         assert f.shape == expected[distributor.nprocs][distributor.myrank]
+        assert f.size_global == 225
 
     @pytest.mark.parallel(mode=[2, 4])
     def test_partitioning_fewer_dims(self):


### PR DESCRIPTION
Tiny PR adding a quick method to `Function`'s for returning `size_global`.

But see #1498 re. the naming.