### PR TITLE
compiler: Loop fission

### DIFF
--- a/devito/core/cpu.py
+++ b/devito/core/cpu.py
@@ -4,7 +4,8 @@ from devito.core.operator import CoreOperator, CustomOperator
 from devito.exceptions import InvalidOperator
 from devito.passes.equations import collect_derivatives
 from devito.passes.clusters import (Lift, blocking, buffering, cire, cse,
-                                    extract_increments, factorize, fuse, optimize_pows)
+                                    extract_increments, factorize, fission, fuse,
+                                    optimize_pows)
 from devito.passes.iet import (CTarget, OmpTarget, avoid_denormals, linearize, mpiize,
                                optimize_halospots, hoist_prodders, relax_incr_dimensions)
 from devito.tools import timed_pass
@@ -296,6 +297,7 @@ class Cpu64CustomOperator(Cpu64OperatorMixin, CustomOperator):
             'buffering': lambda i: buffering(i, callback, sregistry, options),
             'blocking': lambda i: blocking(i, options),
             'factorize': factorize,
+            'fission': fission,
             'fuse': fuse,
             'lift': lambda i: Lift().process(cire(i, 'invariants', sregistry,
                                                   options, platform)),
@@ -332,8 +334,8 @@ class Cpu64CustomOperator(Cpu64OperatorMixin, CustomOperator):
         # Expressions
         'buffering',
         # Clusters
-        'blocking', 'topofuse', 'fuse', 'factorize', 'cire-sops', 'cse', 'lift',
-        'opt-pows',
+        'blocking', 'topofuse', 'fission', 'fuse', 'factorize', 'cire-sops',
+        'cse', 'lift', 'opt-pows',
         # IET
         'denormals', 'optcomms', 'openmp', 'mpi', 'linearize', 'simd', 'prodders',
     )

--- a/devito/ir/clusters/algorithms.py
+++ b/devito/ir/clusters/algorithms.py
@@ -5,7 +5,7 @@ import numpy as np
 import sympy
 
 from devito.exceptions import InvalidOperator
-from devito.ir.support import Any, Backward, Forward, IterationSpace
+from devito.ir.support import Any, Backward, Forward, IterationSpace, Stamp
 from devito.ir.clusters.analysis import analyze
 from devito.ir.clusters.cluster import Cluster, ClusterGroup
 from devito.ir.clusters.queue import Queue, QueueStateful
@@ -138,11 +138,12 @@ class Schedule(QueueStateful):
         # Handle the backlog -- the Clusters characterized by flow- and anti-dependences
         # along one or more Dimensions
         idir = {d: Any for d in known_break}
+        stamp = Stamp()
         for i, c in enumerate(list(backlog)):
-            ispace = IterationSpace(c.ispace.intervals.lift(known_break),
+            ispace = IterationSpace(c.ispace.intervals.lift(known_break, stamp),
                                     c.ispace.sub_iterators,
                                     {**c.ispace.directions, **idir})
-            dspace = c.dspace.lift(known_break)
+            dspace = c.dspace.lift(known_break, stamp)
             backlog[i] = c.rebuild(ispace=ispace, dspace=dspace)
 
         return processed + self.callback(backlog, prefix)

--- a/devito/ir/clusters/algorithms.py
+++ b/devito/ir/clusters/algorithms.py
@@ -5,12 +5,13 @@ import numpy as np
 import sympy
 
 from devito.exceptions import InvalidOperator
-from devito.ir.support import Any, Backward, Forward, IterationSpace, Stamp
+from devito.ir.support import Any, Backward, Forward, IterationSpace
 from devito.ir.clusters.analysis import analyze
 from devito.ir.clusters.cluster import Cluster, ClusterGroup
 from devito.ir.clusters.queue import Queue, QueueStateful
 from devito.symbolics import uxreplace, xreplace_indices
-from devito.tools import DefaultOrderedDict, as_mapper, flatten, is_integer, timed_pass
+from devito.tools import (DefaultOrderedDict, Stamp, as_mapper, flatten, is_integer,
+                          timed_pass)
 from devito.types import ModuloDimension
 
 __all__ = ['clusterize']

--- a/devito/ir/support/space.py
+++ b/devito/ir/support/space.py
@@ -7,24 +7,12 @@ from cached_property import cached_property
 from sympy import Expr
 
 from devito.ir.support.vector import Vector, vmin, vmax
-from devito.tools import (PartialOrderTuple, as_list, as_tuple, filter_ordered,
+from devito.tools import (PartialOrderTuple, Stamp, as_list, as_tuple, filter_ordered,
                           frozendict, is_integer, toposort)
 from devito.types import Dimension, ModuloDimension
 
-__all__ = ['Stamp', 'NullInterval', 'Interval', 'IntervalGroup', 'IterationSpace',
+__all__ = ['NullInterval', 'Interval', 'IntervalGroup', 'IterationSpace',
            'DataSpace', 'Forward', 'Backward', 'Any']
-
-
-class Stamp(object):
-
-    """
-    Uniquely identifies Intervals.
-    """
-
-    def __repr__(self):
-        return "<%s>" % str(id(self))[-3:]
-
-    __str__ = __repr__
 
 
 # The default Stamp, used by all new Intervals

--- a/devito/passes/clusters/aliases.py
+++ b/devito/passes/clusters/aliases.py
@@ -9,13 +9,13 @@ import sympy
 from devito.finite_differences import EvalDerivative
 from devito.ir import (SEQUENTIAL, PARALLEL_IF_PVT, ROUNDABLE, DataSpace,
                        Forward, IterationInstance, IterationSpace, Interval,
-                       Cluster, Queue, IntervalGroup, LabeledVector, Stamp,
-                       detect_accesses, build_intervals, normalize_properties,
-                       relax_properties)
+                       Cluster, Queue, IntervalGroup, LabeledVector, detect_accesses,
+                       build_intervals, normalize_properties, relax_properties)
 from devito.passes.clusters.utils import timed_pass
 from devito.symbolics import (Uxmapper, compare_ops, estimate_cost, q_constant,
                               reuse_if_untouched, retrieve_indexed, search, uxreplace)
-from devito.tools import as_mapper, as_tuple, flatten, frozendict, generator, split
+from devito.tools import (Stamp, as_mapper, as_tuple, flatten, frozendict, generator,
+                          split)
 from devito.types import (Array, TempFunction, Eq, Symbol, ModuloDimension,
                           CustomDimension, IncrDimension, Indexed)
 

--- a/devito/passes/clusters/aliases.py
+++ b/devito/passes/clusters/aliases.py
@@ -9,7 +9,7 @@ import sympy
 from devito.finite_differences import EvalDerivative
 from devito.ir import (SEQUENTIAL, PARALLEL_IF_PVT, ROUNDABLE, DataSpace,
                        Forward, IterationInstance, IterationSpace, Interval,
-                       Cluster, Queue, IntervalGroup, LabeledVector,
+                       Cluster, Queue, IntervalGroup, LabeledVector, Stamp,
                        detect_accesses, build_intervals, normalize_properties,
                        relax_properties)
 from devito.passes.clusters.utils import timed_pass
@@ -611,6 +611,7 @@ def lower_aliases(aliases, meta, maxpar):
     """
     Create a Schedule from an AliasList.
     """
+    stampcache = {}
     dmapper = {}
     processed = []
     for a in aliases:
@@ -635,8 +636,6 @@ def lower_aliases(aliases, meta, maxpar):
                     intervals.append(i)
                     continue
 
-            assert i.stamp >= interval.stamp
-
             if not (writeto or
                     interval != interval.zero() or
                     (maxpar and SEQUENTIAL not in meta.properties.get(i.dim))):
@@ -654,7 +653,9 @@ def lower_aliases(aliases, meta, maxpar):
 
             # We further bump the interval stamp if we were requested to trade
             # fusion for more collapse-parallelism
-            interval = interval.lift(interval.stamp + int(maxpar))
+            if maxpar:
+                stamp = stampcache.setdefault(interval.dim, Stamp())
+                interval = interval.lift(stamp)
 
             writeto.append(interval)
             intervals.append(interval)

--- a/devito/passes/clusters/misc.py
+++ b/devito/passes/clusters/misc.py
@@ -2,10 +2,10 @@ from collections import Counter
 from itertools import groupby, product
 
 from devito.ir.clusters import Cluster, ClusterGroup, Queue
-from devito.ir.support import TILABLE, SEQUENTIAL, Scope, Stamp
+from devito.ir.support import TILABLE, SEQUENTIAL, Scope
 from devito.passes.clusters.utils import cluster_pass
 from devito.symbolics import pow_to_mul
-from devito.tools import DAG, as_tuple, flatten, frozendict, timed_pass
+from devito.tools import DAG, Stamp, as_tuple, flatten, frozendict, timed_pass
 from devito.types import Symbol
 
 __all__ = ['Lift', 'fuse', 'optimize_pows', 'extract_increments',

--- a/devito/tools/abc.py
+++ b/devito/tools/abc.py
@@ -2,7 +2,7 @@ import abc
 from hashlib import sha1
 
 
-__all__ = ['Tag', 'Signer', 'Pickable', 'Singleton']
+__all__ = ['Tag', 'Signer', 'Pickable', 'Singleton', 'Stamp']
 
 
 class Tag(abc.ABC):
@@ -162,3 +162,15 @@ class Singleton(type):
         if cls not in cls._instances:
             cls._instances[cls] = super(Singleton, cls).__call__(*args, **kwargs)
         return cls._instances[cls]
+
+
+class Stamp(object):
+
+    """
+    Uniquely identify objects.
+    """
+
+    def __repr__(self):
+        return "<%s>" % str(id(self))[-3:]
+
+    __str__ = __repr__

--- a/tests/test_fission.py
+++ b/tests/test_fission.py
@@ -1,0 +1,96 @@
+from conftest import assert_structure
+from devito import (Eq, Inc, Grid, Function, TimeFunction, SubDimension, SubDomain,
+                    Operator, solve)
+
+
+def test_issue_1725():
+
+    class ToyPMLLeft(SubDomain):
+        name = 'toypmlleft'
+
+        def define(self, dimensions):
+            x, y = dimensions
+            return {x: x, y: ('left', 2)}
+
+    class ToyPMLRight(SubDomain):
+        name = 'toypmlright'
+
+        def define(self, dimensions):
+            x, y = dimensions
+            return {x: x, y: ('right', 2)}
+
+    subdomains = [ToyPMLLeft(), ToyPMLRight()]
+    grid = Grid(shape=(20, 20), subdomains=subdomains)
+
+    u = TimeFunction(name='u', grid=grid, time_order=2, space_order=2)
+
+    eqns = [Eq(u.forward, solve(u.dt2 - u.laplace, u.forward), subdomain=sd)
+            for sd in subdomains]
+
+    op = Operator(eqns, opt='fission')
+
+    # Note the `x` loop is fissioned, so now both loop nests can be collapsed
+    # for maximum parallelism
+    assert_structure(op, ['t,x,i1y', 't,x,i2y'], 't,x,i1y,x,i2y')
+
+
+def test_nofission_as_unprofitable():
+    """
+    Test there's no fission if not gonna increase number of collapsable loops.
+    """
+    grid = Grid(shape=(20, 20))
+    x, y = grid.dimensions
+    t = grid.stepping_dim
+
+    yl = SubDimension.left(name='yl', parent=y, thickness=4)
+    yr = SubDimension.right(name='yr', parent=y, thickness=4)
+
+    u = TimeFunction(name='u', grid=grid)
+
+    eqns = [Eq(u.forward, u[t + 1, x, y + 1] + 1.).subs(y, yl),
+            Eq(u.forward, u[t + 1, x, y - 1] + 1.).subs(y, yr)]
+
+    op = Operator(eqns, opt='fission')
+
+    assert_structure(op, ['t,x,yl', 't,x,yr'], 't,x,yl,yr')
+
+
+def test_nofission_as_illegal():
+    """
+    Test there's no fission if dependencies would break.
+    """
+    grid = Grid(shape=(20, 20))
+    x, y = grid.dimensions
+
+    f = Function(name='f', grid=grid, dimensions=(y,), shape=(20,))
+    u = TimeFunction(name='u', grid=grid)
+    v = TimeFunction(name='v', grid=grid)
+
+    eqns = [Inc(f, v + 1.),
+            Eq(u.forward, f[y + 1] + 1.)]
+
+    op = Operator(eqns, opt='fission')
+
+    assert_structure(op, ['t,x,y', 't,x,y'], 't,x,y,y')
+
+
+def test_fission_partial():
+    """
+    Test there's no fission if not gonna increase number of collapsable loops.
+    """
+    grid = Grid(shape=(20, 20))
+    x, y = grid.dimensions
+    t = grid.stepping_dim
+
+    yl = SubDimension.left(name='yl', parent=y, thickness=4)
+    yr = SubDimension.right(name='yr', parent=y, thickness=4)
+
+    u = TimeFunction(name='u', grid=grid)
+
+    eqns = [Eq(u.forward, u[t + 1, x, y + 1] + 1.).subs(y, yl),
+            Eq(u.forward, u[t + 1, x, y - 1] + 1.).subs(y, yr),
+            Eq(u.forward, u[t + 1, x, y] + 1.)]
+
+    op = Operator(eqns, opt='fission')
+
+    assert_structure(op, ['t,x,yl', 't,x,yr', 't,x,y'], 't,x,yl,yr,x,y')


### PR DESCRIPTION
Add loop fission, a compiler pass that is currently used to trade-off data locality for more collapsable loops on GPUs.

Example:

```
#pragma acc collapse(1)
for x
  for y0
    ...
  for y1
    ...
```

after loop fission (I emphasize that **currently** this only gets applied if running on GPUs) we get:

```
#pragma acc collapse(2)
for x
  for y0
    ...
#pragma acc collapse(2)
for x
  for y1
    ...
```

fixes #1725 
