### PR TITLE
types: Drop unsafe/unnecessary memoization in the arguments processing engine

### DIFF
--- a/benchmarks/regression/benchmarks/arguments.py
+++ b/benchmarks/regression/benchmarks/arguments.py
@@ -1,0 +1,28 @@
+from devito import Grid, Function, TimeFunction, SparseTimeFunction, Eq, Operator
+
+
+# ASV config
+repeat = 10
+
+
+class Processing(object):
+
+    def setup(self):
+        grid = Grid(shape=(5, 5, 5))
+
+        funcs = [Function(name='f%d' % n, grid=grid) for n in range(30)]
+        tfuncs = [TimeFunction(name='u%d' % n, grid=grid) for n in range(30)]
+        stfuncs = [SparseTimeFunction(name='su%d' % n, grid=grid, npoint=1, nt=100)
+                   for n in range(30)]
+        v = TimeFunction(name='v', grid=grid, space_order=2)
+
+        eq = Eq(v.forward, v.laplace + sum(funcs) + sum(tfuncs) + sum(stfuncs),
+                subdomain=grid.interior)
+
+        self.op = Operator(eq, opt='noop')
+
+        # Allocate data, populate cached properties, etc.
+        self.op.arguments(time_M=98)
+
+    def time_processing(self):
+        self.op.arguments(time_M=98)

--- a/devito/operator/operator.py
+++ b/devito/operator/operator.py
@@ -490,9 +490,6 @@ class Operator(Callable):
                 # User-provided floats/ndarray obviously do not have `_arg_as_ctype`
                 args.update(p._arg_as_ctype(args, alias=p))
 
-        # Add in any backend-specific argument
-        args.update(kwargs.pop('backend', {}))
-
         # Execute autotuning and adjust arguments accordingly
         args = self._autotune(args, kwargs.pop('autotune', configuration['autotuning']))
 

--- a/devito/types/dense.py
+++ b/devito/types/dense.py
@@ -791,9 +791,6 @@ class DiscreteFunction(AbstractFunction, ArgProvider, Differentiable):
         """Tuple of argument names introduced by this function."""
         return (self.name,)
 
-    # NOTE: This _arg_defaults, unlike many others, cannot be memoized
-    # since it leads to halo's not being updated when required. See
-    # test_mpi: test_haloupdate_multi_op
     def _arg_defaults(self, alias=None):
         """
         A map of default argument values defined by this symbol.

--- a/devito/types/dimension.py
+++ b/devito/types/dimension.py
@@ -7,7 +7,7 @@ from cached_property import cached_property
 from devito.data import LEFT, RIGHT
 from devito.exceptions import InvalidArgument
 from devito.logger import debug
-from devito.tools import Pickable, dtype_to_cstr, is_integer, memoized_meth
+from devito.tools import Pickable, dtype_to_cstr, is_integer
 from devito.types.args import ArgProvider
 from devito.types.basic import Symbol, DataSymbol, Scalar
 
@@ -207,7 +207,6 @@ class Dimension(ArgProvider):
         """Tuple of argument names introduced by the Dimension."""
         return (self.name, self.size_name, self.max_name, self.min_name)
 
-    @memoized_meth
     def _arg_defaults(self, _min=None, size=None, alias=None):
         """
         A map of default argument values defined by the Dimension.
@@ -223,7 +222,8 @@ class Dimension(ArgProvider):
             self's if None.
         """
         dim = alias or self
-        return {dim.min_name: _min or 0, dim.size_name: size,
+        return {dim.min_name: _min or 0,
+                dim.size_name: size,
                 dim.max_name: size if size is None else size-1}
 
     def _arg_values(self, args, interval, grid, **kwargs):

--- a/devito/types/grid.py
+++ b/devito/types/grid.py
@@ -7,7 +7,7 @@ from cached_property import cached_property
 
 from devito.data import LEFT, RIGHT
 from devito.mpi import Distributor, MPI
-from devito.tools import ReducerMap, as_tuple, memoized_meth
+from devito.tools import ReducerMap, as_tuple
 from devito.types.args import ArgProvider
 from devito.types.basic import Scalar
 from devito.types.dense import Function
@@ -301,7 +301,6 @@ class Grid(ArgProvider):
                 ret.extend([a.name for a in i.free_symbols])
         return tuple(ret)
 
-    @memoized_meth
     def _arg_defaults(self):
         """A map of default argument values defined by this Grid."""
         args = ReducerMap()

--- a/devito/types/sparse.py
+++ b/devito/types/sparse.py
@@ -279,7 +279,6 @@ class AbstractSparseFunction(DiscreteFunction):
         """
         raise NotImplementedError
 
-    @memoized_meth
     def _arg_defaults(self, alias=None):
         key = alias or self
         mapper = {self: key}
@@ -1349,16 +1348,6 @@ class MatrixSparseTimeFunction(AbstractSparseTimeFunction):
 
         self.scatter_result = None
         self.scattered_data = None
-
-        # Because AbstractSparseFunction._arg_defaults caches the values of the
-        # above arrays, we also need to wipe out our per-object cache
-        try:
-            # Names are mangled to prevent this kind of tomfoolery
-            # So instead of clearing __cache we do this
-            # https://dbader.org/blog/meaning-of-underscores-in-python
-            del self._memoized_meth__cache_meth
-        except AttributeError:
-            pass
 
     @property
     def dt(self):


### PR DESCRIPTION
bonus: Adding one more performance regression test to our ASV
the second (and future) `op.arguments(...)` call in the test, on this branch, takes about 45ms on my workstation. 

Ah, the `_arg_defaults` 's memorization in `sparse.py` turns out to be unsafe for MatrixSparseFunction
