### PR TITLE
BoundSymbol constructor to be cached

### DIFF
--- a/devito/types/basic.py
+++ b/devito/types/basic.py
@@ -1209,12 +1209,12 @@ class BoundSymbol(Symbol):
     Wrapper class for Symbols that are bound to a symbolic data object.
     """
 
-    def __init_finalize__(self, *args, function=None, **kwargs):
-        self._function = function
+    def __new__(cls, *args, function=None, **kwargs):
+        obj = Symbol.__new__(cls, *args, **kwargs)
+        obj._function = function
+        return obj
 
-        super().__init_finalize__(*args, **kwargs)
-
-    @property
+    @cached_property
     def function(self):
         return self._function
 

--- a/devito/types/basic.py
+++ b/devito/types/basic.py
@@ -1203,18 +1203,27 @@ class IndexedData(sympy.IndexedBase, Pickable):
     __reduce_ex__ = Pickable.__reduce_ex__
 
 
-class BoundSymbol(Symbol):
+class BoundSymbol(AbstractSymbol):
 
     """
     Wrapper class for Symbols that are bound to a symbolic data object.
+
+    Notes
+    -----
+    By deliberately inheriting from AbstractSymbol, a BoundSymbol won't be
+    in the devito cache. This will avoid cycling references in the cache
+    (e.g., an entry for a Function `u(x)` and an entry for `u._C_symbol` with
+    the latter's key including `u(x)`). This is totally fine. The BoundSymbol
+    is tied to a specific Function; once the Function gets out of scope, the
+    BoundSymbol will also become a garbage collector candidate.
     """
 
     def __new__(cls, *args, function=None, **kwargs):
-        obj = Symbol.__new__(cls, *args, **kwargs)
+        obj = AbstractSymbol.__new__(cls, *args, **kwargs)
         obj._function = function
         return obj
 
-    @cached_property
+    @property
     def function(self):
         return self._function
 

--- a/tests/test_caching.py
+++ b/tests/test_caching.py
@@ -455,12 +455,24 @@ class TestCaching(object):
         for i in range(10):
             assert(len(_SymbolCache) == cache_size)
 
-            u = Function(name='u', grid=grid, space_order=2)
-            u._C_symbol
-            # All u, u(inds) and u.function through u._c_symbol added to cache
-            assert(len(_SymbolCache) == cache_size + 3)
-            del u
+            Function(name='u', grid=grid, space_order=2)
+            # Both u and u(inds) added to cache
+            assert(len(_SymbolCache) == cache_size + 2)
+
             clear_cache()
+
+    def test_clear_cache_with_Csymbol(self, operate_on_empty_cache, nx=1000, ny=1000):
+        grid = Grid(shape=(nx, ny), dtype=np.float64)
+        cache_size = len(_SymbolCache)
+
+        u = Function(name='u', grid=grid, space_order=2)
+        # Both u and u(inds) added to cache
+        assert(len(_SymbolCache) == cache_size + 2)
+
+        a = u._C_symbol
+        # Cache size won't change since _C_symbol isn't cached by devito to
+        # avoid circular references in the cache
+        assert(len(_SymbolCache) == cache_size + 2)
 
     def test_clear_cache_with_alive_symbols(self, operate_on_empty_cache,
                                             nx=1000, ny=1000):

--- a/tests/test_caching.py
+++ b/tests/test_caching.py
@@ -455,10 +455,11 @@ class TestCaching(object):
         for i in range(10):
             assert(len(_SymbolCache) == cache_size)
 
-            Function(name='u', grid=grid, space_order=2)
+            u = Function(name='u', grid=grid, space_order=2)
+            u._C_symbol
             # Both u and u(inds) added to cache
-            assert(len(_SymbolCache) == cache_size + 2)
-
+            assert(len(_SymbolCache) == cache_size + 3)
+            del u
             clear_cache()
 
     def test_clear_cache_with_alive_symbols(self, operate_on_empty_cache,

--- a/tests/test_caching.py
+++ b/tests/test_caching.py
@@ -457,7 +457,7 @@ class TestCaching(object):
 
             u = Function(name='u', grid=grid, space_order=2)
             u._C_symbol
-            # Both u and u(inds) added to cache
+            # All u, u(inds) and u.function through u._c_symbol added to cache
             assert(len(_SymbolCache) == cache_size + 3)
             del u
             clear_cache()

--- a/tests/test_caching.py
+++ b/tests/test_caching.py
@@ -469,7 +469,7 @@ class TestCaching(object):
         # Both u and u(inds) added to cache
         assert(len(_SymbolCache) == cache_size + 2)
 
-        a = u._C_symbol
+        u._C_symbol
         # Cache size won't change since _C_symbol isn't cached by devito to
         # avoid circular references in the cache
         assert(len(_SymbolCache) == cache_size + 2)


### PR DESCRIPTION
Fixes #1575 

Switch from `__init_finalize` to `__new__` to make sure the extra `u.function` is  cought by the cache and added extra line to `clear_cache` test to test it (breaks on master)