### PR TITLE
compiler: Define Iteration bounds through hierarchy-related rules

### DIFF
--- a/devito/core/cpu.py
+++ b/devito/core/cpu.py
@@ -63,6 +63,7 @@ class Cpu64OperatorMixin(object):
         # Misc
         o['optcomms'] = oo.pop('optcomms', True)
         o['linearize'] = oo.pop('linearize', False)
+        o['relax'] = oo.pop('relax', True)
         o['mapify-reduce'] = oo.pop('mapify-reduce', cls.MAPIFY_REDUCE)
 
         # Recognised but unused by the CPU backend
@@ -165,7 +166,7 @@ class Cpu64AdvOperator(Cpu64OperatorMixin, CoreOperator):
         mpiize(graph, **kwargs)
 
         # Lower BlockDimensions so that blocks of arbitrary shape may be used
-        relax_incr_dimensions(graph)
+        relax_incr_dimensions(graph, options=options)
 
         # Parallelism
         parizer = cls._Target.Parizer(sregistry, options, platform, compiler)
@@ -254,7 +255,7 @@ class Cpu64CustomOperator(Cpu64OperatorMixin, CustomOperator):
 
         return {
             'denormals': avoid_denormals,
-            'blocking': partial(relax_incr_dimensions),
+            'blocking': partial(relax_incr_dimensions, options=options),
             'parallel': parizer.make_parallel,
             'openmp': parizer.make_parallel,
             'mpi': partial(mpiize, **kwargs),

--- a/devito/core/gpu.py
+++ b/devito/core/gpu.py
@@ -76,6 +76,7 @@ class DeviceOperatorMixin(object):
         # Misc
         o['optcomms'] = oo.pop('optcomms', True)
         o['linearize'] = oo.pop('linearize', False)
+        o['relax'] = oo.pop('relax', True)
         o['mapify-reduce'] = oo.pop('mapify-reduce', cls.MAPIFY_REDUCE)
 
         if oo:
@@ -179,7 +180,7 @@ class DeviceAdvOperator(DeviceOperatorMixin, CoreOperator):
         mpiize(graph, **kwargs)
 
         # Lower BlockDimensions so that blocks of arbitrary shape may be used
-        relax_incr_dimensions(graph)
+        relax_incr_dimensions(graph, options=options)
 
         # GPU parallelism
         parizer = cls._Target.Parizer(sregistry, options, platform, compiler)

--- a/devito/passes/iet/misc.py
+++ b/devito/passes/iet/misc.py
@@ -68,7 +68,7 @@ def hoist_prodders(iet):
 
 
 @iet_pass
-def relax_incr_dimensions(iet, **kwargs):
+def relax_incr_dimensions(iet, options, **kwargs):
     """
     This pass adjusts the bounds of blocked Iterations in order to include the "remainder
     regions".  Without the relaxation that occurs in this pass, the only way to iterate
@@ -88,6 +88,8 @@ def relax_incr_dimensions(iet, **kwargs):
 
     """
     mapper = {}
+    relax = options['relax']
+
     for tree in retrieve_iteration_tree(iet):
         iterations = [i for i in tree if i.dim.is_Block]
         if not iterations:
@@ -159,12 +161,13 @@ def relax_incr_dimensions(iet, **kwargs):
             # Step 4: Drop a candidate if it is the symbolic_min of other candidates
             # Applies to defmin only. e.g. defmin = [x0_blk0, x_m] and
             # (x0_blk0.symbolic_min is x_m), then drop `x_m`, defmin = [x0_blk0]
-            for k in defmin.copy():  # TOFIX: Should not use a copy I guess?
-                try:
-                    if k.symbolic_min in defmin:
-                        defmin.remove(k.symbolic_min)
-                except:
-                    pass
+            if relax:
+                for k in defmin.copy():  # TOFIX: Should not use a copy I guess?
+                    try:
+                        if k.symbolic_min in defmin:
+                            defmin.remove(k.symbolic_min)
+                    except:
+                        pass
 
             # Step 5: Drop candidates that reduce the iteration space
             # Usually due to presence of offsets due to subdimensions

--- a/devito/symbolics/extended_sympy.py
+++ b/devito/symbolics/extended_sympy.py
@@ -649,8 +649,33 @@ class DOUBLEP(CastStar):
 
 CEIL = Function('ceil')
 FLOOR = Function('floor')
-MAX = Function('MAX')
 MIN = Function('MIN')
+MAX = Function('MAX')
+
+
+class RMin(Function):
+    """
+    Utility class for recursively generating nested MIN relations.
+    """
+
+    def __new__(cls, item, *args):
+        if len(args) == 0:
+            return item
+        else:
+            return MIN(item, RMin(*args))
+
+
+class RMax(Function):
+    """
+    Utility class for recursively generating nested MAX relations.
+    """
+
+    def __new__(cls, item, *args):
+        if len(args) == 0:
+            return item
+        else:
+            return MAX(item, RMax(*args))
+
 
 Null = Macro('NULL')
 

--- a/devito/symbolics/extended_sympy.py
+++ b/devito/symbolics/extended_sympy.py
@@ -652,6 +652,9 @@ FLOOR = Function('floor')
 MAX = Function('MAX')
 MIN = Function('MIN')
 
+# DefFunction, unlike sympy.Function, generates e.g. `sizeof(float)`, not `sizeof(float_)`
+SizeOf = lambda *args: DefFunction('sizeof', tuple(args))
+
 
 def rfunc(func, item, *args):
     """

--- a/devito/symbolics/extended_sympy.py
+++ b/devito/symbolics/extended_sympy.py
@@ -652,6 +652,8 @@ FLOOR = Function('floor')
 MAX = Function('MAX')
 MIN = Function('MIN')
 
+Null = Macro('NULL')
+
 # DefFunction, unlike sympy.Function, generates e.g. `sizeof(float)`, not `sizeof(float_)`
 SizeOf = lambda *args: DefFunction('sizeof', tuple(args))
 

--- a/devito/symbolics/extended_sympy.py
+++ b/devito/symbolics/extended_sympy.py
@@ -653,37 +653,7 @@ MIN = Function('MIN')
 MAX = Function('MAX')
 
 
-class RMin(Function):
-    """
-    Utility class for recursively generating nested MIN relations.
-    """
-
-    def __new__(cls, item, *args):
-        if len(args) == 0:
-            return item
-        else:
-            return MIN(item, RMin(*args))
-
-
-class RMax(Function):
-    """
-    Utility class for recursively generating nested MAX relations.
-    """
-
-    def __new__(cls, item, *args):
-        if len(args) == 0:
-            return item
-        else:
-            return MAX(item, RMax(*args))
-
-
-Null = Macro('NULL')
-
-# DefFunction, unlike sympy.Function, generates e.g. `sizeof(float)`, not `sizeof(float_)`
-SizeOf = lambda *args: DefFunction('sizeof', tuple(args))
-
-
-def rfunc(func, item, *args):
+def rfunc(func=None, item=None, *args):
     """
     A utility function that recursively generates 'func' nested relations.
 

--- a/devito/symbolics/extended_sympy.py
+++ b/devito/symbolics/extended_sympy.py
@@ -649,11 +649,11 @@ class DOUBLEP(CastStar):
 
 CEIL = Function('ceil')
 FLOOR = Function('floor')
-MIN = Function('MIN')
 MAX = Function('MAX')
+MIN = Function('MIN')
 
 
-def rfunc(func=None, item=None, *args):
+def rfunc(func, item, *args):
     """
     A utility function that recursively generates 'func' nested relations.
 

--- a/devito/symbolics/manipulation.py
+++ b/devito/symbolics/manipulation.py
@@ -16,7 +16,7 @@ from devito.types.relational import Le, Lt, Gt, Ge
 
 __all__ = ['xreplace_indices', 'pow_to_mul', 'indexify', 'split_affine',
            'subs_op_args', 'uxreplace', 'Uxmapper', 'reuse_if_untouched',
-           'evalrel']
+           'evaluate_relation', 'reduce_relation']
 
 
 def uxreplace(expr, rule):

--- a/devito/symbolics/manipulation.py
+++ b/devito/symbolics/manipulation.py
@@ -387,5 +387,8 @@ def evalrel(func=min, input=None, assumptions=None, eval=True):
     except TypeError:
         pass
 
-    # If eval=False return only the simplified list
-    return rfunc(func, *input) if eval else input
+    if eval:
+        return rfunc(func, *input)
+    else:
+        # If 'eval==False' return only the simplified list
+        return input

--- a/devito/symbolics/manipulation.py
+++ b/devito/symbolics/manipulation.py
@@ -295,7 +295,7 @@ def reuse_if_untouched(expr, args, evaluate=False):
         return expr.func(*args, evaluate=evaluate)
 
 
-def evalrel(func=min, input=None, assumptions=None):
+def evalrel(func=min, input=None, assumptions=None, eval=True):
     """
     The purpose of this function is two-fold: (i) to reduce the `input` candidates of a
     for a MIN/MAX expression based on the given `assumptions` and (ii) return the nested
@@ -310,6 +310,9 @@ def evalrel(func=min, input=None, assumptions=None):
     assumptions : list
         A list of assumptions formed as relationals between candidates, assumed to be
         True. Defaults to None.
+    eval : bool, optional
+        Return the nested MIN/MAX expression if True. Otherwise return only the
+        reduced `input`. Defaults to True.
 
     Examples
     --------
@@ -323,6 +326,8 @@ def evalrel(func=min, input=None, assumptions=None):
     >>> d = Symbol('d')
     >>> evalrel(max, [a, b, c, d], [Le(d, a), Ge(c, b)])
     MAX(a, c)
+    >>> evalrel(max, [a, b, c, d], [Le(d, a), Ge(c, b)], eval=False)
+    [a, c]
     """
     sfunc = (Min if func is min else Max)  # Choose SymPy's Min/Max
 
@@ -381,4 +386,6 @@ def evalrel(func=min, input=None, assumptions=None):
             return exp
     except TypeError:
         pass
-    return rfunc(func, *input)
+
+    # If eval=False return only the simplified list
+    return rfunc(func, *input) if eval else input

--- a/devito/types/relational.py
+++ b/devito/types/relational.py
@@ -6,6 +6,7 @@ __all__ = ['Le', 'Lt', 'Ge', 'Gt', 'Ne']
 
 
 class AbstractRel(object):
+
     """
     Abstract mixin class for objects subclassing sympy.Relational.
     """

--- a/devito/types/relational.py
+++ b/devito/types/relational.py
@@ -49,6 +49,8 @@ class Le(AbstractRel, sympy.Le):
     >>> Le(g, 1)
     g(x, y) <= 1
     """
+    is_Le = True
+    is_Lt = False
 
     def __new__(cls, lhs, rhs=0, subdomain=None, **kwargs):
         kwargs.update({'evaluate': False})
@@ -84,6 +86,8 @@ class Lt(AbstractRel, sympy.Lt):
     >>> Lt(g, 1)
     g(x, y) < 1
     """
+    is_Lt = True
+    is_Le = False
 
     def __new__(cls, lhs, rhs=0, subdomain=None, **kwargs):
         kwargs.update({'evaluate': False})
@@ -119,6 +123,8 @@ class Ge(AbstractRel, sympy.Ge):
     >>> Ge(g, 1)
     g(x, y) >= 1
     """
+    is_Ge = True
+    is_Gt = False
 
     def __new__(cls, lhs, rhs=0, subdomain=None, **kwargs):
         kwargs.update({'evaluate': False})
@@ -154,6 +160,8 @@ class Gt(AbstractRel, sympy.Gt):
     >>> Gt(g, 1)
     g(x, y) > 1
     """
+    is_Gt = True
+    is_Ge = False
 
     def __new__(cls, lhs, rhs=0, subdomain=None, **kwargs):
         kwargs.update({'evaluate': False})

--- a/devito/types/relational.py
+++ b/devito/types/relational.py
@@ -9,6 +9,7 @@ class AbstractRel(object):
     """
     Abstract mixin class for objects subclassing sympy.Relational.
     """
+
     @property
     def negated(self):
         return ops.get(self.func)(*self.args)
@@ -49,8 +50,6 @@ class Le(AbstractRel, sympy.Le):
     >>> Le(g, 1)
     g(x, y) <= 1
     """
-    is_Le = True
-    is_Lt = False
 
     def __new__(cls, lhs, rhs=0, subdomain=None, **kwargs):
         kwargs.update({'evaluate': False})
@@ -86,8 +85,6 @@ class Lt(AbstractRel, sympy.Lt):
     >>> Lt(g, 1)
     g(x, y) < 1
     """
-    is_Lt = True
-    is_Le = False
 
     def __new__(cls, lhs, rhs=0, subdomain=None, **kwargs):
         kwargs.update({'evaluate': False})
@@ -123,8 +120,6 @@ class Ge(AbstractRel, sympy.Ge):
     >>> Ge(g, 1)
     g(x, y) >= 1
     """
-    is_Ge = True
-    is_Gt = False
 
     def __new__(cls, lhs, rhs=0, subdomain=None, **kwargs):
         kwargs.update({'evaluate': False})
@@ -160,8 +155,6 @@ class Gt(AbstractRel, sympy.Gt):
     >>> Gt(g, 1)
     g(x, y) > 1
     """
-    is_Gt = True
-    is_Ge = False
 
     def __new__(cls, lhs, rhs=0, subdomain=None, **kwargs):
         kwargs.update({'evaluate': False})

--- a/tests/test_skewing.py
+++ b/tests/test_skewing.py
@@ -2,7 +2,7 @@ import pytest
 import numpy as np
 
 from conftest import assert_blocking
-from devito.symbolics import MIN
+from devito.symbolics import MIN, MAX
 from devito import Grid, Dimension, Eq, Function, TimeFunction, Operator, norm # noqa
 from devito.ir import Expression, Iteration, FindNodes
 
@@ -58,6 +58,74 @@ class TestCodeGenSkewing(object):
         assert iters[2].symbolic_max == MIN(iters[0].dim + iters[0].dim.symbolic_incr
                                             - 1, iters[0].dim.symbolic_max + time)
         assert iters[3].symbolic_min == iters[3].dim.symbolic_min
+        assert iters[3].symbolic_max == MIN(iters[1].dim + iters[1].dim.symbolic_incr
+                                            - 1, iters[1].dim.symbolic_max + time)
+        assert iters[4].symbolic_min == (iters[4].dim.symbolic_min)
+        assert iters[4].symbolic_max == (iters[4].dim.symbolic_max)
+        skewed = [i.expr for i in FindNodes(Expression).visit(bns['x0_blk0'])]
+        assert str(skewed[0]).replace(' ', '') == expected
+        assert np.isclose(norm(u), norm_u, rtol=1e-5)
+        assert np.isclose(norm(v), norm_v, rtol=1e-5)
+
+        u.data[:] = 0
+        v.data[:] = 0
+        op2 = Operator(eqn, opt=('advanced'))
+        op2.apply(time_M=5)
+        assert np.isclose(norm(u), norm_u, rtol=1e-5)
+        assert np.isclose(norm(v), norm_v, rtol=1e-5)
+
+    '''
+    Test code generation with blocking+skewing+nonrelaxed bounds, tests adapted from
+    test_operator.py
+    '''
+    @pytest.mark.parametrize('expr, expected, norm_u, norm_v', [
+        (['Eq(u.forward, u + 1)',
+          'Eq(u[t1,x-time+1,y-time+1,z+1],u[t0,x-time+1,y-time+1,z+1]+1)',
+         np.sqrt((16*16*16)*6**2 + (16*16*16)*5**2), 0]),
+        (['Eq(u.forward, v + 1)',
+          'Eq(u[t1,x-time+1,y-time+1,z+1],v[t0,x-time+1,y-time+1,z+1]+1)',
+         np.sqrt((16*16*16)*1**2 + (16*16*16)*1**2), 0]),
+        (['Eq(u, v + 1)',
+          'Eq(u[t0,x-time+1,y-time+1,z+1],v[t0,x-time+1,y-time+1,z+1]+1)',
+         np.sqrt((16*16*16)*1**2 + (16*16*16)*1**2), 0]),
+    ])
+    def test_skewed_bounds_expanded(self, expr, expected, norm_u, norm_v):
+        """Tests code generation on skewed indices."""
+        grid = Grid(shape=(16, 16, 16))
+        x, y, z = grid.dimensions
+        time = grid.time_dim
+
+        u = TimeFunction(name='u', grid=grid)  # noqa
+        v = TimeFunction(name='v', grid=grid)  # noqa
+        eqn = eval(expr)
+        # List comprehension would need explicit locals/globals mappings to eval
+        op = Operator(eqn, opt=('advanced', {'skewing': True, 'relax': False}))
+        op.apply(time_M=5)
+        iters = FindNodes(Iteration).visit(op)
+        time_iter = [i for i in iters if i.dim.is_Time]
+        assert len(time_iter) == 1
+
+        bns, _ = assert_blocking(op, {'x0_blk0'})
+
+        iters = FindNodes(Iteration).visit(bns['x0_blk0'])
+        assert len(iters) == 5
+        assert iters[0].dim.parent is x
+        assert iters[1].dim.parent is y
+        assert iters[4].dim is z
+        assert iters[2].dim.parent is iters[0].dim
+        assert iters[3].dim.parent is iters[1].dim
+
+        assert iters[0].symbolic_min == (iters[0].dim.parent.symbolic_min + time)
+        assert iters[0].symbolic_max == (iters[0].dim.parent.symbolic_max + time)
+        assert iters[1].symbolic_min == (iters[1].dim.parent.symbolic_min + time)
+        assert iters[1].symbolic_max == (iters[1].dim.parent.symbolic_max + time)
+
+        assert iters[2].symbolic_min == MAX(iters[2].dim.symbolic_min,
+                                            iters[2].dim.parent.symbolic_min + time)
+        assert iters[2].symbolic_max == MIN(iters[0].dim + iters[0].dim.symbolic_incr
+                                            - 1, iters[0].dim.symbolic_max + time)
+        assert iters[3].symbolic_min == MAX(iters[3].dim.symbolic_min,
+                                            iters[3].dim.parent.symbolic_min + time)
         assert iters[3].symbolic_max == MIN(iters[1].dim + iters[1].dim.symbolic_incr
                                             - 1, iters[1].dim.symbolic_max + time)
         assert iters[4].symbolic_min == (iters[4].dim.symbolic_min)

--- a/tests/test_symbolics.py
+++ b/tests/test_symbolics.py
@@ -313,7 +313,7 @@ class TestRelationsWithAssumptions(object):
 
     def test_multibounds_op(self):
         """
-        Tests evalrel function on a simple example.
+        Tests evaluate_relation function on a simple example.
         """
 
         grid = Grid(shape=(16, 16, 16))
@@ -331,7 +331,7 @@ class TestRelationsWithAssumptions(object):
         f = TimeFunction(name='f', grid=grid, space_order=2)
 
         f.data[:] = 0.1
-        eqns = [Eq(f.forward, f.laplace + f * evalrel(min, [f, b, c, d]))]
+        eqns = [Eq(f.forward, f.laplace + f * evaluate_relation(min, [f, b, c, d]))]
         op = Operator(eqns, opt=('advanced'))
         op.apply(time_M=5)
         fnorm = norm(f)
@@ -340,7 +340,8 @@ class TestRelationsWithAssumptions(object):
         d2 = Function(name='d2', grid=grid)
 
         f.data[:] = 0.1
-        eqns = [Eq(f.forward, f.laplace + f * evalrel(min, [f, b, c2, d2], [Ge(d, c)]))]
+        eqns = [Eq(f.forward, f.laplace + f * evaluate_relation(min, [f, b, c2, d2],
+                [Ge(d, c)]))]
         op = Operator(eqns, opt=('advanced'))
         op.apply(time_M=5)
         fnorm2 = norm(f)
@@ -380,7 +381,7 @@ class TestRelationsWithAssumptions(object):
         eqn = eval(expr)
         assumptions = eval(assumptions)
         expected = eval(expected)
-        assert evalrel(op, eqn, assumptions) == expected
+        assert evaluate_relation(op, eqn, assumptions) == expected
 
     @pytest.mark.parametrize('op, expr, assumptions, expected', [
         ([min, '[a, b, c, d]', '[Ge(b, a), Ge(a, b), Le(c, b), Le(b, d)]', 'c']),
@@ -423,7 +424,7 @@ class TestRelationsWithAssumptions(object):
         eqn = eval(expr)
         assumptions = eval(assumptions)
         expected = eval(expected)
-        assert evalrel(op, eqn, assumptions) == expected
+        assert evaluate_relation(op, eqn, assumptions) == expected
 
     @pytest.mark.parametrize('op, expr, assumptions, expected', [
         ([min, '[a, b, c, d]', '[Ge(b, a)]', 'a']),
@@ -446,4 +447,4 @@ class TestRelationsWithAssumptions(object):
         eqn = eval(expr)
         assumptions = eval(assumptions)
         expected = eval(expected)
-        assert evalrel(op, eqn, assumptions) == expected
+        assert evaluate_relation(op, eqn, assumptions) == expected

--- a/tests/test_symbolics.py
+++ b/tests/test_symbolics.py
@@ -8,7 +8,7 @@ from sympy import Symbol
 from devito import (Constant, Dimension, Grid, Function, solve, TimeFunction, Eq,  # noqa
                     Operator, SubDimension, norm, Le, Ge, Gt, Lt)
 from devito.ir import Expression, FindNodes
-from devito.symbolics import (retrieve_functions, retrieve_indexed, evalrel,  # noqa
+from devito.symbolics import (retrieve_functions, retrieve_indexed, evaluate_relation,  # noqa
                               CallFromPointer, Cast, FieldFromPointer,
                               FieldFromComposite, IntDiv, MIN, MAX, ccode)
 from devito.types import Array, Object


### PR DESCRIPTION
Definitely needs some improvement in terms of presenting better the theoretic background of it.

Main concept : This is a system of rules to handle iteration bounds in a parametric way based upon known assumptions of their relations. 

Clearly there are more lines of code, and considering that devito supports only one type of blocking shapes this may seem an overkill. However this opens up space for new blocking scheme implementations where more complex iteration bounds are needed.

Opening now, to get reviewers familiar with the reasoning and the code.