### PR TITLE
Skip viscoacoustic tests with openacc

### DIFF
--- a/examples/seismic/viscoacoustic/viscoacoustic_example.py
+++ b/examples/seismic/viscoacoustic/viscoacoustic_example.py
@@ -2,7 +2,7 @@ import numpy as np
 import pytest
 
 from devito.logger import info
-from devito import norm
+from devito import norm, configuration
 from examples.seismic.viscoacoustic import ViscoacousticWaveSolver
 from examples.seismic import demo_model, setup_geometry, seismic_args
 
@@ -36,6 +36,7 @@ def run(shape=(50, 50), spacing=(20.0, 20.0), tn=1000.0,
     return (summary.gflopss, summary.oi, summary.timings, [rec, p, v])
 
 
+@pytest.mark.skipif(configuration['language'] == 'openacc', reason="see issue #1560")
 @pytest.mark.parametrize('kernel, time_order, normrec, atol', [
     ('sls', 2, 684.385, 1e-2),
     ('sls', 1, 18.774, 1e-2),
@@ -49,6 +50,7 @@ def test_viscoacoustic(kernel, time_order, normrec, atol):
     assert np.isclose(norm(rec), normrec, atol=atol, rtol=0)
 
 
+@pytest.mark.skipif(configuration['language'] == 'openacc', reason="see issue #1560")
 @pytest.mark.parametrize('ndim', [2, 3])
 @pytest.mark.parametrize('kernel', ['sls', 'ren', 'deng_mcmechan'])
 @pytest.mark.parametrize('time_order', [1, 2])


### PR DESCRIPTION
Owing to what looks like a [compiler bug](https://github.com/devitocodes/devito/runs/1726964978), the viscoacoustic tests will be skipped for the time being if openacc offloading to gpu.

See issue #1560.