### PR TITLE
Introduce devito/arch

### DIFF
--- a/benchmarks/user/benchmark.py
+++ b/benchmarks/user/benchmark.py
@@ -6,7 +6,7 @@ import click
 import os
 from devito import (clear_cache, configuration, info, warning, set_log_level,
                     switchconfig, norm)
-from devito.compiler import IntelCompiler
+from devito.arch.compiler import IntelCompiler
 from devito.mpi import MPI
 from devito.operator.profiling import PerformanceSummary
 from devito.tools import all_equal, as_tuple, sweep

--- a/devito/__init__.py
+++ b/devito/__init__.py
@@ -16,7 +16,7 @@ from devito.types.relational import *  # noqa
 from devito.types.tensor import *  # noqa
 
 # Imports required to initialize Devito
-from devito.archinfo import platform_registry
+from devito.arch import platform_registry
 from devito.backends import backends_registry, init_backend
 from devito.compiler import compiler_registry
 from devito.logger import error, warning, info, logger_registry, set_log_level  # noqa

--- a/devito/__init__.py
+++ b/devito/__init__.py
@@ -16,9 +16,8 @@ from devito.types.relational import *  # noqa
 from devito.types.tensor import *  # noqa
 
 # Imports required to initialize Devito
-from devito.arch import platform_registry
+from devito.arch import compiler_registry, platform_registry
 from devito.backends import backends_registry, init_backend
-from devito.compiler import compiler_registry
 from devito.logger import error, warning, info, logger_registry, set_log_level  # noqa
 from devito.operator import profiler_registry, operator_registry
 

--- a/devito/arch/__init__.py
+++ b/devito/arch/__init__.py
@@ -1,0 +1,1 @@
+from .archinfo import *

--- a/devito/arch/__init__.py
+++ b/devito/arch/__init__.py
@@ -1,1 +1,2 @@
-from .archinfo import *
+from .archinfo import *  # noqa
+from .compiler import *  # noqa

--- a/devito/arch/archinfo.py
+++ b/devito/arch/archinfo.py
@@ -11,10 +11,12 @@ import re
 from devito.logger import warning
 from devito.tools import all_equal, memoized_func
 
-__all__ = ['platform_registry',
-           'INTEL64', 'SNB', 'IVB', 'HSW', 'BDW', 'SKX', 'KNL', 'KNL7210',
-           'ARM',
-           'POWER8', 'POWER9']
+__all__ = ['platform_registry', 'get_cpu_info', 'get_gpu_info',
+           'Platform', 'Cpu64', 'Intel64', 'Amd', 'Arm', 'Power', 'Device',
+           'NvidiaDevice', 'AmdDevice',
+           'INTEL64', 'SNB', 'IVB', 'HSW', 'BDW', 'SKX', 'KNL', 'KNL7210',  # Intel
+           'AMD', 'ARM', 'POWER8', 'POWER9',  # Other CPU architectures
+           'AMDGPUX', 'NVIDIAX']  # GPUs
 
 
 @memoized_func

--- a/devito/arch/compiler.py
+++ b/devito/arch/compiler.py
@@ -19,7 +19,7 @@ from devito.parameters import configuration
 from devito.tools import (as_tuple, change_directory, filter_ordered,
                           memoized_meth, make_tempdir)
 
-__all__ = ['GNUCompiler']
+__all__ = ['sniff_mpi_distro', 'compiler_registry']
 
 
 def sniff_compiler_version(cc):

--- a/devito/compiler.py
+++ b/devito/compiler.py
@@ -12,7 +12,7 @@ import numpy.ctypeslib as npct
 from codepy.jit import compile_from_string
 from codepy.toolchain import GCCToolchain
 
-from devito.archinfo import AMDGPUX, NVIDIAX, SKX, POWER8, POWER9
+from devito.arch import AMDGPUX, NVIDIAX, SKX, POWER8, POWER9
 from devito.exceptions import CompilationError
 from devito.logger import debug, warning, error
 from devito.parameters import configuration

--- a/devito/core/__init__.py
+++ b/devito/core/__init__.py
@@ -1,4 +1,4 @@
-from devito.archinfo import Cpu64, Intel64, Arm, Power, Device
+from devito.arch import Cpu64, Intel64, Arm, Power, Device
 from devito.core.cpu import (CPU64NoopOperator, CPU64Operator, CPU64OpenMPOperator,
                              CustomOperator)
 from devito.core.intel import (Intel64Operator, Intel64OpenMPOperator,

--- a/devito/core/autotuning.py
+++ b/devito/core/autotuning.py
@@ -3,7 +3,7 @@ from itertools import combinations, product
 from functools import total_ordering
 import resource
 
-from devito.archinfo import KNL, KNL7210
+from devito.arch import KNL, KNL7210
 from devito.ir import Backward, retrieve_iteration_tree
 from devito.logger import perf, warning as _warning
 from devito.mpi.distributed import MPI, MPINeighborhood

--- a/devito/operator/operator.py
+++ b/devito/operator/operator.py
@@ -6,7 +6,7 @@ from math import ceil
 from cached_property import cached_property
 import ctypes
 
-from devito.archinfo import platform_registry
+from devito.arch import platform_registry
 from devito.compiler import compiler_registry
 from devito.exceptions import InvalidOperator
 from devito.logger import info, perf, warning, is_log_enabled_for

--- a/devito/operator/operator.py
+++ b/devito/operator/operator.py
@@ -6,8 +6,7 @@ from math import ceil
 from cached_property import cached_property
 import ctypes
 
-from devito.arch import platform_registry
-from devito.compiler import compiler_registry
+from devito.arch import compiler_registry, platform_registry
 from devito.exceptions import InvalidOperator
 from devito.logger import info, perf, warning, is_log_enabled_for
 from devito.ir.equations import LoweredEq, lower_exprs, generate_implicit_exprs

--- a/devito/operator/registry.py
+++ b/devito/operator/registry.py
@@ -1,7 +1,7 @@
 from collections import OrderedDict
 from itertools import product
 
-from devito.archinfo import Platform
+from devito.arch import Platform
 from devito.exceptions import InvalidOperator
 from devito.tools import Singleton
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,7 +9,7 @@ from sympy import cos, Symbol  # noqa
 from devito import (Grid, TimeDimension, SteppingDimension, SpaceDimension, # noqa
                     Constant, Function, TimeFunction, Eq, configuration, SparseFunction, # noqa
                     SparseTimeFunction)  # noqa
-from devito.archinfo import Device
+from devito.arch import Device
 from devito.compiler import sniff_mpi_distro
 from devito.tools import as_tuple
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,8 +9,7 @@ from sympy import cos, Symbol  # noqa
 from devito import (Grid, TimeDimension, SteppingDimension, SpaceDimension, # noqa
                     Constant, Function, TimeFunction, Eq, configuration, SparseFunction, # noqa
                     SparseTimeFunction)  # noqa
-from devito.arch import Device
-from devito.compiler import sniff_mpi_distro
+from devito.arch import Device, sniff_mpi_distro
 from devito.tools import as_tuple
 
 try:

--- a/tests/test_gpu_common.py
+++ b/tests/test_gpu_common.py
@@ -3,7 +3,7 @@ import numpy as np
 
 from devito import (Constant, Eq, Inc, Grid, Function, ConditionalDimension,
                     SubDimension, SubDomain, TimeFunction, Operator)
-from devito.archinfo import get_gpu_info
+from devito.arch import get_gpu_info
 from devito.ir import Expression, Section, FindNodes, FindSymbols, retrieve_iteration_tree
 from devito.passes import OpenMPIteration
 from devito.types import Lock, STDThreadArray


### PR DESCRIPTION
This PR moves `archinfo.py` and `compiler.py` from `devito/devito` to `devito/devito/arch`