### PR TITLE
Solve time only

### DIFF
--- a/devito/types/equation.py
+++ b/devito/types/equation.py
@@ -242,7 +242,6 @@ def solve(eq, target, **kwargs):
         # Try first linear solver
         try:
             sol = list(sympy.linsolve([eval_t(e)], [t]))
-            print(eval_t(e), sol)
             sols.append(sol[0][0])
         except ValueError:
             warning("Equation is not affine w.r.t the target, falling back to standard"

--- a/tests/test_caching.py
+++ b/tests/test_caching.py
@@ -710,7 +710,7 @@ class TestMemoryLeaks(object):
         # to u(t + dt), u(x - h_x) and u(x + h_x) that have to be cleared.
         # Then `u` points to the various Dimensions, the Dimensions point to the various
         # spacing symbols, hence, we need four sweeps to clear up the cache.
-        assert len(_SymbolCache) == 16
+        assert len(_SymbolCache) == 14
         clear_cache()
         assert len(_SymbolCache) == 9
         clear_cache()

--- a/tests/test_dse.py
+++ b/tests/test_dse.py
@@ -1800,12 +1800,12 @@ class TestIsoAcoustic(object):
         assert len(op0._func_table) == 0
         assert len(op1._func_table) == 1  # due to loop blocking
 
-        assert summary0[('section0', None)].ops == 50
+        assert summary0[('section0', None)].ops == 46
         assert summary0[('section1', None)].ops == 151
-        assert np.isclose(summary0[('section0', None)].oi, 2.851, atol=0.001)
+        assert np.isclose(summary0[('section0', None)].oi, 2.623, atol=0.001)
 
-        assert summary1[('section0', None)].ops == 33
-        assert np.isclose(summary1[('section0', None)].oi, 1.882, atol=0.001)
+        assert summary1[('section0', None)].ops == 29
+        assert np.isclose(summary1[('section0', None)].oi, 1.654, atol=0.001)
 
         assert np.allclose(u0.data, u1.data, atol=10e-5)
         assert np.allclose(rec0.data, rec1.data, atol=10e-5)

--- a/tests/test_symbolics.py
+++ b/tests/test_symbolics.py
@@ -84,3 +84,19 @@ def test_canonical_ordering(expr, expected):
         expected[n] = eval(i)
 
     assert retrieve_indexed(expr) == expected
+
+
+def test_solve_time():
+    """
+    Tests that solves only evaluate the time derivative
+    """
+    grid = Grid(shape=(11, 11))
+    u = TimeFunction(name="u", grid=grid, time_order=2, space_order=4)
+    m = Function(name="m", grid=grid, space_order=4)
+    dt = grid.time_dim.spacing
+    eq = m * u.dt2 + u.dx
+    sol = solve(eq, u.forward)
+    # Check u.dx is not evaluated. Need to simplify because the solution
+    # contains some Dummy in the Derivatibe subs that make equality break.
+    assert sympy.simplify(u.dx - sol.args[2].args[3]) == 0
+    assert sympy.simplify(sol - (-dt**2*u.dx/m + 2.0*u - u.backward)) == 0


### PR DESCRIPTION
Refactor `solve` to only evaluate time derivative by default  (will evaluate full equation if doesn't find a solution) and corresponding test.