### PR TITLE
Remove use of set-env from workflows

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -27,10 +27,10 @@ jobs:
 
     steps:
     - name: Checkout devito
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
 
     - name: Setup conda
-      uses: goanpeca/setup-miniconda@v1
+      uses: goanpeca/setup-miniconda@master
       with:
        activate-environment: devito
        environment-file: environment-dev.yml

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -30,7 +30,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Setup conda
-      uses: goanpeca/setup-miniconda@master
+      uses: conda-incubator/setup-miniconda@v2
       with:
        activate-environment: devito
        environment-file: environment-dev.yml

--- a/.github/workflows/pytest-core-nompi.yml
+++ b/.github/workflows/pytest-core-nompi.yml
@@ -21,7 +21,6 @@ jobs:
       DEVITO_BACKEND: "core"
       OMP_NUM_THREADS: 2
       PYTHON_VERSION: "${{ matrix.python-version }}"
-      TESTS: "tests/"
 
     strategy:
       # Prevent all build to stop if a single one fails
@@ -108,17 +107,29 @@ jobs:
       if: matrix.name == 'pytest-docker-py36-gcc-omp'
       run: |
           docker build . --file docker/Dockerfile --tag devito_img
-          echo "::set-env name=RUN_CMD::docker run --rm --name testrun devito_img"
+
+    - name: Set run prefix
+      run: |
+          if [ "${{ matrix.name }}" == 'pytest-docker-py36-gcc-omp' ]; then
+              echo "::set-output name=RUN_CMD::docker run --rm --name testrun devito_img"
+          else
+              echo "::set-output name=RUN_CMD::"
+          fi
+      id: set-run
 
     - name: Install GCC ${{ matrix.arch }}
       if: runner.os == 'linux'
       run : |
         sudo apt-get install -y ${{ matrix.arch }}
 
-    - name: Reduce number of tests for OSX
-      if: runner.os == 'macOS'
+    - name: Set tests (reduced number for OSX)
       run : |
-        echo "::set-env name=TESTS::tests/test_operator.py"
+          if [ "${{ runner.os }}" == 'macOS' ]; then
+              echo "::set-output name=TESTS::tests/test_operator.py"
+          else
+              echo "::set-output name=TESTS::tests/"
+          fi
+      id: set-tests
 
     - name: Install dependencies
       if: matrix.name != 'pytest-docker-py36-gcc-omp'
@@ -128,7 +139,7 @@ jobs:
 
     - name: Test with pytest
       run: |
-        $RUN_CMD pytest -m "not parallel" --cov --cov-config=.coveragerc --cov-report=xml $TESTS
+        ${{ steps.set-run.outputs.RUN_CMD }} pytest -m "not parallel" --cov --cov-config=.coveragerc --cov-report=xml ${{ steps.set-tests.outputs.TESTS }}
 
     - name: Upload coverage to Codecov
       if: matrix.name != 'pytest-docker-py36-gcc-omp'

--- a/.github/workflows/pytest-gpu.yml
+++ b/.github/workflows/pytest-gpu.yml
@@ -19,6 +19,12 @@ jobs:
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.tags }}
 
+    env:
+      DEVITO_ARCH: ${{ matrix.arch }}
+      DEVITO_PLATFORM: ${{ matrix.platform }}
+      DEVITO_LANGUAGE: ${{ matrix.language }}
+      OMPI_CC: ${{ matrix.arch }}
+
     strategy:
       # Prevent all build to stop if a single one fails
       fail-fast: false
@@ -46,14 +52,6 @@ jobs:
     steps:
     - name: Checkout devito
       uses: actions/checkout@v1
-
-    - name: set environment variables
-      uses: allenevans/set-env@v1.0.0
-      with:
-        DEVITO_ARCH: ${{ matrix.arch }}
-        DEVITO_PLATFORM: ${{ matrix.platform }}
-        DEVITO_LANGUAGE: ${{ matrix.language }}
-        OMPI_CC: ${{ matrix.arch }}
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/tutorials.yml
+++ b/.github/workflows/tutorials.yml
@@ -20,7 +20,6 @@ jobs:
       DEVITO_LANGUAGE: ${{ matrix.language }}
       DEVITO_BACKEND: "core"
       PYTHON_VERSION: "3.7"
-      RUN_CMD: ""
 
     strategy:
       # Prevent all build to stop if a single one fails
@@ -77,7 +76,15 @@ jobs:
       if: matrix.name == 'tutos-docker-gcc-py36'
       run: |
           docker build . --file docker/Dockerfile --tag devito_img
-          echo "::set-env name=RUN_CMD::docker run --rm --name testrun devito_img"
+
+    - name: Set run prefix
+      run: |
+          if [ "${{ matrix.name }}" == 'tutos-docker-gcc-py36' ]; then
+              echo "::set-output name=RUN_CMD::docker run --rm --name testrun devito_img"
+          else
+              echo "::set-output name=RUN_CMD::"
+          fi
+      id: set-run
 
     - name: Install dependencies
       if: matrix.name != 'tutos-docker-gcc-py36'
@@ -88,41 +95,41 @@ jobs:
 
     - name: Seismic notebooks
       run: |
-        $RUN_CMD py.test --nbval --cov . --cov-config=.coveragerc --cov-report=xml:seis_coverage.xml -k 'not dask' examples/seismic/tutorials/  # Horrible, but we're still at a loss
-        $RUN_CMD py.test --nbval --cov . --cov-config=.coveragerc --cov-report=xml:acc_coverage.xml examples/seismic/acoustic/accuracy.ipynb
+        ${{ steps.set-run.outputs.RUN_CMD }} py.test --nbval --cov . --cov-config=.coveragerc --cov-report=xml:seis_coverage.xml -k 'not dask' examples/seismic/tutorials/  # Horrible, but we're still at a loss
+        ${{ steps.set-run.outputs.RUN_CMD }} py.test --nbval --cov . --cov-config=.coveragerc --cov-report=xml:acc_coverage.xml examples/seismic/acoustic/accuracy.ipynb
 
     - name: Dask notebooks
       if: runner.os != 'macOS'
       run: |
-          $RUN_CMD py.test --nbval --cov . --cov-config=.coveragerc --cov-report=xml:seis_coverage.xml examples/seismic/tutorials/*dask*.ipynb
+          ${{ steps.set-run.outputs.RUN_CMD }} py.test --nbval --cov . --cov-config=.coveragerc --cov-report=xml:seis_coverage.xml examples/seismic/tutorials/*dask*.ipynb
 
     - name: Self-adjoint notebooks
       run: |
-        $RUN_CMD py.test --nbval --cov . --cov-config=.coveragerc --cov-report=xml:sa_coverage.xml examples/seismic/self_adjoint/
+        ${{ steps.set-run.outputs.RUN_CMD }} py.test --nbval --cov . --cov-config=.coveragerc --cov-report=xml:sa_coverage.xml examples/seismic/self_adjoint/
 
     - name: CFD notebooks
       run: |
-        $RUN_CMD py.test --nbval --cov . --cov-config=.coveragerc --cov-report=xml:cfd_coverage.xml examples/cfd
+        ${{ steps.set-run.outputs.RUN_CMD }} py.test --nbval --cov . --cov-config=.coveragerc --cov-report=xml:cfd_coverage.xml examples/cfd
 
     - name: User api notebooks
       run: |
-        $RUN_CMD py.test --nbval --cov . --cov-config=.coveragerc --cov-report=xml:api_coverage.xml examples/userapi
+        ${{ steps.set-run.outputs.RUN_CMD }} py.test --nbval --cov . --cov-config=.coveragerc --cov-report=xml:api_coverage.xml examples/userapi
 
     - name: Compiler notebooks
       run: |
-        $RUN_CMD py.test --nbval --cov . --cov-config=.coveragerc --cov-report=xml:comp_coverage.xml examples/compiler
+        ${{ steps.set-run.outputs.RUN_CMD }} py.test --nbval --cov . --cov-config=.coveragerc --cov-report=xml:comp_coverage.xml examples/compiler
         
     - name: Finance notebooks
       run: |
-        $RUN_CMD py.test --nbval --cov . --cov-config=.coveragerc --cov-report=xml:comp_coverage.xml examples/finance
+        ${{ steps.set-run.outputs.RUN_CMD }} py.test --nbval --cov . --cov-config=.coveragerc --cov-report=xml:comp_coverage.xml examples/finance
 
     - name: Performance notebooks
       run: |
-        $RUN_CMD py.test --nbval --cov . --cov-config=.coveragerc --cov-report=xml:comp_coverage.xml examples/performance
+        ${{ steps.set-run.outputs.RUN_CMD }} py.test --nbval --cov . --cov-config=.coveragerc --cov-report=xml:comp_coverage.xml examples/performance
 
     - name: ABC Notebooks
       run: |
-        $RUN_CMD py.test --nbval --cov . --cov-config=.coveragerc --cov-report=xml:comp_coverage.xml examples/seismic/abc_methods
+        ${{ steps.set-run.outputs.RUN_CMD }} py.test --nbval --cov . --cov-config=.coveragerc --cov-report=xml:comp_coverage.xml examples/seismic/abc_methods
 
     - name: Upload coverage to Codecov
       if: matrix.name != 'tutos-docker-gcc-py36'


### PR DESCRIPTION
Updating various workflows owing to the [deprecation](https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/) of `set-env`.