### PR TITLE
compiler: Fix zero to zero slices

### DIFF
--- a/devito/builtins/initializers.py
+++ b/devito/builtins/initializers.py
@@ -283,9 +283,7 @@ def initialize_function(function, data, nbl, mapper=None, mode='constant',
             pad_outhalo(function)
         return
 
-    nbl = nbl_to_padsize(nbl, function.ndim)
-    slices = tuple([slice(nl, -nr) for _, (nl, nr) in zip(range(function.grid.dim),
-                                                          as_tuple(nbl))])
+    nbl, slices = nbl_to_padsize(nbl, function.ndim)
     if isinstance(data, dv.Function):
         function.data[slices] = data.data[:]
     else:

--- a/devito/builtins/utils.py
+++ b/devito/builtins/utils.py
@@ -50,18 +50,27 @@ def nbl_to_padsize(nbl, ndim):
     nb_total = as_tuple(nbl)
     if len(nb_total) == 1 and len(nb_total) < ndim:
         nb_pad = ndim*((nb_total[0], nb_total[0]),)
+        slices = ndim*(slice(nb_total[0], None, 1),) \
+            if nb_total[0] == 0 else ndim*(slice(nb_total[0], -nb_total[0], 1),)
     elif len(nb_total) == ndim:
         nb_pad = []
+        slices = []
         for nb_dim in nb_total:
             if len(as_tuple(nb_dim)) == 1:
                 nb_pad.append((nb_dim, nb_dim))
+                s = slice(nb_dim, None, 1) if nb_dim == 0 \
+                    else slice(nb_dim, -nb_dim, 1)
+                slices.append(s)
             else:
                 assert len(nb_dim) == 2
                 nb_pad.append(nb_dim)
+                s = slice(nb_dim[0], None, 1) if nb_dim[1] == 0 \
+                    else slice(nb_dim[0], -nb_dim[1], 1)
+                slices.append(s)
     else:
         raise ValueError("`nbl` must be an integer or tuple of (tuple of) integers"
                          "of length `function.ndim`.")
-    return tuple(nb_pad)
+    return tuple(nb_pad), tuple(slices)
 
 
 def pad_outhalo(function):

--- a/devito/data/data.py
+++ b/devito/data/data.py
@@ -415,8 +415,7 @@ class Data(np.ndarray):
                 # Need to wrap index based on modulo
                 v = index_apply_modulo(i, s)
             elif self._is_distributed is True and dec is not None:
-                # Need to convert the user-provided global indices into local indices.
-                # Obviously this will have no effect if MPI is not used
+                # Convert the user-provided global indices into local indices.
                 try:
                     v = convert_index(i, dec, mode='glb_to_loc')
                 except TypeError:

--- a/devito/data/decomposition.py
+++ b/devito/data/decomposition.py
@@ -239,7 +239,13 @@ class Decomposition(tuple):
                 elif isinstance(glb_idx, slice):
                     if self.loc_empty:
                         return slice(-1, -3)
-                    if glb_idx.step >= 0:
+                    if glb_idx.step >= 0 and glb_idx.stop == 0:
+                        glb_idx_min = self.glb_min if glb_idx.start is None \
+                            else glb_idx.start
+                        glb_idx_max = self.glb_max if glb_idx.stop is None \
+                            else glb_idx.stop
+                        retfunc = lambda a, b: slice(a, b, glb_idx.step)
+                    elif glb_idx.step >= 0:
                         glb_idx_min = self.glb_min if glb_idx.start is None \
                             else glb_idx.start
                         glb_idx_max = self.glb_max if glb_idx.stop is None \

--- a/devito/data/decomposition.py
+++ b/devito/data/decomposition.py
@@ -239,11 +239,10 @@ class Decomposition(tuple):
                 elif isinstance(glb_idx, slice):
                     if self.loc_empty:
                         return slice(-1, -3)
-                    if glb_idx.step >= 0 and glb_idx.stop == 0:
+                    if glb_idx.step >= 0 and glb_idx.stop == self.glb_min:
                         glb_idx_min = self.glb_min if glb_idx.start is None \
                             else glb_idx.start
-                        glb_idx_max = self.glb_max if glb_idx.stop is None \
-                            else glb_idx.stop
+                        glb_idx_max = self.glb_min
                         retfunc = lambda a, b: slice(a, b, glb_idx.step)
                     elif glb_idx.step >= 0:
                         glb_idx_min = self.glb_min if glb_idx.start is None \

--- a/devito/data/utils.py
+++ b/devito/data/utils.py
@@ -91,7 +91,6 @@ def index_dist_to_repl(idx, decomposition):
 def convert_index(idx, decomposition, mode='glb_to_loc'):
     """Convert a global index into a local index or vise versa according to mode."""
     if is_integer(idx) or isinstance(idx, slice):
-        # FIXME: Bug in here: wrong slices are being returned when start and end are zero
         return decomposition(idx, mode=mode)
     elif isinstance(idx, (tuple, list)):
         return [decomposition(i, mode=mode) for i in idx]

--- a/devito/data/utils.py
+++ b/devito/data/utils.py
@@ -91,6 +91,7 @@ def index_dist_to_repl(idx, decomposition):
 def convert_index(idx, decomposition, mode='glb_to_loc'):
     """Convert a global index into a local index or vise versa according to mode."""
     if is_integer(idx) or isinstance(idx, slice):
+        # FIXME: Bug in here: wrong slices are being returned when start and end are zero
         return decomposition(idx, mode=mode)
     elif isinstance(idx, (tuple, list)):
         return [decomposition(i, mode=mode) for i in idx]

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1034,6 +1034,21 @@ class TestDataDistributed(object):
         expected2 = np.full(result2.shape, 1)
         assert(np.all(result2 == expected2))
 
+    def test_empty_slicing(self):
+        grid = Grid(shape=(2, 2), extent=(1, 1))
+        f = Function(name='f', grid=grid)
+        g = TimeFunction(name='g', grid=grid)
+        assert(f.data[0:0].shape == (0, 2))
+        assert(f.data[0:0, 0:0].shape == (0, 0))
+        assert(g.data[0:0].shape == (0, 2, 2))
+        assert(g.data[0:0, 0:0].shape == (0, 0, 2))
+        assert(g.data[0:0, 0:0, 0:0].shape == (0, 0, 0))
+        assert(f.data[1:1].shape == (0, 2))
+        assert(f.data[0:0, 1:1].shape == (0, 0))
+        assert(g.data[1:1].shape == (0, 2, 2))
+        assert(g.data[1:1, 0:0].shape == (0, 0, 2))
+        assert(g.data[1:1, 0:0, 1:1].shape == (0, 0, 0))
+
     @pytest.mark.parallel(mode=4)
     def test_neg_start_stop(self):
         grid0 = Grid(shape=(8, 8))


### PR DESCRIPTION
Fixes a bug where slices of `Function`'s of the form `f.data[0:0]` were returning all data instead of an empty array of shape `(0, n, ...)`.

Fixes #1756.