### PR TITLE
examples: add first order adjoint viscoacoustic equations

### DIFF
--- a/examples/seismic/viscoacoustic/operators.py
+++ b/examples/seismic/viscoacoustic/operators.py
@@ -55,6 +55,8 @@ def sls_1st_order(model, geometry, p, **kwargs):
     p : TimeFunction
         Pressure field.
     """
+    forward = kwargs.get('forward', True)
+    space_order = p.space_order
     save = kwargs.get('save', False)
     s = model.grid.stepping_dim.spacing
     b = model.b
@@ -84,19 +86,36 @@ def sls_1st_order(model, geometry, p, **kwargs):
     # Memory variable.
     r = TimeFunction(name="r", grid=model.grid, staggered=NODE,
                      save=geometry.nt if save else None,
-                     time_order=1)
+                     time_order=1, space_order=space_order)
 
-    # Define PDE
-    pde_v = v - s * b * grad(p)
-    u_v = Eq(v.forward, damp * pde_v)
+    if forward:
 
-    pde_r = r - s * (1. / t_s) * r - s * (1. / t_s) * tt * bm * div(v.forward)
-    u_r = Eq(r.forward, damp * pde_r)
+        # Define PDE
+        pde_v = v - s * b * grad(p)
+        u_v = Eq(v.forward, damp * pde_v)
 
-    pde_p = p - s * bm * (tt + 1.) * div(v.forward) - s * r.forward
-    u_p = Eq(p.forward, damp * pde_p)
+        pde_r = r - s * (1. / t_s) * r - s * (1. / t_s) * tt * bm * div(v.forward)
+        u_r = Eq(r.forward, damp * pde_r)
 
-    return [u_v, u_r, u_p]
+        pde_p = p - s * bm * (tt + 1.) * div(v.forward) - s * r.forward
+        u_p = Eq(p.forward, damp * pde_p)
+
+        return [u_v, u_r, u_p]
+
+    else:
+
+        # Define PDE
+        pde_r = r - s * (1. / t_s) * r - s * p
+        u_r = Eq(r.backward, damp * pde_r)
+
+        pde_v = v + s * grad(bm * (1. + tt) * p) + s * \
+            grad((1. / t_s) * bm * tt * r.backward)
+        u_v = Eq(v.backward, damp * pde_v)
+
+        pde_p = p + s * div(b * v.backward)
+        u_p = Eq(p.backward, damp * pde_p)
+
+        return [u_r, u_v, u_p]
 
 
 def sls_2nd_order(model, geometry, p, **kwargs):
@@ -170,6 +189,7 @@ def ren_1st_order(model, geometry, p, **kwargs):
     p : TimeFunction
         Pressure field.
     """
+    forward = kwargs.get('forward', True)
     s = model.grid.stepping_dim.spacing
     f0 = geometry._f0
     vp = model.vp
@@ -186,15 +206,33 @@ def ren_1st_order(model, geometry, p, **kwargs):
     # Density
     rho = 1. / b
 
-    # Define PDE
-    pde_v = v - s * b * grad(p)
-    u_v = Eq(v.forward, damp * pde_v)
+    eta = (vp * vp) / (w0 * qp)
 
-    pde_p = p - s * vp * vp * rho * div(v.forward) + \
-        s * ((vp * vp * rho) / (w0 * qp)) * div(b * grad(p, shift=.5), shift=-.5)
-    u_p = Eq(p.forward, damp * pde_p)
+    # Bulk modulus
+    bm = rho * (vp * vp)
 
-    return [u_v, u_p]
+    if forward:
+
+        # Define PDE
+        pde_v = v - s * b * grad(p)
+        u_v = Eq(v.forward, damp * pde_v)
+
+        pde_p = p - s * vp * vp * rho * div(v.forward) + \
+            s * ((vp * vp * rho) / (w0 * qp)) * div(b * grad(p, shift=.5), shift=-.5)
+        u_p = Eq(p.forward, damp * pde_p)
+
+        return [u_v, u_p]
+
+    else:
+
+        pde_v = v + s * grad(bm * p)
+        u_v = Eq(v.backward, pde_v * damp)
+
+        pde_p = p + s * div(b * grad(rho * eta * p, shift=.5), shift=-.5) + \
+            s * div(b * v.backward)
+        u_p = Eq(p.backward, pde_p * damp)
+
+        return [u_v, u_p]
 
 
 def ren_2nd_order(model, geometry, p, **kwargs):
@@ -260,6 +298,7 @@ def deng_1st_order(model, geometry, p, **kwargs):
     p : TimeFunction
         Pressure field.
     """
+    forward = kwargs.get('forward', True)
     s = model.grid.stepping_dim.spacing
     f0 = geometry._f0
     vp = model.vp
@@ -276,14 +315,29 @@ def deng_1st_order(model, geometry, p, **kwargs):
     # Density
     rho = 1. / b
 
-    # Define PDE
-    pde_v = v - s * b * grad(p)
-    u_v = Eq(v.forward, damp * pde_v)
+    # Bulk modulus
+    bm = rho * (vp * vp)
 
-    pde_p = p - s * vp * vp * rho * div(v.forward) - s * (w0 / qp) * p
-    u_p = Eq(p.forward, damp * pde_p)
+    if forward:
 
-    return [u_v, u_p]
+        # Define PDE
+        pde_v = v - s * b * grad(p)
+        u_v = Eq(v.forward, damp * pde_v)
+
+        pde_p = p - s * vp * vp * rho * div(v.forward) - s * (w0 / qp) * p
+        u_p = Eq(p.forward, damp * pde_p)
+
+        return [u_v, u_p]
+
+    else:
+
+        pde_v = v + s * grad(bm * p)
+        u_v = Eq(v.backward, pde_v * damp)
+
+        pde_p = p + s * div(b * v.backward) - s * (w0 / qp) * p
+        u_p = Eq(p.backward, pde_p * damp)
+
+        return [u_v, u_p]
 
 
 def deng_2nd_order(model, geometry, p, **kwargs):
@@ -468,12 +522,17 @@ def AdjointOperator(model, geometry, space_order=4, kernel='sls', time_order=2, 
         deng_mcmechan - Deng and McMechan (2007) viscoacoustic equation
         Defaults to sls 2nd order.
     """
+    if time_order == 1:
+        va = VectorTimeFunction(name="va", grid=model.grid, save=None,
+                                time_order=time_order, space_order=space_order)
+        kwargs.update({'v': va})
+
     pa = TimeFunction(name="pa", grid=model.grid, save=None, time_order=time_order,
                       space_order=space_order, staggered=NODE)
 
     # Equations kernels
     eq_kernel = kernels[kernel]
-    eqn = eq_kernel(model, geometry, pa, forward=False)
+    eqn = eq_kernel(model, geometry, pa, forward=False, **kwargs)
 
     srcrec = src_rec(pa, model, geometry, forward=False)
 

--- a/examples/seismic/viscoacoustic/operators.py
+++ b/examples/seismic/viscoacoustic/operators.py
@@ -81,12 +81,11 @@ def sls_1st_order(model, geometry, p, **kwargs):
     rho = 1. / b
 
     # Bulk modulus
-    bm = rho * (vp * vp)
+    bm = rho * vp * vp
 
     # Memory variable.
-    r = TimeFunction(name="r", grid=model.grid, staggered=NODE,
-                     save=geometry.nt if save else None,
-                     time_order=1, space_order=space_order)
+    r = TimeFunction(name="r", grid=model.grid, time_order=1, space_order=space_order,
+                     save=geometry.nt if save else None, staggered=NODE)
 
     if forward:
 
@@ -131,6 +130,7 @@ def sls_2nd_order(model, geometry, p, **kwargs):
     """
     forward = kwargs.get('forward', True)
     space_order = p.space_order
+    save = kwargs.get('save', False)
     s = model.grid.stepping_dim.spacing
     b = model.b
     vp = model.vp
@@ -150,8 +150,11 @@ def sls_2nd_order(model, geometry, p, **kwargs):
     # Density
     rho = 1. / b
 
+    # Bulk modulus
+    bm = rho * vp * vp
+
     r = TimeFunction(name="r", grid=model.grid, time_order=2, space_order=space_order,
-                     staggered=NODE)
+                     save=geometry.nt if save else None, staggered=NODE)
 
     if forward:
 
@@ -159,7 +162,7 @@ def sls_2nd_order(model, geometry, p, **kwargs):
             s * (1. / t_s) * r
         u_r = Eq(r.forward, damp * pde_r)
 
-        pde_p = 2. * p - damp * p.backward + s * s * vp * vp * (1. + tt) * rho * \
+        pde_p = 2. * p - damp * p.backward + s * s * bm * (1. + tt) * \
             div(b * grad(p, shift=.5), shift=-.5) - s * s * vp * vp * r.forward
         u_p = Eq(p.forward, damp * pde_p)
 
@@ -209,7 +212,7 @@ def ren_1st_order(model, geometry, p, **kwargs):
     eta = (vp * vp) / (w0 * qp)
 
     # Bulk modulus
-    bm = rho * (vp * vp)
+    bm = rho * vp * vp
 
     if forward:
 
@@ -217,7 +220,7 @@ def ren_1st_order(model, geometry, p, **kwargs):
         pde_v = v - s * b * grad(p)
         u_v = Eq(v.forward, damp * pde_v)
 
-        pde_p = p - s * vp * vp * rho * div(v.forward) + \
+        pde_p = p - s * bm * div(v.forward) + \
             s * ((vp * vp * rho) / (w0 * qp)) * div(b * grad(p, shift=.5), shift=-.5)
         u_p = Eq(p.forward, damp * pde_p)
 
@@ -264,7 +267,7 @@ def ren_2nd_order(model, geometry, p, **kwargs):
     eta = (vp * vp) / (w0 * qp)
 
     # Bulk modulus
-    bm = rho * (vp * vp)
+    bm = rho * vp * vp
 
     if forward:
 
@@ -316,7 +319,7 @@ def deng_1st_order(model, geometry, p, **kwargs):
     rho = 1. / b
 
     # Bulk modulus
-    bm = rho * (vp * vp)
+    bm = rho * vp * vp
 
     if forward:
 
@@ -324,7 +327,7 @@ def deng_1st_order(model, geometry, p, **kwargs):
         pde_v = v - s * b * grad(p)
         u_v = Eq(v.forward, damp * pde_v)
 
-        pde_p = p - s * vp * vp * rho * div(v.forward) - s * (w0 / qp) * p
+        pde_p = p - s * bm * div(v.forward) - s * (w0 / qp) * p
         u_p = Eq(p.forward, damp * pde_p)
 
         return [u_v, u_p]
@@ -367,7 +370,7 @@ def deng_2nd_order(model, geometry, p, **kwargs):
     # Density
     rho = 1. / b
 
-    bm = rho * (vp * vp)
+    bm = rho * vp * vp
 
     if forward:
 

--- a/examples/seismic/viscoacoustic/wavesolver.py
+++ b/examples/seismic/viscoacoustic/wavesolver.py
@@ -195,8 +195,12 @@ class ViscoacousticWaveSolver(object):
             # Execute operator and return wavefield and receiver data
             # With Memory variable
             summary = self.op_adj().apply(src=srca, rec=rec, pa=pa, r=r, b=b, vp=vp,
-                                          qp=qp, dt=kwargs.pop('dt', self.dt), **kwargs)
+                                          qp=qp, dt=kwargs.pop('dt', self.dt),
+                                          time_m=0 if self.time_order == 1 else None,
+                                          **kwargs)
         else:
             summary = self.op_adj().apply(src=srca, rec=rec, pa=pa, vp=vp, b=b, qp=qp,
-                                          dt=kwargs.pop('dt', self.dt), **kwargs)
+                                          dt=kwargs.pop('dt', self.dt),
+                                          time_m=0 if self.time_order == 1 else None,
+                                          **kwargs)
         return srca, pa, va, summary

--- a/tests/test_adjoint.py
+++ b/tests/test_adjoint.py
@@ -101,14 +101,7 @@ class TestAdjoint(object):
 
         # Run forward and adjoint operators
         rec = solver.forward(save=False)[0]
-
-        if time_order == 1:
-
-            solver.adjoint(rec=rec, srca=srca, time_m=0)
-
-        else:
-
-            solver.adjoint(rec=rec, srca=srca)
+        solver.adjoint(rec=rec, srca=srca)
 
         # Adjoint test: Verify <Ax,y> matches  <x, A^Ty> closely
         term1 = np.dot(srca.data.reshape(-1), solver.geometry.src.data)

--- a/tests/test_adjoint.py
+++ b/tests/test_adjoint.py
@@ -17,53 +17,68 @@ presets = {
 
 
 class TestAdjoint(object):
-
-    @pytest.mark.parametrize('mkey, shape, kernel, space_order, setup_func', [
+    @pytest.mark.parametrize('mkey, shape, kernel, space_order, time_order, setup_func', [
         # 1 tests with varying time and space orders
-        ('layers', (60, ), 'OT2', 12, acoustic_setup),
-        ('layers', (60, ), 'OT2', 8, acoustic_setup),
-        ('layers', (60, ), 'OT4', 4, acoustic_setup),
+        ('layers', (60, ), 'OT2', 12, 2, acoustic_setup),
+        ('layers', (60, ), 'OT2', 8, 2, acoustic_setup),
+        ('layers', (60, ), 'OT4', 4, 2, acoustic_setup),
         # 2D tests with varying time and space orders
-        ('layers', (60, 70), 'OT2', 12, acoustic_setup),
-        ('layers', (60, 70), 'OT2', 8, acoustic_setup),
-        ('layers', (60, 70), 'OT2', 4, acoustic_setup),
-        ('layers', (60, 70), 'OT4', 2, acoustic_setup),
+        ('layers', (60, 70), 'OT2', 12, 2, acoustic_setup),
+        ('layers', (60, 70), 'OT2', 8, 2, acoustic_setup),
+        ('layers', (60, 70), 'OT2', 4, 2, acoustic_setup),
+        ('layers', (60, 70), 'OT4', 2, 2, acoustic_setup),
         # 3D tests with varying time and space orders
-        ('layers', (60, 70, 80), 'OT2', 8, acoustic_setup),
-        ('layers', (60, 70, 80), 'OT2', 6, acoustic_setup),
-        ('layers', (60, 70, 80), 'OT2', 4, acoustic_setup),
-        ('layers', (60, 70, 80), 'OT4', 2, acoustic_setup),
+        ('layers', (60, 70, 80), 'OT2', 8, 2, acoustic_setup),
+        ('layers', (60, 70, 80), 'OT2', 6, 2, acoustic_setup),
+        ('layers', (60, 70, 80), 'OT2', 4, 2, acoustic_setup),
+        ('layers', (60, 70, 80), 'OT4', 2, 2, acoustic_setup),
         # Constant model in 2D and 3D
-        ('constant', (60, 70), 'OT2', 10, acoustic_setup),
-        ('constant', (60, 70, 80), 'OT2', 8, acoustic_setup),
-        ('constant', (60, 70), 'OT2', 4, acoustic_setup),
-        ('constant', (60, 70, 80), 'OT4', 2, acoustic_setup),
+        ('constant', (60, 70), 'OT2', 10, 2, acoustic_setup),
+        ('constant', (60, 70, 80), 'OT2', 8, 2, acoustic_setup),
+        ('constant', (60, 70), 'OT2', 4, 2, acoustic_setup),
+        ('constant', (60, 70, 80), 'OT4', 2, 2, acoustic_setup),
         # 2D TTI tests with varying space orders
-        ('layers-tti', (30, 35), 'centered', 8, tti_setup),
-        ('layers-tti', (30, 35), 'centered', 4, tti_setup),
+        ('layers-tti', (30, 35), 'centered', 8, 2, tti_setup),
+        ('layers-tti', (30, 35), 'centered', 4, 2, tti_setup),
         # 3D TTI tests with varying space orders
-        ('layers-tti', (30, 35, 40), 'centered', 8, tti_setup),
-        ('layers-tti', (30, 35, 40), 'centered', 4, tti_setup),
-        # 2D SLS Viscoacoustic tests with varying space orders
-        ('layers-viscoacoustic', (20, 25), 'sls', 4, viscoacoustic_setup),
-        ('layers-viscoacoustic', (20, 25), 'sls', 2, viscoacoustic_setup),
-        # 3D SLS Viscoacoustic tests with varying space orders
-        ('layers-viscoacoustic', (20, 25, 20), 'sls', 4, viscoacoustic_setup),
-        ('layers-viscoacoustic', (20, 25, 20), 'sls', 2, viscoacoustic_setup),
-        # 2D Ren Viscoacoustic tests with varying space orders
-        ('layers-viscoacoustic', (20, 25), 'ren', 4, viscoacoustic_setup),
-        ('layers-viscoacoustic', (20, 25), 'ren', 2, viscoacoustic_setup),
-        # 3D Ren Viscoacoustic tests with varying space orders
-        ('layers-viscoacoustic', (20, 25, 20), 'ren', 4, viscoacoustic_setup),
-        ('layers-viscoacoustic', (20, 25, 20), 'ren', 2, viscoacoustic_setup),
-        # 2D Deng Mcmechan Viscoacoustic tests with varying space orders
-        ('layers-viscoacoustic', (20, 25), 'deng_mcmechan', 4, viscoacoustic_setup),
-        ('layers-viscoacoustic', (20, 25), 'deng_mcmechan', 2, viscoacoustic_setup),
-        # 3D Deng Mcmechan Viscoacoustic tests with varying space orders
-        ('layers-viscoacoustic', (20, 25, 20), 'deng_mcmechan', 4, viscoacoustic_setup),
-        ('layers-viscoacoustic', (20, 25, 20), 'deng_mcmechan', 2, viscoacoustic_setup),
+        ('layers-tti', (30, 35, 40), 'centered', 8, 2, tti_setup),
+        ('layers-tti', (30, 35, 40), 'centered', 4, 2, tti_setup),
+        # 2D SLS Viscoacoustic tests with varying space and equation orders
+        ('layers-viscoacoustic', (20, 25), 'sls', 4, 1, viscoacoustic_setup),
+        ('layers-viscoacoustic', (20, 25), 'sls', 2, 1, viscoacoustic_setup),
+        ('layers-viscoacoustic', (20, 25), 'sls', 4, 2, viscoacoustic_setup),
+        ('layers-viscoacoustic', (20, 25), 'sls', 2, 2, viscoacoustic_setup),
+        # 3D SLS Viscoacoustic tests with varying space and equation orders
+        ('layers-viscoacoustic', (20, 25, 20), 'sls', 4, 1, viscoacoustic_setup),
+        ('layers-viscoacoustic', (20, 25, 20), 'sls', 2, 1, viscoacoustic_setup),
+        ('layers-viscoacoustic', (20, 25, 20), 'sls', 4, 2, viscoacoustic_setup),
+        ('layers-viscoacoustic', (20, 25, 20), 'sls', 2, 2, viscoacoustic_setup),
+        # 2D Ren Viscoacoustic tests with varying space and equation orders
+        ('layers-viscoacoustic', (20, 25), 'ren', 4, 1, viscoacoustic_setup),
+        ('layers-viscoacoustic', (20, 25), 'ren', 2, 1, viscoacoustic_setup),
+        ('layers-viscoacoustic', (20, 25), 'ren', 4, 2, viscoacoustic_setup),
+        ('layers-viscoacoustic', (20, 25), 'ren', 2, 2, viscoacoustic_setup),
+        # 3D Ren Viscoacoustic tests with varying space and equation orders
+        ('layers-viscoacoustic', (20, 25, 20), 'ren', 4, 1, viscoacoustic_setup),
+        ('layers-viscoacoustic', (20, 25, 20), 'ren', 2, 1, viscoacoustic_setup),
+        ('layers-viscoacoustic', (20, 25, 20), 'ren', 4, 2, viscoacoustic_setup),
+        ('layers-viscoacoustic', (20, 25, 20), 'ren', 2, 2, viscoacoustic_setup),
+        # 2D Deng Mcmechan Viscoacoustic tests with varying space and equation orders
+        ('layers-viscoacoustic', (20, 25), 'deng_mcmechan', 4, 1, viscoacoustic_setup),
+        ('layers-viscoacoustic', (20, 25), 'deng_mcmechan', 2, 1, viscoacoustic_setup),
+        ('layers-viscoacoustic', (20, 25), 'deng_mcmechan', 4, 2, viscoacoustic_setup),
+        ('layers-viscoacoustic', (20, 25), 'deng_mcmechan', 2, 2, viscoacoustic_setup),
+        # 3D Deng Mcmechan Viscoacoustic tests with varying space and equation orders
+        ('layers-viscoacoustic', (20, 25, 20), 'deng_mcmechan', 4, 1, \
+            viscoacoustic_setup),
+        ('layers-viscoacoustic', (20, 25, 20), 'deng_mcmechan', 2, 1, \
+            viscoacoustic_setup),
+        ('layers-viscoacoustic', (20, 25, 20), 'deng_mcmechan', 4, 2, \
+            viscoacoustic_setup),
+        ('layers-viscoacoustic', (20, 25, 20), 'deng_mcmechan', 2, 2, \
+            viscoacoustic_setup),
     ])
-    def test_adjoint_F(self, mkey, shape, kernel, space_order, setup_func):
+    def test_adjoint_F(self, mkey, shape, kernel, space_order, time_order, setup_func):
         """
         Adjoint test for the forward modeling operator.
         The forward modeling operator F generates a shot record (measurements)
@@ -76,7 +91,7 @@ class TestAdjoint(object):
         # Create solver from preset
         solver = setup_func(shape=shape, spacing=[15. for _ in shape],
                             kernel=kernel, nbl=10, tn=tn,
-                            space_order=space_order,
+                            space_order=space_order, time_order=time_order,
                             **(presets[mkey]), dtype=np.float64)
 
         # Create adjoint receiver symbol
@@ -86,7 +101,14 @@ class TestAdjoint(object):
 
         # Run forward and adjoint operators
         rec = solver.forward(save=False)[0]
-        solver.adjoint(rec=rec, srca=srca)
+
+        if time_order == 1:
+
+            solver.adjoint(rec=rec, srca=srca, time_m=0)
+
+        else:
+
+            solver.adjoint(rec=rec, srca=srca)
 
         # Adjoint test: Verify <Ax,y> matches  <x, A^Ty> closely
         term1 = np.dot(srca.data.reshape(-1), solver.geometry.src.data)


### PR DESCRIPTION
Hi guys,

Once the issue (#1513)  was discussed here and also in [slack ](https://devitocodes.slack.com/archives/C1HSXP6KB/p1605747162212800?thread_ts=1603204771.133200&cid=C1HSXP6KB), we were able to develop a set of first-order adjoint viscoacoustic equations.

Thus, we finalized the implementation of the forward and adjoint viscoacoustic equations to first and second-order formulation.
 
The next step will be the implementation of the viscoacoustic Born operators!