### PR TITLE
Allow asv workflow to discover new benchmarks

### DIFF
--- a/.github/workflows/asv.yml
+++ b/.github/workflows/asv.yml
@@ -71,6 +71,7 @@ jobs:
       run: |
         git config --local user.email "action@github.com"
         git config --local user.name "GitHub Action"
+        asv run --bench just-discover
         git add -f benchmarks/regression/.asv/results/
         git status
         git commit -m "Commit ASV results"


### PR DESCRIPTION
To discover new benchmarks it seems we need to add `asv run --bench just-discover` to the workflow. This worked locally so hopefully will do the trick now.