### PR TITLE
compiler: gpu cc detection fix

### DIFF
--- a/devito/arch/archinfo.py
+++ b/devito/arch/archinfo.py
@@ -319,11 +319,11 @@ def get_nvidia_cc():
     cc_major = ctypes.c_int()
     cc_minor = ctypes.c_int()
 
-    if (cuda.cuDeviceComputeCapability(ctypes.byref(cc_major), ctypes.byref(cc_minor), 0)
-       == cuda.cuInit(0)):
-        return 10*cc_major.value + cc_minor.value
-    else:
+    if cuda.cuInit(0) != 0:
         return None
+    elif (cuda.cuDeviceComputeCapability(ctypes.byref(cc_major),
+          ctypes.byref(cc_minor), 0) == 0):
+        return 10*cc_major.value + cc_minor.value
 
 
 @memoized_func


### PR DESCRIPTION
` cuda.cuInit(0) ` needs to be called before cuda.cuDeviceComputeCapability and not inside.
Tests were passing accidentally before. Now it should be fine before the offloading dockerfile comes in.