### PR TITLE
dsl: patch for custom coefficients on staggered grids or at forward timesteps

### DIFF
--- a/devito/finite_differences/coefficients.py
+++ b/devito/finite_differences/coefficients.py
@@ -214,7 +214,6 @@ class Substitutions(object):
                     subs.update({function._coeff_symbol
                                  (symbolic_indices[j], deriv_order, function, index):
                                      weights[as_tuple(idx)]})
-
             return subs
 
         # Figure out when symbolic coefficients can be replaced
@@ -249,7 +248,8 @@ def default_rules(obj, functions):
 
         for j in range(len(coeffs)):
             subs.update({function._coeff_symbol
-                        (symbolic_indices[j], deriv_order, function, dim): coeffs[j]})
+                        (symbolic_indices[j], deriv_order,
+                         function.function, dim): coeffs[j]})
 
         return subs
 
@@ -260,7 +260,7 @@ def default_rules(obj, functions):
 
     subs = obj.substitutions
     if subs:
-        args_provided = [(i.deriv_order, i.function, i.dimension)
+        args_provided = [(i.deriv_order, i.function.function, i.dimension)
                          for i in subs.coefficients]
     else:
         args_provided = []

--- a/devito/finite_differences/coefficients.py
+++ b/devito/finite_differences/coefficients.py
@@ -294,6 +294,8 @@ def default_rules(obj, functions):
     print("Args not provided", not_provided)
 
     # Extract evaluation position from expr and create a mapper
+    # FIXME: Need to be able to force this to specified values
+    # FIXME: This is necessary to deal with offset derivatives
     try:
         mapper = {d: obj.lhs.indices_ref[d] for d in obj.rhs.dimensions}
 

--- a/devito/finite_differences/finite_difference.py
+++ b/devito/finite_differences/finite_difference.py
@@ -256,7 +256,12 @@ def generic_derivative(expr, dim, fd_order, deriv_order, symbolic=False,
         # User should set staggered coefficients manually
         indices, x0 = generate_indices(expr, dim, fd_order)
         # Integer indices for symbolic weights
-        symbolic_indices = tuple([index for index in range(fd_order+1)])
+        if fd_order < 2:
+            # For order 1, additional weights are needed to deal with forward
+            # and backward differences
+            symbolic_indices = tuple(range(3))
+        else:
+            symbolic_indices = tuple([index for index in range(fd_order+1)])
         c = symbolic_weights(expr, deriv_order, symbolic_indices, x0)
     else:
         indices, x0 = generate_indices(expr, dim, fd_order, x0=x0)

--- a/devito/finite_differences/finite_difference.py
+++ b/devito/finite_differences/finite_difference.py
@@ -252,7 +252,8 @@ def generic_derivative(expr, dim, fd_order, deriv_order, symbolic=False,
 
     # Finite difference weights from Taylor approximation with these positions
     if symbolic:
-        # No x0 given if symbolic. Stencil is not truncated by stagger
+        # No x0 given if symbolic. Stencil length not altered by staggering
+        # User should set staggered coefficients manually
         indices, x0 = generate_indices(expr, dim, fd_order)
         # Integer indices for symbolic weights
         symbolic_indices = tuple([index for index in range(fd_order+1)])

--- a/devito/finite_differences/finite_difference.py
+++ b/devito/finite_differences/finite_difference.py
@@ -254,7 +254,11 @@ def generic_derivative(expr, dim, fd_order, deriv_order, symbolic=False,
     if symbolic:
         # No x0 given if symbolic. Stencil length not altered by staggering
         # User should set staggered coefficients manually
+        print("x0 supplied to generic_derivative", x0)
+        print("Indices in generic derivative (test)")
+        print(generate_indices(expr, dim, fd_order, x0))
         indices, x0 = generate_indices(expr, dim, fd_order)
+
         # Integer indices for symbolic weights
         if fd_order < 2:
             # For order 1, additional weights are needed to deal with forward

--- a/devito/finite_differences/finite_difference.py
+++ b/devito/finite_differences/finite_difference.py
@@ -249,13 +249,16 @@ def generic_derivative(expr, dim, fd_order, deriv_order, symbolic=False,
     # first order fd that is a lot better
     if deriv_order == 1 and fd_order == 2 and not symbolic:
         fd_order = 1
-    # Stencil positions
-    indices, x0 = generate_indices(expr, dim, fd_order, x0=x0)
 
     # Finite difference weights from Taylor approximation with these positions
     if symbolic:
-        c = symbolic_weights(expr, deriv_order, indices, x0)
+        # No x0 given if symbolic. Stencil is not truncated by stagger
+        indices, x0 = generate_indices(expr, dim, fd_order)
+        # Integer indices for symbolic weights
+        symbolic_indices = tuple([index for index in range(fd_order+1)])
+        c = symbolic_weights(expr, deriv_order, symbolic_indices, x0)
     else:
+        indices, x0 = generate_indices(expr, dim, fd_order, x0=x0)
         c = numeric_weights(deriv_order, indices, x0)
 
     return indices_weights_to_fd(expr, dim, indices, c, matvec=matvec.val)

--- a/devito/finite_differences/tools.py
+++ b/devito/finite_differences/tools.py
@@ -141,8 +141,6 @@ def generate_fd_shortcuts(dims, so, to=0):
 
 
 def symbolic_weights(function, deriv_order, indices, dim):
-    print("Indices for symbolic weights")
-    print(indices)
     return [function._coeff_symbol(indices[j], deriv_order, function.function,
             retrieve_dimensions(dim)[0])
             for j in range(0, len(indices))]

--- a/devito/finite_differences/tools.py
+++ b/devito/finite_differences/tools.py
@@ -5,6 +5,7 @@ import numpy as np
 from sympy import S, finite_diff_weights, cacheit, sympify
 
 from devito.tools import Tag, as_tuple
+from devito.symbolics.search import retrieve_dimensions
 
 
 class Transpose(Tag):
@@ -140,7 +141,8 @@ def generate_fd_shortcuts(dims, so, to=0):
 
 
 def symbolic_weights(function, deriv_order, indices, dim):
-    return [function._coeff_symbol(indices[j], deriv_order, function, dim)
+    return [function._coeff_symbol(indices[j], deriv_order, function.function,
+            retrieve_dimensions(dim)[0])
             for j in range(0, len(indices))]
 
 

--- a/devito/finite_differences/tools.py
+++ b/devito/finite_differences/tools.py
@@ -141,6 +141,8 @@ def generate_fd_shortcuts(dims, so, to=0):
 
 
 def symbolic_weights(function, deriv_order, indices, dim):
+    print("Indices for symbolic weights")
+    print(indices)
     return [function._coeff_symbol(indices[j], deriv_order, function.function,
             retrieve_dimensions(dim)[0])
             for j in range(0, len(indices))]
@@ -257,7 +259,12 @@ def generate_indices_staggered(func, dim, order, side=None, x0=None):
     else:
         ind = [start + i * diff for i in range(-order//2, order//2+1)]
         if order < 2:
-            ind = [start, start - diff]
+            # Symbolic coefficients use an additional index to cope with forward
+            # or backward stagger in first order
+            if func.coefficients == 'symbolic':
+                ind = [start - diff, start, start + diff]
+            else:
+                ind = [start, start - diff]
 
     return start, tuple(ind)
 


### PR DESCRIPTION
Supersedes  #1619 with cleaner implementation, and fixes for derivatives taken on `u.forward` or `u.backward`.