### PR TITLE
compiler: Check consistency between shape and grid for TimeFunction, too

### DIFF
--- a/devito/types/dense.py
+++ b/devito/types/dense.py
@@ -1341,7 +1341,8 @@ class TimeFunction(Function):
     def __shape_setup__(cls, **kwargs):
         grid = kwargs.get('grid')
         save = kwargs.get('save') or None  # Force to None if 0/False/None/...
-        shape = kwargs.get('shape')
+        dimensions = kwargs.get('dimensions')
+        shape = kwargs.get('shape', kwargs.get('shape_global'))
         time_order = kwargs.get('time_order', 1)
 
         if grid is None:
@@ -1360,6 +1361,14 @@ class TimeFunction(Function):
                 shape.insert(cls._time_position, save)
             else:
                 raise TypeError("`save` can be None, int or Buffer, not %s" % type(save))
+        elif dimensions is None:
+            raise TypeError("`dimensions` required if both `grid` and "
+                            "`shape` are provided")
+        else:
+            shape = super(TimeFunction, cls).__shape_setup__(
+                grid=grid, shape=shape, dimensions=dimensions
+            )
+
         return tuple(shape)
 
     @cached_property

--- a/tests/test_mpi.py
+++ b/tests/test_mpi.py
@@ -50,6 +50,31 @@ class TestDistributor(object):
         }
         assert f.shape == expected[distributor.nprocs][distributor.myrank]
 
+    @pytest.mark.parallel(mode=[2, 4])
+    def test_partitioning_fewer_dims_timefunc(self):
+        """Test domain decomposition for Functions defined over a strict subset
+        of grid-decomposed dimensions."""
+        size_x, size_y = 16, 16
+        grid = Grid(shape=(size_x, size_y))
+        x, y = grid.dimensions
+
+        # A function with fewer dimensions that in `grid`
+        f = TimeFunction(
+            name='f',
+            grid=grid,
+            dimensions=(grid.time_dim, x,),
+            shape=(10, size_x,),
+        )
+
+        distributor = grid.distributor
+        expected = {  # nprocs -> [(rank0 shape), (rank1 shape), ...]
+            2: [(8,), (8,)],
+            4: [(8,), (8,), (8,), (8,)]
+        }
+        assert len(f.shape) == 2
+        assert f.shape[0] == 10
+        assert f.shape[1:] == expected[distributor.nprocs][distributor.myrank]
+
     @pytest.mark.parallel(mode=9)
     def test_neighborhood_horizontal_2d(self):
         grid = Grid(shape=(3, 3))


### PR DESCRIPTION
This duplicates the logic used for `Function.__shape_setup__` into `TimeFunction` as well - essentially sanity-checking the provided shape matches the grid and dimensions, if both are provided.

This allows for `TimeFunction`s over smaller numbers of dimensions to still work correctly with MPI.