### PR TITLE
dsl: Patch symbolic coefficients with staggered grids

### DIFF
--- a/devito/finite_differences/coefficients.py
+++ b/devito/finite_differences/coefficients.py
@@ -259,7 +259,6 @@ def default_rules(obj, functions):
     # Determine which 'rules' are missing
     sym = get_sym(functions)
     terms = obj.find(sym)
-    # DEBUG: Only seem to have two terms here?
     args_present = filter_ordered(term.args[1:] for term in terms)
 
     subs = obj.substitutions
@@ -277,8 +276,6 @@ def default_rules(obj, functions):
 
     rules = {}
     for i in not_provided:
-        # DEBUG: For every not provided, generates a set of rules and appends to
-        # DEBUG: existing dictionary
         rules = {**rules, **generate_subs(*i)}
 
     return rules

--- a/devito/finite_differences/coefficients.py
+++ b/devito/finite_differences/coefficients.py
@@ -3,7 +3,7 @@ import numpy as np
 from cached_property import cached_property
 
 from devito.finite_differences import generate_indices
-from devito.tools import filter_ordered, as_tuple, frozendict
+from devito.tools import filter_ordered, as_tuple
 from devito.symbolics.search import retrieve_dimensions
 
 __all__ = ['Coefficient', 'Substitutions', 'default_rules']
@@ -243,7 +243,7 @@ def default_rules(obj, functions):
 
         subs = {}
 
-        mapper = frozendict({dim: index})
+        mapper = {dim: index}
 
         indices, x0 = generate_indices(function, dim,
                                        fd_order, side=None, x0=mapper)
@@ -263,7 +263,6 @@ def default_rules(obj, functions):
 
     subs = obj.substitutions
     if subs:
-        # .index is not including function offset correctly
         args_provided = [(i.deriv_order, i.function, i.index)
                          for i in subs.coefficients]
     else:

--- a/devito/finite_differences/tools.py
+++ b/devito/finite_differences/tools.py
@@ -163,7 +163,7 @@ def generate_indices(func, dim, order, side=None, x0=None):
         Order of the finite-difference scheme
     side: Side
         Side of the scheme, (centered, left, right)
-    x0: Dimension or Expr or Number
+    x0: Dict of {Dimension: Dimension or Expr or Number}
         Origin of the scheme, ie. `x`, `x + .5 * x.spacing`, ...
 
     Returns
@@ -192,7 +192,7 @@ def generate_indices_cartesian(dim, order, side, x0):
         Order of the finite-difference scheme
     side: Side
         Side of the scheme, (centered, left, right)
-    x0: Dimension or Expr or Number
+    x0: Dict of {Dimension: Dimension or Expr or Number}
         Origin of the scheme, ie. `x`, `x + .5 * x.spacing`, ...
 
     Returns
@@ -234,7 +234,7 @@ def generate_indices_staggered(func, dim, order, side=None, x0=None):
         Order of the finite-difference scheme
     side: Side
         Side of the scheme, (centered, left, right)
-    x0: Dimension or Expr or Number
+    x0: Dict of {Dimension: Dimension or Expr or Number}
         Origin of the scheme, ie. `x`, `x + .5 * x.spacing`, ...
 
     Returns

--- a/tests/test_symbolic_coefficients.py
+++ b/tests/test_symbolic_coefficients.py
@@ -119,7 +119,6 @@ class TestSC(object):
 
         assert expected == str(eq.evaluate.lhs)
 
-    # FIXME: Needs to test several grid spacings and dimensions
     @pytest.mark.parametrize('order', [1, 2, 6, 8])
     @pytest.mark.parametrize('extent', [1., 10., 100.])
     @pytest.mark.parametrize('conf', [{'l': 'NODE', 'r1': 'x', 'r2': None},
@@ -147,9 +146,9 @@ class TestSC(object):
             else:
                 raise ValueError("Invalid stagger in configuration")
 
-            f_std = Function(name=name+'std', grid=grid, space_order=order,
+            f_std = Function(name=name, grid=grid, space_order=order,
                              staggered=staggered)
-            f_sym = Function(name=name+'sym', grid=grid, space_order=order,
+            f_sym = Function(name=name, grid=grid, space_order=order,
                              staggered=staggered, coefficients='symbolic')
 
             return f_std, f_sym
@@ -192,7 +191,13 @@ class TestSC(object):
         eq_std = get_eq(u_std, a_std, b_std, conf)
         eq_sym = get_eq(u_sym, a_sym, b_sym, conf)
 
-        Operator([eq_std, eq_sym])()
+        evaluated_std = eq_std.evaluate.evalf(_PRECISION)
+        evaluated_sym = eq_sym.evaluate.evalf(_PRECISION)
+
+        assert str(evaluated_std) == str(evaluated_sym)
+
+        Operator(eq_std)()
+        Operator(eq_sym)()
 
         assert np.all(np.isclose(u_std.data - u_sym.data, 0.0, atol=1e-5, rtol=0))
 


### PR DESCRIPTION
Fix for the bug where derivatives with symbolic coefficients on staggered grids default to incorrect values. Fixes one of the two issues detailed in #1589.