### PR TITLE
CI: Update gpu workflow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -88,7 +88,7 @@ jobs:
   # Comment out until gpu docker image problem resolved
   test-gpu-image:
     needs: deploy-docker
-    runs-on: [self-hosted, gpu]
+    runs-on: [self-hosted, gpu, docker]
 
     strategy:
       fail-fast: false

--- a/.github/workflows/pytest-gpu.yml
+++ b/.github/workflows/pytest-gpu.yml
@@ -4,17 +4,72 @@
 
 name: CI-gpu
 
+env:
+  OUTPUT_PATH: ${{ github.workspace }}
+  RESOURCE_GROUP: CI-gpu
+
 on:
-  # Trigger the workflow on push or pull request,
-  # but only for the master branch
-  push:
-    branches:
-      - master
-  pull_request:
-    branches:
-      - master
+  workflow_dispatch:
+    inputs:
+      tags:
+        description: 'Run GPU tests'
 
 jobs:
+  # Start the self-hosted runner and start runner app
+  start-runners:
+    name: ${{ matrix.name }}
+    runs-on: ubuntu-latest
+
+    strategy:
+      # Prevent all build to stop if a single one fails
+      fail-fast: false
+
+      matrix:
+        name: [
+          start-runner-omp,
+          start-runner-acc
+        ]
+        include:
+        - name: start-runner-omp
+          vm_name: gpu-runner-04
+
+        - name: start-runner-acc
+          vm_name: gpu-runner-01
+
+    steps:
+    - name: checkout repo
+      uses: actions/checkout@v2.3.2
+
+    - name: start VM
+      env:
+        SP_APPID: ${{ secrets.SERVICE_PRINCIPAL_APPID }}
+        SP_SECRET: ${{ secrets.SERVICE_PRINCIPAL_SECRET }}
+        TENANT_ID: ${{ secrets.SERVICE_PRINCIPAL_TENANTID }}
+        SUB_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+      run: >
+        pwsh -command "& '${{ env.OUTPUT_PATH }}\.github\azure\startVM.ps1'"
+        -servicePrincipal $SP_APPID
+        -servicePrincipalSecret $SP_SECRET
+        -servicePrincipalTenantId $TENANT_ID
+        -azureSubscriptionName $SUB_ID
+        -resourceGroupName $RESOURCE_GROUP
+        -vmName ${{ matrix.vm_name }}
+
+    - name: set host
+      run: echo ::set-output name=action_host::$(az vm show -d -g $RESOURCE_GROUP -n $VM_NAME --query publicIps -o tsv)
+      id: host
+
+    - name: start actions runner app
+      uses: fifsky/ssh-action@master
+      with:
+        command: |
+          #!/bin/bash
+          nohup actions-runner/run.sh >/dev/null 2>&1 &
+        host: ${{ steps.host.outputs.action_host }}
+        user: ${{ secrets.CI_GPU_VM_ADMIN_LOGIN }}
+        pass: ${{ secrets.CI_GPU_VM_ADMIN_PASSWORD }}
+        args: "-tt"
+
   build:
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.tags }}
@@ -86,3 +141,45 @@ jobs:
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         name: ${{ matrix.name }}
+
+  # Deallocate runners
+  stop-runner:
+    name: ${{ matrix.name }}
+    if: ${{ always() }}
+    needs: benchmarks
+    runs-on: ubuntu-latest
+
+    strategy:
+      # Prevent all build to stop if a single one fails
+      fail-fast: false
+
+      matrix:
+        name: [
+          stop-runner-omp,
+          stop-runner-acc
+        ]
+        include:
+        - name: start-runner-omp
+          vm_name: gpu-runner-04
+
+        - name: start-runner-acc
+          vm_name: gpu-runner-01
+
+    steps:
+    - name: checkout repo
+      uses: actions/checkout@v2.3.2
+
+    - name: stop VM
+      env:
+        SP_APPID: ${{ secrets.SERVICE_PRINCIPAL_APPID }}
+        SP_SECRET: ${{ secrets.SERVICE_PRINCIPAL_SECRET }}
+        TENANT_ID: ${{ secrets.SERVICE_PRINCIPAL_TENANTID }}
+        SUB_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+      run: >
+        pwsh -command "& '${{ env.OUTPUT_PATH }}\.github\azure\stopVM.ps1'"
+        -servicePrincipal $SP_APPID
+        -servicePrincipalSecret $SP_SECRET
+        -servicePrincipalTenantId $TENANT_ID
+        -azureSubscriptionName $SUB_ID
+        -resourceGroupName $RESOURCE_GROUP
+        -vmName ${{ matrix.vm_name }}

--- a/.github/workflows/pytest-gpu.yml
+++ b/.github/workflows/pytest-gpu.yml
@@ -143,7 +143,7 @@ jobs:
         name: ${{ matrix.name }}
 
   # Deallocate runners
-  stop-runner:
+  stop-runners:
     name: ${{ matrix.name }}
     if: ${{ always() }}
     needs: benchmarks
@@ -159,10 +159,10 @@ jobs:
           stop-runner-acc
         ]
         include:
-        - name: start-runner-omp
+        - name: stop-runner-omp
           vm_name: gpu-runner-04
 
-        - name: start-runner-acc
+        - name: stop-runner-acc
           vm_name: gpu-runner-01
 
     steps:


### PR DESCRIPTION
This, for the time being, supersedes #1537. GPU tests will now be run on demand via workflow dispatch and the runners started and stopped during the workflow.