### PR TITLE
mpi: Patch neighborhood construction

### DIFF
--- a/devito/mpi/distributed.py
+++ b/devito/mpi/distributed.py
@@ -367,11 +367,11 @@ class Distributor(AbstractDistributor):
         # Set up diagonal neighbours
         for i in product([LEFT, CENTER, RIGHT], repeat=self.ndim):
             neighbor = [c + s.val for c, s in zip(self.mycoords, i)]
-            try:
-                ret[i] = self.comm.Get_cart_rank(neighbor)
-            except:
-                # Fallback for MPI ranks at the grid boundary
+
+            if any(c < 0 or c >= s for c, s in zip(neighbor, self.topology)):
                 ret[i] = MPI.PROC_NULL
+            else:
+                ret[i] = self.comm.Get_cart_rank(neighbor)
 
         return ret
 


### PR DESCRIPTION
From the MPI specs (for example [at this link](https://mpi.deino.net/mpi_functions/MPI_Cart_rank.html)):

> MPI_ERR_ARG
>    Invalid argument. Some argument is invalid and is not identified by a specific error class (e.g., MPI_ERR_RANK). 

In master, we're catching the MPI_ERR_ARG as if that were an indication that the MPI rank is at the boundary. This is the case for many many MPI distributions and configurations, but (unsurprisingly) not for all. I have a server with several GPUs and the NVidia MPI configured as per our `Dockerfile.nvidia` where `Get_cart_rank` does **not** trigger `MPI_ERR_RANK` for MPI ranks at the boundary -- rather, it provides the MPI rank of the process at the opposite side of the virtual topology.

With this patch, we explicitly use `MPI.PROC_NULL`, when necessary, for the neighborhood of the MPI ranks at the grid boundary.

PS: I don't really know how to add a test here. But this edit simply makes sure we honor the MPI specification as we should have done in the first place