### PR TITLE
dsl: patch for custom coefficients with staggered equations

### DIFF
--- a/devito/finite_differences/coefficients.py
+++ b/devito/finite_differences/coefficients.py
@@ -187,7 +187,6 @@ class Substitutions(object):
             dim = i.dimension
             index = i.index
             weights = i.weights
-            print(deriv_order, function, dim, index, weights)
 
             if isinstance(weights, np.ndarray):
                 fd_order = len(weights)-1
@@ -286,11 +285,8 @@ def default_rules(obj, functions):
         return subs
 
     # Determine which 'rules' are missing
-    print("Functions", functions)
     sym = get_sym(functions)
-    print("Sym", sym)
     terms = obj.find(sym)
-    print("Terms", terms)
     args_present = filter_ordered(term.args[1:] for term in terms)
 
     subs = obj.substitutions
@@ -303,8 +299,6 @@ def default_rules(obj, functions):
     # NOTE: Do we want to throw a warning if the same arg has
     # been provided twice?
     args_provided = list(set(args_provided))
-    print("Args present", args_present)
-    print("Args provided", args_provided)
 
     # Need to compare dimensions,, not indices, then take the index from
     # args_present to pass to generate_subs()

--- a/devito/finite_differences/coefficients.py
+++ b/devito/finite_differences/coefficients.py
@@ -203,7 +203,6 @@ class Substitutions(object):
             # passed as a dictionary of the form {pos: w} (or something similar).
             if isinstance(weights, np.ndarray):
                 for j in range(len(weights)):
-                    # Index here is incorrect. Need to pull it from elsewhere
                     subs.update({function._coeff_symbol
                                  (indices[j], deriv_order,
                                   function, index): weights[j]})
@@ -300,7 +299,7 @@ def default_rules(obj, functions):
     # been provided twice?
     args_provided = list(set(args_provided))
 
-    # Need to compare dimensions,, not indices, then take the index from
+    # Need to compare dimensions, not indices, then take the index from
     # args_present to pass to generate_subs()
     args_pres_dim = [(arg[0], arg[1], retrieve_dimensions(arg[2])[0])
                      for arg in args_present]

--- a/devito/finite_differences/tools.py
+++ b/devito/finite_differences/tools.py
@@ -163,7 +163,7 @@ def generate_indices(func, dim, order, side=None, x0=None):
         Order of the finite-difference scheme
     side: Side
         Side of the scheme, (centered, left, right)
-    x0: Dict of {Dimension: Dimension or Expr or Number}
+    x0: dict of {Dimension: Dimension or Expr or Number}
         Origin of the scheme, ie. `x`, `x + .5 * x.spacing`, ...
 
     Returns
@@ -192,7 +192,7 @@ def generate_indices_cartesian(dim, order, side, x0):
         Order of the finite-difference scheme
     side: Side
         Side of the scheme, (centered, left, right)
-    x0: Dict of {Dimension: Dimension or Expr or Number}
+    x0: dict of {Dimension: Dimension or Expr or Number}
         Origin of the scheme, ie. `x`, `x + .5 * x.spacing`, ...
 
     Returns
@@ -234,7 +234,7 @@ def generate_indices_staggered(func, dim, order, side=None, x0=None):
         Order of the finite-difference scheme
     side: Side
         Side of the scheme, (centered, left, right)
-    x0: Dict of {Dimension: Dimension or Expr or Number}
+    x0: dict of {Dimension: Dimension or Expr or Number}
         Origin of the scheme, ie. `x`, `x + .5 * x.spacing`, ...
 
     Returns

--- a/devito/types/equation.py
+++ b/devito/types/equation.py
@@ -97,7 +97,9 @@ class Eq(sympy.Eq, Evaluable):
             # all rules to be expunged during this procress.
             rules = default_rules(eq, eq._symbolic_functions)
             try:
-                eq = eq.xreplace({**eq.substitutions.rules, **rules})
+                eq = eq.xreplace(rules)
+                custom_rules = eq.substitutions.update_rules(eq)
+                eq = eq.xreplace(custom_rules)
             except AttributeError:
                 if bool(rules):
                     eq = eq.xreplace(rules)

--- a/tests/test_symbolic_coefficients.py
+++ b/tests/test_symbolic_coefficients.py
@@ -243,6 +243,64 @@ class TestSC(object):
         eval_sym = str(Eq(g, f_sym.dx(x0=x+offset*h_x/2)).evaluate.evalf(_PRECISION))
         assert eval_std == eval_sym
 
+    @pytest.mark.parametrize('so, expected', [(2, '1.0*f(x) + 1.0*f(x + h_x)'),
+                                              (4, '1.0*f(x) + 1.0*f(x - h_x) '
+                                                  '+ 1.0*f(x + h_x) + 1.0*f(x + 2*h_x)'),
+                                              (6, '1.0*f(x) + 1.0*f(x - 2*h_x)'
+                                                  ' + 1.0*f(x - h_x) + 1.0*f(x + h_x)'
+                                                  ' + 1.0*f(x + 2*h_x)'
+                                                  ' + 1.0*f(x + 3*h_x)')])
+    def test_custom_coefficients_staggered_eq(self, so, expected):
+        """Test custom coefficients for staggered equations"""
+        grid = Grid(shape=(11,), extent=(10.,))
+        x = grid.dimensions[0]
+        f = Function(name='f', grid=grid, space_order=so, staggered=NODE,
+                     coefficients='symbolic')
+        g = Function(name='g', grid=grid, space_order=so, staggered=x,
+                     coefficients='symbolic')
+        weights = np.ones(so+1)
+        coeffs = Coefficient(1, f, x, weights)
+        eq = Eq(g, f.dx, coefficients=Substitutions(coeffs))
+        assert str(eq.evaluate.rhs) == expected
+
+    @pytest.mark.parametrize('so, expected', [(2, '1.0*f(x) + 1.0*f(x + h_x)'
+                                                  ' - g(x)/h_x + g(x + h_x)/h_x'),
+                                              (4, '1.0*f(x) + 1.0*f(x - h_x)'
+                                                  ' + 1.0*f(x + h_x) + 1.0*f(x + 2*h_x)'
+                                                  ' - 9*g(x)/(8*h_x)'
+                                                  ' + g(x - h_x)/(24*h_x)'
+                                                  ' + 9*g(x + h_x)/(8*h_x)'
+                                                  ' - g(x + 2*h_x)/(24*h_x)'),
+                                              (6, '1.0*f(x) + 1.0*f(x - 2*h_x)'
+                                                  ' + 1.0*f(x - h_x)'
+                                                  ' + 1.0*f(x + h_x)'
+                                                  ' + 1.0*f(x + 2*h_x)'
+                                                  ' + 1.0*f(x + 3*h_x)'
+                                                  ' - 75*g(x)/(64*h_x)'
+                                                  ' - 3*g(x - 2*h_x)/(640*h_x)'
+                                                  ' + 25*g(x - h_x)/(384*h_x)'
+                                                  ' + 75*g(x + h_x)/(64*h_x)'
+                                                  ' - 25*g(x + 2*h_x)/(384*h_x)'
+                                                  ' + 3*g(x + 3*h_x)/(640*h_x)')])
+    def test_custom_default_combo(self, so, expected):
+        """
+        Test that staggered equations containing a mixture of default and custom
+        coefficients evaluate as expected.
+        """
+        grid = Grid(shape=(11,), extent=(10.,))
+        x = grid.dimensions[0]
+        f = Function(name='f', grid=grid, space_order=so, staggered=NODE,
+                     coefficients='symbolic')
+        g = Function(name='g', grid=grid, space_order=so, staggered=NODE,
+                     coefficients='symbolic')
+        h = Function(name='h', grid=grid, space_order=so, staggered=x,
+                     coefficients='symbolic')
+
+        weights = np.ones(so+1)
+        coeffs = Coefficient(1, f, x, weights)
+        eq = Eq(h, f.dx + g.dx, coefficients=Substitutions(coeffs))
+        assert str(eq.evaluate.rhs) == expected
+
     @pytest.mark.parametrize('order', [2, 4, 6])
     def test_staggered_array(self, order):
         """Test custom coefficients provided as an array on a staggered grid"""


### PR DESCRIPTION
Fixed #1589. Allows for custom coefficients to be set on equations with staggered functions.