### PR TITLE
compiler: Tweak nested-par candidate condition

### DIFF
--- a/devito/passes/iet/parpragma.py
+++ b/devito/passes/iet/parpragma.py
@@ -307,7 +307,7 @@ class PragmaShmTransformer(PragmaSimdTransformer):
             # within a block)
             candidates = []
             for i in inner:
-                if self.key(i) and any((j.dim.parent is i.dim.root) for j in outer):
+                if self.key(i) and any((j.dim.root is i.dim.root) for j in outer):
                     candidates.append(i)
                 elif candidates:
                     # If there's at least one candidate but `i` doesn't honor the

--- a/devito/passes/iet/parpragma.py
+++ b/devito/passes/iet/parpragma.py
@@ -11,7 +11,7 @@ from devito.symbolics import CondEq, INT, ccode
 from devito.passes.iet.engine import iet_pass
 from devito.passes.iet.langbase import LangBB, LangTransformer, DeviceAwareMixin
 from devito.passes.iet.misc import is_on_device
-from devito.tools import as_tuple, is_integer, prod
+from devito.tools import as_tuple, prod
 from devito.types import Symbol, NThreadsBase
 
 __all__ = ['PragmaSimdTransformer', 'PragmaShmTransformer',
@@ -307,7 +307,7 @@ class PragmaShmTransformer(PragmaSimdTransformer):
             # within a block)
             candidates = []
             for i in inner:
-                if self.key(i) and any(is_integer(j.step-i.symbolic_size) for j in outer):
+                if self.key(i) and any((j.dim.parent is i.dim.root) for j in outer):
                     candidates.append(i)
                 elif candidates:
                     # If there's at least one candidate but `i` doesn't honor the

--- a/tests/test_dle.py
+++ b/tests/test_dle.py
@@ -128,6 +128,7 @@ def test_cache_blocking_structure_subdims():
 
         * With local SubDimensions no-blocking is expected.
         * With non-local SubDimensions, blocking is expected.
+        * With non-local SubDimensions, nested blocking works fine when expected.
     """
     grid = Grid(shape=(4, 4, 4))
     x, y, z = grid.dimensions
@@ -156,6 +157,27 @@ def test_cache_blocking_structure_subdims():
     assert tree[3].dim.is_Incr and tree[3].dim.parent is tree[1].dim and\
         tree[3].dim.root is y
     assert not tree[4].dim.is_Incr and tree[4].dim is zi and tree[4].dim.parent is z
+
+    # Non-local SubDimension -> nested blocking can works as expected
+    op = Operator(Eq(f.forward, f + 1, subdomain=grid.interior),
+                  opt=('blocking', 'openmp', {'par-nested': 0, 'par-collapse-ncores': 2,
+                       'par-dynamic-work': 0}))
+    trees = retrieve_iteration_tree(op._func_table['bf0'].root)
+    assert len(trees) == 1
+    tree = trees[0]
+    assert len(tree) == 5
+    assert tree[0].dim.is_Incr and tree[0].dim.parent is xi and tree[0].dim.root is x
+    assert tree[1].dim.is_Incr and tree[1].dim.parent is yi and tree[1].dim.root is y
+    assert tree[2].dim.is_Incr and tree[2].dim.parent is tree[0].dim and\
+        tree[2].dim.root is x
+    assert tree[3].dim.is_Incr and tree[3].dim.parent is tree[1].dim and\
+        tree[3].dim.root is y
+    assert not tree[4].dim.is_Incr and tree[4].dim is zi and tree[4].dim.parent is z
+    assert trees[0][0].pragmas[0].value ==\
+        'omp for collapse(2) schedule(dynamic,1)'
+    assert trees[0][2].pragmas[0].value == ('omp parallel for collapse(2) '
+                                            'schedule(dynamic,1) '
+                                            'num_threads(nthreads_nested)')
 
 
 @pytest.mark.parallel(mode=[(1, 'full')])  # Shortcut to put loops in nested efuncs

--- a/tests/test_dle.py
+++ b/tests/test_dle.py
@@ -738,7 +738,8 @@ class TestNestedParallelism(object):
                                                 'schedule(dynamic,1) '
                                                 'num_threads(nthreads_nested)')
 
-    def test_nested_cache_blocking_structure_subdims(self):
+    @pytest.mark.parametrize('blocklevels', [1, 2])
+    def test_nested_cache_blocking_structure_subdims(self, blocklevels):
         """
         Test that:
 
@@ -757,45 +758,34 @@ class TestNestedParallelism(object):
 
         # Non-local SubDimension -> nested blocking can works as expected
         op = Operator(Eq(f.forward, f + 1, subdomain=grid.interior),
-                      opt=('blocking', 'openmp', {'par-nested': 0,
-                           'par-collapse-ncores': 2, 'par-dynamic-work': 0}))
+                      opt=('blocking', 'openmp',
+                           {'par-nested': 0, 'blocklevels': blocklevels,
+                            'par-collapse-ncores': 2,
+                            'par-dynamic-work': 0}))
         trees = retrieve_iteration_tree(op._func_table['bf0'].root)
         assert len(trees) == 1
         tree = trees[0]
-        assert len(tree) == 5
+        assert len(tree) == 5 + (blocklevels - 1) * 2
         assert tree[0].dim.is_Incr and tree[0].dim.parent is xi and tree[0].dim.root is x
         assert tree[1].dim.is_Incr and tree[1].dim.parent is yi and tree[1].dim.root is y
         assert tree[2].dim.is_Incr and tree[2].dim.parent is tree[0].dim and\
             tree[2].dim.root is x
         assert tree[3].dim.is_Incr and tree[3].dim.parent is tree[1].dim and\
             tree[3].dim.root is y
-        assert not tree[4].dim.is_Incr and tree[4].dim is zi and tree[4].dim.parent is z
-        assert trees[0][0].pragmas[0].value ==\
-            'omp for collapse(2) schedule(dynamic,1)'
-        assert trees[0][2].pragmas[0].value == ('omp parallel for collapse(2) '
-                                                'schedule(dynamic,1) '
-                                                'num_threads(nthreads_nested)')
 
-        # Non-local SubDimension -> hierarchical + nested blocking can works as expected
-        op = Operator(Eq(f.forward, f + 1, subdomain=grid.interior),
-                      opt=('blocking', 'openmp', {'blocklevels': 2, 'par-nested': 0,
-                           'par-collapse-ncores': 2, 'par-dynamic-work': 0}))
-        trees = retrieve_iteration_tree(op._func_table['bf0'].root)
-        assert len(trees) == 1
-        tree = trees[0]
-        assert len(tree) == 7
-        assert tree[0].dim.is_Incr and tree[0].dim.parent is xi and tree[0].dim.root is x
-        assert tree[1].dim.is_Incr and tree[1].dim.parent is yi and tree[1].dim.root is y
-        assert tree[2].dim.is_Incr and tree[2].dim.parent is tree[0].dim and\
-            tree[2].dim.root is x
-        assert tree[3].dim.is_Incr and tree[3].dim.parent is tree[1].dim and\
-            tree[3].dim.root is y
-        assert tree[4].dim.is_Incr and tree[4].dim.parent is tree[2].dim and\
-            tree[4].dim.root is x
-        assert tree[5].dim.is_Incr and tree[5].dim.parent is tree[3].dim and\
-            tree[5].dim.root is y
+        if blocklevels == 1:
+            assert not tree[4].dim.is_Incr and tree[4].dim is zi and\
+                tree[4].dim.parent is z
+        elif blocklevels == 2:
+            assert tree[3].dim.is_Incr and tree[3].dim.parent is tree[1].dim and\
+                tree[3].dim.root is y
+            assert tree[4].dim.is_Incr and tree[4].dim.parent is tree[2].dim and\
+                tree[4].dim.root is x
+            assert tree[5].dim.is_Incr and tree[5].dim.parent is tree[3].dim and\
+                tree[5].dim.root is y
+            assert not tree[6].dim.is_Incr and tree[6].dim is zi and\
+                tree[6].dim.parent is z
 
-        assert not tree[6].dim.is_Incr and tree[6].dim is zi and tree[6].dim.parent is z
         assert trees[0][0].pragmas[0].value ==\
             'omp for collapse(2) schedule(dynamic,1)'
         assert trees[0][2].pragmas[0].value == ('omp parallel for collapse(2) '


### PR DESCRIPTION
compiler: Tweak nested-par candidate condition.
Can help preserve parallelism in cases where bounds are expressions.