### PR TITLE
reqs: pip new file arg format

### DIFF
--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -5,4 +5,4 @@ channels:
 dependencies:
   - pip
   - pip:
-    - -r file:requirements.txt
+    - -r requirements.txt


### PR DESCRIPTION
Fixing according to new pip reqs format
According to: https://stackoverflow.com/questions/68571543/using-a-pip-requirements-file-in-a-conda-yml-file-throws-attributeerror-fileno