### PR TITLE
deps: fix py-cpuinfo

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ flake8>=2.1.0
 nbval
 cached-property
 psutil>=5.1.0
-py-cpuinfo
+py-cpuinfo<8
 cgen>=2020.1
 codepy>=2019.1
 click


### PR DESCRIPTION
 to <8 since new version breaks on osx