### PR TITLE
compiler: add relaxation template as part of IncrDimension

### DIFF
--- a/devito/passes/clusters/blocking.py
+++ b/devito/passes/clusters/blocking.py
@@ -3,7 +3,7 @@ from collections import Counter
 from devito.ir.clusters import Queue
 from devito.ir.support import (SEQUENTIAL, SKEWABLE, TILABLE, Interval, IntervalGroup,
                                IterationSpace)
-from devito.symbolics import uxreplace
+from devito.symbolics import uxreplace, evalmin
 from devito.types import IncrDimension
 
 from devito.symbolics import xreplace_indices
@@ -96,10 +96,12 @@ class Blocking(Queue):
         block_dims = [bd]
 
         for i in range(1, self.levels):
-            bd = IncrDimension(name % i, bd, bd, bd + bd.step - 1, size=size)
+            bd = IncrDimension(name % i, bd, bd, bd + bd.step - 1, size=size,
+                               _rmax=evalmin(bd + bd.step - 1, bd.root.symbolic_max))
             block_dims.append(bd)
 
-        bd = IncrDimension(d.name, bd, bd, bd + bd.step - 1, 1, size=size)
+        bd = IncrDimension(d.name, bd, bd, bd + bd.step - 1, 1, size=size,
+                           _rmax=evalmin(bd + bd.step - 1, bd.root.symbolic_max))
         block_dims.append(bd)
 
         processed = []

--- a/devito/symbolics/manipulation.py
+++ b/devito/symbolics/manipulation.py
@@ -12,7 +12,7 @@ from devito.symbolics.search import retrieve_indexed, retrieve_functions
 from devito.tools import as_list, as_tuple, flatten, split
 from devito.types.equation import Eq
 
-__all__ = ['xreplace_indices', 'pow_to_mul', 'as_symbol', 'indexify',
+__all__ = ['evalmin', 'xreplace_indices', 'pow_to_mul', 'as_symbol', 'indexify',
            'split_affine', 'subs_op_args', 'uxreplace', 'aligned_indices',
            'Uxmapper', 'reuse_if_untouched', 'evalmin']
 

--- a/devito/symbolics/manipulation.py
+++ b/devito/symbolics/manipulation.py
@@ -12,7 +12,7 @@ from devito.symbolics.search import retrieve_indexed, retrieve_functions
 from devito.tools import as_list, as_tuple, flatten, split
 from devito.types.equation import Eq
 
-__all__ = ['evalmin', 'xreplace_indices', 'pow_to_mul', 'as_symbol', 'indexify',
+__all__ = ['xreplace_indices', 'pow_to_mul', 'as_symbol', 'indexify',
            'split_affine', 'subs_op_args', 'uxreplace', 'aligned_indices',
            'Uxmapper', 'reuse_if_untouched', 'evalmin']
 

--- a/tests/test_skewing.py
+++ b/tests/test_skewing.py
@@ -88,7 +88,7 @@ class TestCodeGenSkewing(object):
         (['Eq(u, v + 1)',
           'Eq(u[x+1,y+1,z+1],v[x+1,y+1,z+1]+1)']),
     ])
-    def test_no_sequential(self, expr, expected):
+    def test_no_skewing(self, expr, expected):
         """Tests code generation on skewed indices."""
         grid = Grid(shape=(16, 16, 16))
         x, y, z = grid.dimensions
@@ -129,16 +129,16 @@ class TestCodeGenSkewing(object):
           'Eq(u[t0,x-time+1,y-time+1,z-time+1],v[t0,x-time+1,y-time+1,z-time+1]+1)',
           True, True]),
     ])
-    def test_skewing_codegen(self, expr, expected, skewing, blockinner):
-        """Tests code generation on skewed indices."""
+    def test_skewing_zero_blocklevels(self, expr, expected, skewing, blockinner):
+        """Tests code generation is skewed only."""
         grid = Grid(shape=(16, 16, 16))
         x, y, z = grid.dimensions
         time = grid.time_dim
 
         u = TimeFunction(name='u', grid=grid)  # noqa
         v = TimeFunction(name='v', grid=grid)  # noqa
+
         eqn = eval(expr)
-        # List comprehension would need explicit locals/globals mappings to eval
         op = Operator(eqn, opt=('blocking', {'blocklevels': 0, 'skewing': skewing,
                                              'blockinner': blockinner}))
         op.apply(time_M=5)


### PR DESCRIPTION
This PR moves the control of MIN/MAX bounds upon creation of an IncrDimension though:
```
    @cached_property
    def relaxed_max(self):
```
This way an IncrDimension holds info of its MIN/MAX bounds at cluster level.

At IET level, we only add the offsets through replace.

This helps to define (in future) more exotic patterns of blocking schemes at cluster level only.