### PR TITLE
compiler: lift skewing in higher block levels

### DIFF
--- a/devito/passes/clusters/blocking.py
+++ b/devito/passes/clusters/blocking.py
@@ -104,8 +104,6 @@ class Blocking(Queue):
                 properties = dict(c.properties)
                 properties.pop(d)
                 properties.update({bd: c.properties[d] - {TILABLE} for bd in block_dims})
-                properties.update({bd: c.properties[d] - {SKEWABLE}
-                                  for bd in block_dims[:-1]})
 
                 processed.append(c.rebuild(exprs=exprs, ispace=ispace,
                                            properties=properties))
@@ -257,11 +255,15 @@ class Skewing(Queue):
                 return clusters
             skew_dim = skew_dims.pop()
 
+            # The level of a given Dimension in the hierarchy of block Dimensions, used
+            # to skew over the outer level of loops.
+            level = lambda dim: len([i for i in dim._defines if i.is_Incr])
+
             # Since we are here, prefix is skewable and nested under a
             # SEQUENTIAL loop.
             intervals = []
             for i in c.ispace:
-                if i.dim is d:
+                if i.dim is d and level(d) <= 1:  # Skew only at level 0 or 1
                     intervals.append(Interval(d, skew_dim, skew_dim))
                 else:
                     intervals.append(i)


### PR DESCRIPTION
Another PR to help towards time-tiling. When in blocking, skewed bounds are lifted to outer loops. Will help to easier handle skewing factors as the factor is used at the outer levels of blocking.

```
41       for (int x0_blk0 = time + x_m; x0_blk0 <= time + x_M; x0_blk0 += x0_blk0_size)
42       {
43         for (int y0_blk0 = time + y_m; y0_blk0 <= time + y_M; y0_blk0 += y0_blk0_size)
44         {
45           for (int x = x0_blk0; x <= MIN(x0_blk0 + x0_blk0_size - 1, time + x_M); x += 1)
46           {
47             for (int y = y0_blk0; y <= MIN(y0_blk0 + y0_blk0_size - 1, time + y_M); y += 1)
48             {
49               for (int z = z_m; z <= z_M; z += 1)
50               {
51                 u[t0][x - time + 1][y - time + 1][z + 1] = v[t0][x - time + 1][y - time + 1][z + 1] + 1;
```
instead of

```
41       for (int x0_blk0 = x_m; x0_blk0 <= x_M; x0_blk0 += x0_blk0_size)
42       {
43         for (int y0_blk0 = y_m; y0_blk0 <= y_M; y0_blk0 += y0_blk0_size)
44         {
45           for (int x = time + x0_blk0; x <= MIN(time + x0_blk0 + x0_blk0_size - 1, time + x_M); x += 1)
46           {
47             for (int y = time + y0_blk0; y <= MIN(time + y0_blk0 + y0_blk0_size - 1, time + y_M); y += 1)
48             {
49               for (int z = z_m; z <= z_M; z += 1)
50               {
51                 u[t0][x - time + 1][y - time + 1][z + 1] = v[t0][x - time + 1][y - time + 1][z + 1] + 1;
```
