### PR TITLE
Support Apple M1 by moving to py-cpuinfo >= 8.

### DIFF
--- a/devito/arch/archinfo.py
+++ b/devito/arch/archinfo.py
@@ -452,7 +452,10 @@ class Cpu64(Platform):
 
     def _detect_isa(self):
         for i in reversed(self.known_isas):
-            if any(j.startswith(i) for j in get_cpu_info()['flags']):
+            flags = get_cpu_info()['flags']
+            if flags is None:
+                flags = []
+            if any(j.startswith(i) for j in flags):
                 # Using `startswith`, rather than `==`, as a flag such as 'avx512'
                 # appears as 'avx512f, avx512cd, ...'
                 return i

--- a/devito/arch/compiler.py
+++ b/devito/arch/compiler.py
@@ -158,7 +158,7 @@ class Compiler(GCCToolchain):
         self.ldflags = ['-shared']
 
         self.include_dirs = []
-        self.libraries = ['m']
+        self.libraries = []
         self.library_dirs = []
         self.defines = []
         self.undefines = []
@@ -414,7 +414,8 @@ class ClangCompiler(Compiler):
                 # -march isn't supported on power architectures
                 self.cflags += ['-mcpu=native']
             else:
-                self.cflags += ['-march=native']
+                pass
+                # self.cflags += ['-march=native']
             if language == 'openmp':
                 self.ldflags += ['-fopenmp']
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ flake8>=2.1.0
 nbval
 cached-property
 psutil>=5.1.0
-py-cpuinfo<8
+py-cpuinfo
 cgen>=2020.1
 codepy>=2019.1
 click<8.0


### PR DESCRIPTION
Hi! I was hoping to play around with Devito but immediately hit a problem because it seems that support for Apple M1 chips is not available. I don't expect this PR to be merged in its current form but I just wanted to share what I needed to do in order to get devito working for me. 

The initial problem was with the dependency `py-cpuinfo`. The error comes because py-cpuinfo 7.0.0 doesn't support the architecture. It looks like py-cpuinfo 8 and up have partial support for M1, but [this commit](https://github.com/devitocodes/devito/commit/654e98b03a0264604020ac14cdfe3efefd2313dc) is holding Devito back on the old version. I reversed that commit and then made a minor edit to `archinfo.py` that corrected an error about `flags = None`. 

Then, I needed to set the environment vars:
```
export DEVITO_PLATFORM=arm
export DEVITO_ARCH=osx
```

Then I also needed to remove the `m` lib linkage since it's included by default in OSX. I also needed to remove `-march=native` because Apple clang does not support `native` as an architecture choice. 

So far, these edits have been sufficient for me to run the example notebooks and almost all the tests. That said, there are a few test failures that seem unrelated to the M1 problems or the changes here. 