### PR TITLE
bench: Add mpi finalize to benchmark.py

### DIFF
--- a/benchmarks/user/benchmark.py
+++ b/benchmarks/user/benchmark.py
@@ -633,3 +633,9 @@ if __name__ == "__main__":
         configuration['profiling'] = 'advanced'
 
     benchmark()
+
+    try:
+        MPI.Finalize()
+    except TypeError:
+        # MPI not available
+        pass

--- a/examples/seismic/self_adjoint/example_iso.py
+++ b/examples/seismic/self_adjoint/example_iso.py
@@ -13,7 +13,6 @@ def acoustic_sa_setup(shape=(50, 50, 50), spacing=(10.0, 10.0, 10.0),
     # SA parameters
     qmin = 0.1
     qmax = 1000.0
-    tmax = 500.0
     fpeak = 0.010
     omega = 2.0 * np.pi * fpeak
     vp = 1.5*np.ones(shape)
@@ -26,7 +25,7 @@ def acoustic_sa_setup(shape=(50, 50, 50), spacing=(10.0, 10.0, 10.0),
                   space_order=space_order, bcs=init_damp,
                   dtype=kwargs.pop('dtype', np.float32), **kwargs)
     # Source and receiver geometries
-    geometry = setup_geometry(model, tmax)
+    geometry = setup_geometry(model, tn)
 
     # Create solver object to provide relevant operators
     solver = SaIsoAcousticWaveSolver(model, geometry,


### PR DESCRIPTION
Added missing mpi finalize in benchmarks.py spotted by @FabioLuporini.

Edit: This also fixes the simulation end time being hard set in acoustic ssa.