### PR TITLE
Data streaming support with OpenMP offloading

### DIFF
--- a/devito/core/gpu_openmp.py
+++ b/devito/core/gpu_openmp.py
@@ -9,12 +9,11 @@ from devito.core.operator import OperatorCore
 from devito.data import FULL
 from devito.exceptions import InvalidOperator
 from devito.ir.equations import DummyEq
-from devito.ir.iet import (Block, Call, Callable, ElementalFunction, Expression,
-                           List, LocalExpression, ThreadFunction, FindNodes,
-                           FindSymbols, MapExprStmts, Transformer)
+from devito.ir.iet import (Block, Call, Callable, ElementalFunction, EntryFunction,
+                           Expression, List, LocalExpression, ThreadFunction,
+                           FindNodes, FindSymbols, MapExprStmts, Transformer)
 from devito.mpi.distributed import MPICommObject
-from devito.mpi.routines import (CopyBuffer, HaloUpdate, IrecvCall, IsendCall, SendRecv,
-                                 MPICallable)
+from devito.mpi.routines import CopyBuffer, HaloUpdate, IrecvCall, IsendCall, SendRecv
 from devito.passes.equations import collect_derivatives, buffering
 from devito.passes.clusters import (Blocking, Lift, Streaming, Tasker, cire, cse,
                                     eliminate_arrays, extract_increments, factorize,
@@ -326,6 +325,10 @@ def initialize(iet, **kwargs):
 
     @singledispatch
     def _initialize(iet):
+        return iet
+
+    @_initialize.register(EntryFunction)
+    def _(iet):
         comm = None
 
         for i in iet.parameters:
@@ -352,12 +355,6 @@ def initialize(iet, **kwargs):
 
             iet = iet._rebuild(body=(init,) + iet.body)
 
-        return iet
-
-    @_initialize.register(ElementalFunction)
-    @_initialize.register(ThreadFunction)
-    @_initialize.register(MPICallable)
-    def _(iet):
         return iet
 
     iet = _initialize(iet)

--- a/devito/core/gpu_openmp.py
+++ b/devito/core/gpu_openmp.py
@@ -10,8 +10,8 @@ from devito.data import FULL
 from devito.exceptions import InvalidOperator
 from devito.ir.equations import DummyEq
 from devito.ir.iet import (Block, Call, Callable, ElementalFunction, Expression,
-                           List, FindNodes, FindSymbols, LocalExpression,
-                           MapExprStmts, Transformer)
+                           List, LocalExpression, ThreadFunction, FindNodes,
+                           FindSymbols, MapExprStmts, Transformer)
 from devito.mpi.distributed import MPICommObject
 from devito.mpi.routines import (CopyBuffer, HaloUpdate, IrecvCall, IsendCall, SendRecv,
                                  MPICallable)
@@ -306,9 +306,7 @@ class DeviceOpenMPDataManager(DataManager):
             return iet
 
         @_map_onmemspace.register(ElementalFunction)
-        def _(iet):
-            return iet
-
+        @_map_onmemspace.register(ThreadFunction)
         @_map_onmemspace.register(CopyBuffer)
         @_map_onmemspace.register(SendRecv)
         @_map_onmemspace.register(HaloUpdate)
@@ -357,6 +355,7 @@ def initialize(iet, **kwargs):
         return iet
 
     @_initialize.register(ElementalFunction)
+    @_initialize.register(ThreadFunction)
     @_initialize.register(MPICallable)
     def _(iet):
         return iet

--- a/devito/ir/iet/efunc.py
+++ b/devito/ir/iet/efunc.py
@@ -6,9 +6,9 @@ import cgen as c
 
 from devito.ir.iet.nodes import (BlankLine, Call, Callable, Conditional, Dereference,
                                  DummyExpr, Iteration, List, PointerCast, Return, While)
-from devito.ir.iet.utils import derive_parameters
+from devito.ir.iet.utils import derive_parameters, diff_parameters
 from devito.symbolics import CondEq, CondNe, FieldFromComposite, FieldFromPointer, Macro
-from devito.tools import as_tuple, split
+from devito.tools import as_tuple
 from devito.types import PThreadArray, SharedData, Symbol, VoidPointer
 
 __all__ = ['ElementalFunction', 'ElementalCall', 'make_efunc',
@@ -160,9 +160,7 @@ def _make_thread_init(threads, tfunc, isdata, sdata, sregistry):
 def _make_thread_func(name, iet, root, threads, sregistry):
     # Create the SharedData, that is the data structure that will be used by the
     # main thread to pass information dows to the child thread(s)
-    required = derive_parameters(iet)
-    known = root.parameters + tuple(i for i in required if i.is_Array and i._mem_shared)
-    parameters, dynamic_parameters = split(required, lambda i: i in known)
+    required, parameters, dynamic_parameters = diff_parameters(iet, root)
     sdata = SharedData(name=sregistry.make_name(prefix='sdata'), npthreads=threads.size,
                        fields=required, dynamic_fields=dynamic_parameters)
 

--- a/devito/ir/iet/efunc.py
+++ b/devito/ir/iet/efunc.py
@@ -140,6 +140,7 @@ def _make_thread_init(threads, tfunc, isdata, sdata, sregistry):
 
     # Initialize `sdata`
     arguments = list(isdata.parameters)
+    arguments[-2] = sdata.symbolic_base + d
     arguments[-1] = pthreadid
     call0 = Call(isdata.name, arguments)
 

--- a/devito/ir/iet/efunc.py
+++ b/devito/ir/iet/efunc.py
@@ -7,10 +7,9 @@ import cgen as c
 from devito.ir.iet.nodes import (BlankLine, Call, Callable, Conditional, Dereference,
                                  DummyExpr, Iteration, List, PointerCast, Return, While)
 from devito.ir.iet.utils import derive_parameters
-from devito.symbolics import (CondEq, CondNe, FieldFromComposite, FieldFromPointer,
-                              Literal, Macro)
+from devito.symbolics import CondEq, CondNe, FieldFromComposite, FieldFromPointer, Macro
 from devito.tools import as_tuple, split
-from devito.types import LocalObject, PThreadArray, SharedData, Symbol, VoidPointer
+from devito.types import PThreadArray, SharedData, Symbol, VoidPointer
 
 __all__ = ['ElementalFunction', 'ElementalCall', 'make_efunc',
            'EntryFunction', 'ThreadFunction', 'make_thread_ctx']
@@ -137,7 +136,7 @@ def _make_thread_init(threads, tfunc, isdata, sdata, sregistry):
 
     # A unique identifier for each created pthread
     other_thread_pools = set(sregistry.npthreads) - {threads.size}
-    pthreadid = 1 + sum(i.data for i in other_thread_pools) + threads.dim
+    pthreadid = 1 + sum(i.data for i in other_thread_pools) + d
 
     # Initialize `sdata`
     arguments = list(isdata.parameters)
@@ -172,7 +171,7 @@ def _make_thread_func(name, iet, root, threads, sregistry):
 
     # Create a Callable to initialize `sdata` with the known const values
     iname = 'init_%s' % sdata.dtype._type_.__name__
-    ibody = [DummyExpr(FieldFromPointer(i._C_name, sbase), Literal(i._C_name))
+    ibody = [DummyExpr(FieldFromPointer(i._C_name, sbase), i._C_symbol)
              for i in parameters]
     ibody.extend([
         BlankLine,

--- a/devito/ir/iet/efunc.py
+++ b/devito/ir/iet/efunc.py
@@ -162,6 +162,7 @@ def _make_thread_func(name, iet, root, threads, sregistry):
     # Create the SharedData, that is the data structure that will be used by the
     # main thread to pass information dows to the child thread(s)
     required, parameters, dynamic_parameters = diff_parameters(iet, root)
+    parameters = sorted(parameters, key=lambda i: i.is_Function)  # Allow casting
     sdata = SharedData(name=sregistry.make_name(prefix='sdata'), npthreads=threads.size,
                        fields=required, dynamic_fields=dynamic_parameters)
 

--- a/devito/ir/iet/efunc.py
+++ b/devito/ir/iet/efunc.py
@@ -116,7 +116,7 @@ def make_tfunc(name, iet, root, threads, sregistry):
     parameters, dynamic_parameters = split(required, lambda i: i in known)
 
     sdata = SharedData(name=sregistry.make_name(prefix='sdata'),
-                       nthreads_std=threads.size, fields=dynamic_parameters)
+                       npthreads=threads.size, fields=dynamic_parameters)
     parameters.append(sdata)
 
     # Prepend the unwinded SharedData fields, available upon thread activation

--- a/devito/ir/iet/nodes.py
+++ b/devito/ir/iet/nodes.py
@@ -16,8 +16,7 @@ from devito.ir.support import (SEQUENTIAL, PARALLEL, PARALLEL_IF_ATOMIC, VECTORI
 from devito.symbolics import ListInitializer, FunctionFromPointer, as_symbol, ccode
 from devito.tools import (Signer, as_tuple, filter_ordered, filter_sorted, flatten,
                           validate_type)
-from devito.types import Symbol, Indexed
-from devito.types.basic import AbstractFunction
+from devito.types.basic import AbstractFunction, Indexed, LocalObject, Symbol
 
 __all__ = ['Node', 'Block', 'Expression', 'Element', 'Callable', 'Call', 'Conditional',
            'Iteration', 'List', 'LocalExpression', 'Section', 'TimedList', 'Prodder',
@@ -269,12 +268,13 @@ class Call(ExprStmt, Node):
 
     @property
     def functions(self):
-        retval = tuple(i for i in self.arguments if isinstance(i, AbstractFunction))
+        retval = [i.function for i in self.arguments
+                  if isinstance(i, (AbstractFunction, Indexed, LocalObject))]
         if self.base is not None:
-            retval += (self.base.function,)
+            retval.append(self.base.function)
         if self.retobj is not None:
-            retval += (self.retobj.function,)
-        return retval
+            retval.append(self.retobj.function)
+        return tuple(retval)
 
     @property
     def children(self):

--- a/devito/ir/iet/nodes.py
+++ b/devito/ir/iet/nodes.py
@@ -771,7 +771,7 @@ class TimedList(List):
         return (self.timer,)
 
 
-class PointerCast(Node):
+class PointerCast(ExprStmt, Node):
 
     """
     A node encapsulating a cast of a raw C pointer to a multi-dimensional array.
@@ -779,8 +779,9 @@ class PointerCast(Node):
 
     is_PointerCast = True
 
-    def __init__(self, function):
+    def __init__(self, function, obj=None):
         self.function = function
+        self.obj = obj
 
     def __repr__(self):
         return "<PointerCast(%s)>" % self.function
@@ -821,7 +822,12 @@ class PointerCast(Node):
 class Dereference(ExprStmt, Node):
 
     """
-    A node encapsulating a dereference from a PointerArray to an Array.
+    A node encapsulating a dereference from an object `parray` to another object
+    `array`. Two possibilities are supported:
+
+        * `parray` is a PointerArray and `array` is an Array (default case)
+        * `parray` is an ArrayObject representing a pointer to a C struct while
+          `array` is a field in `parray`.
     """
 
     is_Dereference = True

--- a/devito/ir/iet/nodes.py
+++ b/devito/ir/iet/nodes.py
@@ -23,7 +23,7 @@ __all__ = ['Node', 'Block', 'Expression', 'Element', 'Callable', 'Call', 'Condit
            'MetaCall', 'PointerCast', 'ForeignExpression', 'HaloSpot', 'IterationTree',
            'ExpressionBundle', 'AugmentedExpression', 'Increment', 'Return', 'While',
            'ParallelIteration', 'ParallelBlock', 'Dereference', 'Lambda', 'SyncSpot',
-           'DummyExpr', 'BlankLine']
+           'PragmaList', 'DummyExpr', 'BlankLine']
 
 # First-class IET nodes
 
@@ -1044,6 +1044,29 @@ class Prodder(Call):
     @property
     def periodic(self):
         return self._periodic
+
+
+class PragmaList(List):
+
+    """
+    A floating sequence of pragmas.
+    """
+
+    def __init__(self, pragmas, functions=None, **kwargs):
+        super().__init__(header=pragmas)
+        self._functions = as_tuple(functions)
+
+    @property
+    def pragmas(self):
+        return self.header
+
+    @property
+    def functions(self):
+        return self._functions
+
+    @property
+    def free_symbols(self):
+        return self._functions
 
 
 class ParallelIteration(Iteration):

--- a/devito/ir/iet/nodes.py
+++ b/devito/ir/iet/nodes.py
@@ -287,7 +287,7 @@ class Call(ExprStmt, Node):
             if isinstance(i, numbers.Number):
                 continue
             elif isinstance(i, AbstractFunction):
-                if i.is_Array:
+                if i.is_ArrayBasic:
                     free.add(i)
                 else:
                     # Always passed by _C_name since what actually needs to be

--- a/devito/ir/iet/visitors.py
+++ b/devito/ir/iet/visitors.py
@@ -805,7 +805,7 @@ class MultilineCall(c.Generable):
         if not self.is_indirect:
             tip = "%s(" % self.name
         else:
-            tip = "%s," % self.name
+            tip = "%s%s" % (self.name, ',' if self.arguments else '')
         processed = []
         for i in self.arguments:
             if isinstance(i, (MultilineCall, LambdaCollection)):

--- a/devito/ir/support/utils.py
+++ b/devito/ir/support/utils.py
@@ -142,7 +142,7 @@ def detect_io(exprs, relax=False):
     reads = []
     terminals = flatten(retrieve_terminals(i, deep=True) for i in roots)
     for i in terminals:
-        candidates = i.free_symbols
+        candidates = set(i.free_symbols)
         try:
             candidates.update({i.function})
         except AttributeError:

--- a/devito/operator/operator.py
+++ b/devito/operator/operator.py
@@ -11,7 +11,7 @@ from devito.exceptions import InvalidOperator
 from devito.logger import info, perf, warning, is_log_enabled_for
 from devito.ir.equations import LoweredEq, lower_exprs, generate_implicit_exprs
 from devito.ir.clusters import ClusterGroup, clusterize
-from devito.ir.iet import Callable, MetaCall, derive_parameters, iet_build
+from devito.ir.iet import Callable, EntryFunction, MetaCall, derive_parameters, iet_build
 from devito.ir.stree import stree_build
 from devito.operator.profiling import create_profile
 from devito.operator.registry import operator_selector
@@ -387,9 +387,10 @@ class Operator(Callable):
         # Analyze the IET Sections for C-level profiling
         profiler.analyze(iet)
 
-        # Wrap the IET with a Callable
+        # Wrap the IET with an EntryFunction (a special Callable representing
+        # the entry point of the generated library)
         parameters = derive_parameters(iet, True)
-        iet = Callable(name, iet, 'int', parameters, ())
+        iet = EntryFunction(name, iet, 'int', parameters, ())
 
         # Lower IET to a target-specific IET
         graph = Graph(iet)

--- a/devito/operator/symbols.py
+++ b/devito/operator/symbols.py
@@ -38,6 +38,7 @@ class SymbolRegistry(object):
         return "%s%d" % (prefix, counter())
 
     def make_npthreads(self, value):
-        npthreads = NPThreads(name='npthreads', value=value)
+        name = self.make_name(prefix='npthreads')
+        npthreads = NPThreads(name=name, value=value)
         self.npthreads.append(npthreads)
         return npthreads

--- a/devito/operator/symbols.py
+++ b/devito/operator/symbols.py
@@ -1,4 +1,5 @@
 from devito.tools import generator
+from devito.types import NPThreads
 
 __init__ = ['SymbolRegistry']
 
@@ -20,6 +21,10 @@ class SymbolRegistry(object):
         self.nthreads_nonaffine = nthreads_nonaffine
         self.threadid = threadid
 
+        # Several groups of pthreads each of size `npthread` may be created
+        # during compilation
+        self.npthreads = []
+
     def make_name(self, prefix=None):
         # By default we're creating a new symbol
         if prefix is None:
@@ -31,3 +36,8 @@ class SymbolRegistry(object):
             counter = self.counters.setdefault(prefix, generator())
 
         return "%s%d" % (prefix, counter())
+
+    def make_npthreads(self, value):
+        npthreads = NPThreads(name='npthreads', value=value)
+        self.npthreads.append(npthreads)
+        return npthreads

--- a/devito/passes/iet/definitions.py
+++ b/devito/passes/iet/definitions.py
@@ -108,8 +108,7 @@ class DataManager(object):
         Allocate an Array of Objects in the low latency memory.
         """
         shape = "".join("[%s]" % ccode(i) for i in obj.symbolic_shape)
-        alignment = "__attribute__((aligned(%d)))" % obj._data_alignment
-        decl = "%s%s %s" % (obj.name, shape, alignment)
+        decl = "%s%s" % (obj.name, shape)
 
         storage.update(obj, site, allocs=c.Value(obj._C_typedata, decl))
 
@@ -220,13 +219,15 @@ class DataManager(object):
                 objs = list(k.functions)
                 if k.retobj is not None:
                     objs.append(k.retobj.function)
+            elif k.is_PointerCast:
+                placed.append(k.function)
+                objs = []
 
             for i in objs:
                 if i in placed:
                     continue
 
                 try:
-                    #TODO: DROP TRY-EXCPET FINALLY??
                     if i.is_LocalObject:
                         # LocalObject's get placed as close as possible to
                         # their first appearence

--- a/devito/passes/iet/definitions.py
+++ b/devito/passes/iet/definitions.py
@@ -289,8 +289,8 @@ class DataManager(object):
         need_cast = {i for i in functions if i.is_Tensor}
 
         # Make the generated code less verbose by avoiding unnecessary casts
-        indexed_names = {i.name for i in FindSymbols('indexeds').visit(iet)}
-        need_cast = {i for i in need_cast if i.name in indexed_names or i.is_ArrayBasic}
+        symbol_names = {i.name for i in FindSymbols('free-symbols').visit(iet)}
+        need_cast = {i for i in need_cast if i.name in symbol_names}
 
         casts = tuple(PointerCast(i) for i in iet.parameters if i in need_cast)
         if casts:

--- a/devito/passes/iet/definitions.py
+++ b/devito/passes/iet/definitions.py
@@ -217,7 +217,7 @@ class DataManager(object):
                 else:
                     objs = [k.parray]
             elif k.is_Call:
-                objs = list(k.arguments)
+                objs = list(k.functions)
                 if k.retobj is not None:
                     objs.append(k.retobj.function)
 
@@ -226,6 +226,7 @@ class DataManager(object):
                     continue
 
                 try:
+                    #TODO: DROP TRY-EXCPET FINALLY??
                     if i.is_LocalObject:
                         # LocalObject's get placed as close as possible to
                         # their first appearence

--- a/devito/passes/iet/orchestration.py
+++ b/devito/passes/iet/orchestration.py
@@ -165,7 +165,7 @@ class Orchestrator(object):
 
         # Turn prefetch IET into a ThreadFunction
         name = self.sregistry.make_name(prefix='prefetch_host_to_device')
-        body = List(header=c.Line(), body=casts + prefetches)
+        body = List(header=c.Line(), body=prefetches)
         tctx = make_thread_ctx(name, body, root, None, sync_ops, self.sregistry)
         pieces.funcs.extend(tctx.funcs)
 

--- a/devito/passes/iet/orchestration.py
+++ b/devito/passes/iet/orchestration.py
@@ -69,8 +69,9 @@ class Orchestrator(object):
                      for d in s.target.dimensions]
 
             update = self._P._map_update_wait_host(s.target, imask, SharedData._field_id)
-            preactions.append(List(body=[BlankLine, update, DummyExpr(s.handle, 1)]))
+            update = List(header=update)
 
+            preactions.append(List(body=[BlankLine, update, DummyExpr(s.handle, 1)]))
             postactions.append(DummyExpr(s.handle, 2))
         preactions.append(BlankLine)
         postactions.insert(0, BlankLine)

--- a/devito/tools/utils.py
+++ b/devito/tools/utils.py
@@ -221,17 +221,21 @@ def ctypes_to_cstr(ctype, toarray=None):
     elif issubclass(ctype, ctypes.Array):
         return '%s[%d]' % (ctypes_to_cstr(ctype._type_, toarray), ctype._length_)
     elif ctype.__name__.startswith('c_'):
+        if ctype.__name__.startswith('c_volatile_'):
+            name = 'volatile %s' % ctype.__name__[11:]
+        else:
+            name = ctype.__name__[2:]
         # A primitive datatype
         # FIXME: Is there a better way of extracting the C typename ?
         # Here, we're following the ctypes convention that each basic type has
         # either the format c_X_p or c_X, where X is the C typename, for instance
         # `int` or `float`.
-        if ctype.__name__.endswith('_p'):
-            return '%s *' % ctype.__name__[2:-2]
+        if name.endswith('_p'):
+            return '%s *' % name[:-2]
         elif toarray:
-            return '%s %s' % (ctype.__name__[2:], toarray)
+            return '%s %s' % (name, toarray)
         else:
-            return ctype.__name__[2:]
+            return name
     else:
         # A custom datatype (e.g., a typedef-ed pointer to struct)
         return ctype.__name__

--- a/devito/types/array.py
+++ b/devito/types/array.py
@@ -22,6 +22,10 @@ class ArrayBasic(AbstractFunction):
         return as_tuple(kwargs['dimensions']), as_tuple(kwargs['dimensions'])
 
     @property
+    def _C_ctype(self):
+        return POINTER(dtype_to_ctype(self.dtype))
+
+    @property
     def shape(self):
         return self.symbolic_shape
 
@@ -133,7 +137,7 @@ class Array(ArrayBasic):
 
     @property
     def _C_typename(self):
-        return ctypes_to_cstr(POINTER(dtype_to_ctype(self.dtype)))
+        return ctypes_to_cstr(self._C_ctype)
 
     @property
     def space(self):
@@ -231,7 +235,7 @@ class ArrayObject(ArrayBasic):
 
     @classmethod
     def __pfields_setup__(cls, **kwargs):
-        return [(i.name, i._C_ctype) for i in kwargs.get('fields', [])]
+        return [(i._C_name, i._C_ctype) for i in kwargs.get('fields', [])]
 
     @cached_property
     def _C_typename(self):
@@ -312,7 +316,7 @@ class PointerArray(ArrayBasic):
 
     @property
     def _C_typename(self):
-        return ctypes_to_cstr(POINTER(POINTER(dtype_to_ctype(self.dtype))))
+        return ctypes_to_cstr(POINTER(self._C_ctype))
 
     @property
     def dim(self):

--- a/devito/types/array.py
+++ b/devito/types/array.py
@@ -220,7 +220,7 @@ class ArrayObject(ArrayBasic):
 
     def __init_finalize__(self, *args, **kwargs):
         name = kwargs['name']
-        fields = kwargs.pop('fields', [])
+        fields = tuple(kwargs.pop('fields', ()))
 
         self._fields = fields
         self._pname = "t%s" % name

--- a/devito/types/basic.py
+++ b/devito/types/basic.py
@@ -902,7 +902,7 @@ class AbstractFunction(sympy.Function, Basic, Cached, Pickable, Evaluable):
 
     @cached_property
     def _C_symbol(self):
-        return Symbol(name=self._C_name, dtype=self.dtype)
+        return BoundSymbol(name=self._C_name, dtype=self.dtype, function=self.function)
 
     @cached_property
     def _size_domain(self):
@@ -1201,6 +1201,22 @@ class IndexedData(sympy.IndexedBase, Pickable):
     # Pickling support
     _pickle_kwargs = ['label', 'shape', 'function']
     __reduce_ex__ = Pickable.__reduce_ex__
+
+
+class BoundSymbol(Symbol):
+
+    """
+    Wrapper class for Symbols that are bound to a symbolic data object.
+    """
+
+    def __init_finalize__(self, *args, function=None, **kwargs):
+        self._function = function
+
+        super().__init_finalize__(*args, **kwargs)
+
+    @property
+    def function(self):
+        return self._function
 
 
 class Indexed(sympy.Indexed):

--- a/devito/types/basic.py
+++ b/devito/types/basic.py
@@ -164,6 +164,19 @@ class Basic(object):
         """
         return
 
+    @property
+    def _C_symbol(self):
+        """
+        The C-level symbol. This may or may not coincide with the symbol used
+        to make up an `Eq`. For example, if `self` provides the C code with
+        a struct, then the _C_symbol will be the symbol representing such struct.
+
+        Returns
+        -------
+        Basic
+        """
+        return self
+
 
 class AbstractSymbol(sympy.Symbol, Basic, Pickable, Evaluable):
 
@@ -886,6 +899,10 @@ class AbstractFunction(sympy.Function, Basic, Cached, Pickable, Evaluable):
     @property
     def _C_typedata(self):
         return dtype_to_cstr(self.dtype)
+
+    @cached_property
+    def _C_symbol(self):
+        return Symbol(name=self._C_name, dtype=self.dtype)
 
     @cached_property
     def _size_domain(self):

--- a/devito/types/dense.py
+++ b/devito/types/dense.py
@@ -715,7 +715,7 @@ class DiscreteFunction(AbstractFunction, ArgProvider, Differentiable):
     @memoized_meth
     def _C_get_field(self, region, dim, side=None):
         """Symbolic representation of a given data region."""
-        ffp = lambda f, i: FieldFromPointer("%s[%d]" % (f, i), self._C_name)
+        ffp = lambda f, i: FieldFromPointer("%s[%d]" % (f, i), self._C_symbol)
         if region is DOMAIN:
             offset = ffp(self._C_field_owned_ofs, self._C_make_index(dim, LEFT))
             size = ffp(self._C_field_domain_size, self._C_make_index(dim))

--- a/devito/types/dimension.py
+++ b/devito/types/dimension.py
@@ -769,9 +769,9 @@ class ConditionalDimension(DerivedDimension):
     def index(self):
         return self if self.indirect is True else self.parent
 
-    @property
+    @cached_property
     def free_symbols(self):
-        retval = super(ConditionalDimension, self).free_symbols
+        retval = set(super(ConditionalDimension, self).free_symbols)
         if self.condition is not None:
             retval |= self.condition.free_symbols
         return retval

--- a/devito/types/misc.py
+++ b/devito/types/misc.py
@@ -1,8 +1,9 @@
-from ctypes import c_double
+from ctypes import c_int, c_double, c_void_p
 
-from devito.types import CompositeObject
+from devito.types import CompositeObject, LocalObject, Symbol
 
-__all__ = ['Timer']
+__all__ = ['Timer', 'VoidPointer', 'VolatileInt', 'c_volatile_int',
+           'c_volatile_int_p']
 
 
 class Timer(CompositeObject):
@@ -34,3 +35,37 @@ class Timer(CompositeObject):
 
     # Pickling support
     _pickle_args = ['name', 'sections']
+
+
+class VoidPointer(LocalObject):
+
+    dtype = type('void*', (c_void_p,), {})
+
+    def __init__(self, name):
+        self.name = name
+
+    # Pickling support
+    _pickle_args = ['name']
+
+
+class VolatileInt(Symbol):
+
+    @property
+    def _C_typedata(self):
+        return 'volatile int'
+
+    _C_typename = _C_typedata
+
+    @property
+    def _C_ctype(self):
+        return c_volatile_int
+
+
+# ctypes subtypes
+
+class c_volatile_int(c_int):
+    pass
+
+
+class c_volatile_int_p(c_void_p):
+    pass

--- a/devito/types/sync.py
+++ b/devito/types/sync.py
@@ -15,7 +15,7 @@ import numpy as np
 import sympy
 
 from devito.parameters import configuration
-from devito.tools import Pickable, as_tuple, dtype_to_cstr, filter_ordered
+from devito.tools import Pickable, as_list, as_tuple, dtype_to_cstr, filter_ordered
 from devito.types.array import Array, ArrayObject
 from devito.types.basic import Symbol
 from devito.types.constant import Constant
@@ -147,15 +147,13 @@ class SharedData(ThreadArray):
     _symbolic_flag = VolatileInt(name=_field_flag)
 
     def __init_finalize__(self, *args, **kwargs):
-        self.dynamic_fields = kwargs.pop('dynamic_fields', ())
-
-        kwargs.setdefault('fields', []).extend([self._symbolic_id, self._symbolic_flag])
+        self.dynamic_fields = tuple(kwargs.pop('dynamic_fields', ()))
 
         super().__init_finalize__(*args, **kwargs)
 
     @classmethod
     def __pfields_setup__(cls, **kwargs):
-        fields = kwargs.get('fields', []) + [cls._symbolic_id, cls._symbolic_flag]
+        fields = as_list(kwargs.get('fields')) + [cls._symbolic_id, cls._symbolic_flag]
         return [(i._C_name, i._C_ctype) for i in fields]
 
     @cached_property

--- a/devito/types/sync.py
+++ b/devito/types/sync.py
@@ -164,6 +164,9 @@ class SharedData(ThreadArray):
     def symbolic_flag(self):
         return self._symbolic_flag
 
+    # Pickling support
+    _pickle_kwargs = ThreadArray._pickle_kwargs + ['dynamic_fields']
+
 
 class Lock(Array):
 

--- a/devito/types/sync.py
+++ b/devito/types/sync.py
@@ -10,7 +10,7 @@ import os
 from collections import defaultdict
 from ctypes import POINTER, c_int, c_void_p
 
-from cgen import Initializer, Struct, Value
+from cgen import Struct, Value
 from cached_property import cached_property
 import numpy as np
 import sympy

--- a/devito/types/sync.py
+++ b/devito/types/sync.py
@@ -128,9 +128,17 @@ class PThreadArray(ThreadArray):
 
     dtype = type('pthread_t', (c_void_p,), {})
 
+    def __init_finalize__(self, *args, **kwargs):
+        self.base_id = kwargs.pop('base_id')
+
+        super().__init_finalize__(*args, **kwargs)
+
     @classmethod
     def __dtype_setup__(cls, **kwargs):
         return cls.dtype
+
+    # Pickling support
+    _pickle_kwargs = ThreadArray._pickle_kwargs + ['base_id']
 
 
 class SharedData(ThreadArray):

--- a/tests/test_gpu_common.py
+++ b/tests/test_gpu_common.py
@@ -57,7 +57,6 @@ class Bundle(SubDomain):
         return {x: ('middle', 0, 0), y: ('middle', 0, 0), z: ('middle', 0, 0)}
 
 
-@skipif('device-openmp')  # TODO: Still unsupported with OpenMP, but soon will be
 class TestStreaming(object):
 
     def test_tasking_in_isolation(self):
@@ -271,6 +270,7 @@ class TestStreaming(object):
         assert str(sections[1].body[0].body[0].body[0].body[0]) ==\
             'while(lock0[t1] == 0);'
 
+    @skipif('device-openmp')  # TODO: Still unsupported with OpenMP, but soon will be
     def test_streaming_simple(self):
         nt = 10
         grid = Grid(shape=(4, 4))
@@ -290,6 +290,7 @@ class TestStreaming(object):
         assert np.all(u.data[0] == 28)
         assert np.all(u.data[1] == 36)
 
+    @skipif('device-openmp')  # TODO: Still unsupported with OpenMP, but soon will be
     def test_streaming_two_buffers(self):
         nt = 10
         grid = Grid(shape=(4, 4))
@@ -311,6 +312,7 @@ class TestStreaming(object):
         assert np.all(u.data[0] == 56)
         assert np.all(u.data[1] == 72)
 
+    @skipif('device-openmp')  # TODO: Still unsupported with OpenMP, but soon will be
     def test_streaming_multi_input(self):
         nt = 100
         grid = Grid(shape=(10, 10))
@@ -334,6 +336,7 @@ class TestStreaming(object):
 
         assert np.all(grad.data == grad1.data)
 
+    @skipif('device-openmp')  # TODO: Still unsupported with OpenMP, but soon will be
     def test_streaming_postponed_deletion(self):
         nt = 10
         grid = Grid(shape=(10, 10, 10))
@@ -359,6 +362,7 @@ class TestStreaming(object):
         assert np.all(u.data == u1.data)
         assert np.all(v.data == v1.data)
 
+    @skipif('device-openmp')  # TODO: Still unsupported with OpenMP, but soon will be
     def test_streaming_with_host_loop(self):
         grid = Grid(shape=(10, 10, 10))
 
@@ -374,6 +378,7 @@ class TestStreaming(object):
         assert 'init_device0' in op._func_table
         assert 'prefetch_host_to_device0' in op._func_table
 
+    @skipif('device-openmp')  # TODO: Still unsupported with OpenMP, but soon will be
     def test_composite_streaming_tasking(self):
         nt = 10
         grid = Grid(shape=(10, 10, 10))
@@ -482,6 +487,7 @@ class TestStreaming(object):
         assert np.all(usave.data == usave1.data)
         assert np.all(vsave.data == vsave1.data)
 
+    @skipif('device-openmp')  # TODO: Still unsupported with OpenMP, but soon will be
     def test_composite_full(self):
         nt = 10
         grid = Grid(shape=(4, 4))
@@ -670,6 +676,7 @@ class TestStreaming(object):
             assert np.all(usave.data[i, :, :3] == 0)
             assert np.all(usave.data[i, :, -3:] == 0)
 
+    @skipif('device-openmp')  # TODO: Still unsupported with OpenMP, but soon will be
     @pytest.mark.parametrize('gpu_fit', [True, False])
     def test_xcor_from_saved(self, gpu_fit):
         nt = 10

--- a/tests/test_gpu_common.py
+++ b/tests/test_gpu_common.py
@@ -115,14 +115,14 @@ class TestStreaming(object):
         assert len(locks) == 1  # Only 1 because it's only `tmp` that needs protection
         assert len(op._func_table) == 2
         exprs = FindNodes(Expression).visit(op._func_table['copy_device_to_host0'].root)
-        assert len(exprs) == 20
-        assert str(exprs[13]) == 'int id = sdata0->id;'
-        assert str(exprs[14]) == 'const int time = sdata0->time;'
-        assert str(exprs[15]) == 'lock0[0] = 1;'
-        assert exprs[16].write is u
-        assert exprs[17].write is v
-        assert str(exprs[18]) == 'lock0[0] = 2;'
-        assert str(exprs[19]) == 'sdata0->flag = 1;'
+        assert len(exprs) == 19
+        assert str(exprs[12]) == 'int id = sdata0->id;'
+        assert str(exprs[13]) == 'const int time = sdata0->time;'
+        assert str(exprs[14]) == 'lock0[0] = 1;'
+        assert exprs[15].write is u
+        assert exprs[16].write is v
+        assert str(exprs[17]) == 'lock0[0] = 2;'
+        assert str(exprs[18]) == 'sdata0->flag = 1;'
 
         op.apply(time_M=nt-2)
 
@@ -173,12 +173,12 @@ class TestStreaming(object):
         assert str(body.body[4]) == 'sdata1[wi1].flag = 2;'
         assert len(op._func_table) == 4
         exprs = FindNodes(Expression).visit(op._func_table['copy_device_to_host0'].root)
-        assert len(exprs) == 19
-        assert str(exprs[15]) == 'lock0[0] = 1;'
-        assert exprs[16].write is u
+        assert len(exprs) == 18
+        assert str(exprs[14]) == 'lock0[0] = 1;'
+        assert exprs[15].write is u
         exprs = FindNodes(Expression).visit(op._func_table['copy_device_to_host1'].root)
-        assert str(exprs[15]) == 'lock1[0] = 1;'
-        assert exprs[16].write is v
+        assert str(exprs[14]) == 'lock1[0] = 1;'
+        assert exprs[15].write is v
 
         op.apply(time_M=nt-2)
 
@@ -238,10 +238,10 @@ class TestStreaming(object):
         assert str(sections[1].body[0].body[0].body[9]) == 'sdata0[wi0].flag = 2;'
         assert len(op1._func_table) == 2
         exprs = FindNodes(Expression).visit(op1._func_table['copy_device_to_host0'].root)
-        assert len(exprs) == 26
+        assert len(exprs) == 25
         for i in range(3):
-            assert 'lock0[t' in str(exprs[18 + i])
-        assert exprs[21].write is usave
+            assert 'lock0[t' in str(exprs[17 + i])
+        assert exprs[20].write is usave
 
         op0.apply(time_M=nt-2)
         op1.apply(time_M=nt-2, u=u1, usave=usave1)
@@ -370,7 +370,7 @@ class TestStreaming(object):
 
         op = Operator(eqns, opt=('streaming', 'orchestrate'))
 
-        assert len(op._func_table) == 2
+        assert len(op._func_table) == 3
         assert 'init_device0' in op._func_table
         assert 'prefetch_host_to_device0' in op._func_table
 
@@ -472,7 +472,7 @@ class TestStreaming(object):
         assert len(threads) == 2
         assert threads[0].size.data == 1
         assert threads[1].size.data == 1
-        assert len(op1._func_table) == 2  # usave and vsave eqns are in two diff efuncs
+        assert len(op1._func_table) == 4  # usave and vsave eqns are in two diff efuncs
 
         op0.apply(time_M=nt-1)
         op1.apply(time_M=nt-1, u=u1, v=v1, usave=usave1, vsave=vsave1)
@@ -586,7 +586,7 @@ class TestStreaming(object):
         op = Operator(eqns, opt=('buffering', 'tasking', 'topofuse', 'orchestrate'))
 
         # Check generated code
-        assert len(op._func_table) == 2  # usave and vsave eqns are in separate tasks
+        assert len(op._func_table) == 4  # usave and vsave eqns are in separate tasks
 
         op.apply(time_M=nt-1)
 
@@ -637,9 +637,8 @@ class TestStreaming(object):
         op = Operator(eqns, opt=('buffering', 'tasking', 'orchestrate'))
 
         # We just check the generated code here
-        locks = [i for i in FindSymbols().visit(op) if isinstance(i, Lock)]
-        assert len(locks) == 1
-        assert len(op._func_table) == 1
+        assert len([i for i in FindSymbols().visit(op) if isinstance(i, Lock)]) == 1
+        assert len(op._func_table) == 2
 
     def test_save_w_subdims(self):
         nt = 10

--- a/tests/test_gpu_common.py
+++ b/tests/test_gpu_common.py
@@ -6,7 +6,7 @@ from devito import (Constant, Eq, Inc, Grid, Function, ConditionalDimension,
 from devito.arch import get_gpu_info
 from devito.ir import Expression, Section, FindNodes, FindSymbols, retrieve_iteration_tree
 from devito.passes import OpenMPIteration
-from devito.types import Lock, STDThreadArray
+from devito.types import Lock, PThreadArray
 
 from conftest import skipif
 
@@ -396,7 +396,7 @@ class TestStreaming(object):
         assert len(retrieve_iteration_tree(op1)) == 4
         symbols = FindSymbols().visit(op1)
         assert len([i for i in symbols if isinstance(i, Lock)]) == 1
-        threads = [i for i in symbols if isinstance(i, STDThreadArray)]
+        threads = [i for i in symbols if isinstance(i, PThreadArray)]
         assert len(threads) == 2
         assert threads[0].size == 1
         assert threads[1].size.data == 2
@@ -428,7 +428,7 @@ class TestStreaming(object):
         assert len(retrieve_iteration_tree(op1)) == 5
         symbols = FindSymbols().visit(op1)
         assert len([i for i in symbols if isinstance(i, Lock)]) == 1
-        threads = [i for i in symbols if isinstance(i, STDThreadArray)]
+        threads = [i for i in symbols if isinstance(i, PThreadArray)]
         assert len(threads) == 1
         assert threads[0].size.data == 1
 
@@ -466,7 +466,7 @@ class TestStreaming(object):
         assert len(retrieve_iteration_tree(op1)) == 7
         symbols = FindSymbols().visit(op1)
         assert len([i for i in symbols if isinstance(i, Lock)]) == 2
-        threads = [i for i in symbols if isinstance(i, STDThreadArray)]
+        threads = [i for i in symbols if isinstance(i, PThreadArray)]
         assert len(threads) == 2
         assert threads[0].size.data == 1
         assert threads[1].size.data == 1

--- a/tests/test_gpu_openacc.py
+++ b/tests/test_gpu_openacc.py
@@ -65,8 +65,9 @@ class TestCodeGeneration(object):
                       opt=('streaming', 'orchestrate'))
 
         # Check generated code
-        assert len(op._func_table) == 2
+        assert len(op._func_table) == 3
         assert 'init_device0' in op._func_table
+        assert 'init_tsdata0' in op._func_table
         assert 'prefetch_host_to_device0' in op._func_table
         sections = FindNodes(Section).visit(op)
         assert len(sections) == 2

--- a/tests/test_iet.py
+++ b/tests/test_iet.py
@@ -106,7 +106,7 @@ def test_nested_calls_cgen():
 
 
 @pytest.mark.parametrize('mode,expected', [
-    ('free-symbols', '["f", "x"]'),
+    ('free-symbols', '["f_vec", "x"]'),
     ('symbolics', '["f"]')
 ])
 def test_find_symbols_nested(mode, expected):

--- a/tests/test_pickle.py
+++ b/tests/test_pickle.py
@@ -209,8 +209,8 @@ def test_lock():
     new_lock.target.shape == f.shape
 
 
-def test_std_thread_array():
-    a = STDThreadArray(name='threads', nthreads_std=4)
+def test_p_thread_array():
+    a = PThreadArray(name='threads', npthreads=4)
 
     pkl_a = pickle.dumps(a)
     new_a = pickle.loads(pkl_a)
@@ -223,7 +223,7 @@ def test_std_thread_array():
 def test_shared_data():
     s = Scalar(name='s')
 
-    sdata = SharedData(name='sdata', nthreads_std=2, fields=[s])
+    sdata = SharedData(name='sdata', npthreads=2, fields=[s])
 
     pkl_sdata = pickle.dumps(sdata)
     new_sdata = pickle.loads(pkl_sdata)

--- a/tests/test_pickle.py
+++ b/tests/test_pickle.py
@@ -210,7 +210,7 @@ def test_lock():
 
 
 def test_p_thread_array():
-    a = PThreadArray(name='threads', npthreads=4)
+    a = PThreadArray(name='threads', npthreads=4, base_id=2)
 
     pkl_a = pickle.dumps(a)
     new_a = pickle.loads(pkl_a)

--- a/tests/test_pickle.py
+++ b/tests/test_pickle.py
@@ -218,12 +218,14 @@ def test_p_thread_array():
     assert a.name == new_a.name
     assert a.dimensions[0].name == new_a.dimensions[0].name
     assert a.size == new_a.size
+    assert a.base_id == new_a.base_id == 2
 
 
 def test_shared_data():
     s = Scalar(name='s')
+    a = Scalar(name='a')
 
-    sdata = SharedData(name='sdata', npthreads=2, fields=[s])
+    sdata = SharedData(name='sdata', npthreads=2, fields=[s], dynamic_fields=[a])
 
     pkl_sdata = pickle.dumps(sdata)
     new_sdata = pickle.loads(pkl_sdata)
@@ -232,6 +234,7 @@ def test_shared_data():
     assert sdata.size == new_sdata.size
     assert sdata.fields == new_sdata.fields
     assert sdata.pfields == new_sdata.pfields
+    assert sdata.dynamic_fields == new_sdata.dynamic_fields
 
     ffp = FieldFromPointer(sdata._field_flag, sdata.symbolic_base)
 

--- a/tests/test_pickle.py
+++ b/tests/test_pickle.py
@@ -12,7 +12,7 @@ from devito.mpi.halo_scheme import Halo
 from devito.mpi.routines import (MPIStatusObject, MPIMsgEnriched, MPIRequestObject,
                                  MPIRegion)
 from devito.types import (Array, CustomDimension, Symbol as dSymbol, Scalar,
-                          PointerArray, Lock, STDThreadArray, SharedData, Timer)
+                          PointerArray, Lock, PThreadArray, SharedData, Timer)
 from devito.symbolics import (IntDiv, ListInitializer, FieldFromPointer,
                               FunctionFromPointer, DefFunction)
 from examples.seismic import (demo_model, AcquisitionGeometry,


### PR DESCRIPTION
* Only tested (no surprise) with clang and aomp
* the adjoint operators do not work yet because of clang/aomp bugs, which have already been flagged
* Data streaming is now performed in pure C, not C++ (now using pthreads instead of std::threads -- this was necessary because of compatibility issues with clang/aomp)
* Further improvements to the compiler passes implementing data streaming
