### PR TITLE
builtins: Add devito version of NumPy's count_nonzero, nonzero

### DIFF
--- a/tests/test_builtins.py
+++ b/tests/test_builtins.py
@@ -6,7 +6,7 @@ from scipy import misc
 from conftest import skipif
 from devito import Grid, Function, TimeFunction, switchconfig
 from devito.builtins import (assign, norm, gaussian_smooth, initialize_function,
-                             inner, mmin, mmax)
+                             inner, mmin, mmax, count_nonzero)
 from devito.data import LEFT, RIGHT
 from devito.tools import as_tuple
 from devito.types import SubDomain, SparseTimeFunction
@@ -369,3 +369,29 @@ class TestBuiltinsResult(object):
         term1 = np.max(rec0.data)
         term2 = mmax(rec0)
         assert np.isclose(term1/term2 - 1, 0.0, rtol=0.0, atol=1e-5)
+
+    @pytest.mark.parametrize('shape', [(21, 21), (41, 41)])
+    def test_count_nonzero(self, shape):
+        """
+        Test that count of nonzeros works correctly
+        """
+        grid = Grid(shape=shape)
+
+        # Define function 𝑓. We will initialize f's data with ones on its diagonal.
+        f = Function(name='f', shape=shape, dimensions=grid.dimensions)
+        f.data[:] = np.eye(shape[0])
+        count = count_nonzero(f)
+        assert (count == shape[0])
+
+    @pytest.mark.parametrize('shape', [(11,), (21, 21), (41, 41, 41)])
+    def test_count_nonzero_II(self, shape):
+        """
+        Test that count of nonzeros works correctly
+        """
+        grid = Grid(shape=shape)
+
+        # Define function 𝑓. We will initialize f's data using a specific set of numbers.
+        f = TimeFunction(name='f', shape=shape, dimensions=grid.dimensions)
+        f.data[:] = np.random.choice([3, 5, 7, 9], size=shape)
+        count = count_nonzero(f)
+        assert (count == np.prod(shape))


### PR DESCRIPTION
Add a Devito version of NumPy's count_nonzero, nonzero:
https://numpy.org/doc/stable/reference/generated/numpy.count_nonzero.html
This PR is needed towards implementing steps 1,2 of p4 in https://arxiv.org/pdf/2010.10248.pdf.
In the paper, I was using NumPy, but now to automate through Devito, I would like to generate it through Devito.
Numpy's version is faster unless we change to collapse(1). Then Devito is faster for like int32 (20000, 20000) sized functions.
If reviewers require more benchmarking, happy to do so.

Generated code is like:
```
  /* Begin section0 */
  START_TIMER(section0)
  #pragma omp parallel num_threads(nthreads)
  {
    #pragma omp for collapse(2) schedule(static,1) reduction(+:h1[1])
    for (int x = x_m; x <= x_M; x += 1)
    {
      for (int y = y_m; y <= y_M; y += 1)
      {
        if (f[x + 1][y + 1] != 0)
        {
          int r0 = 1;
          h1[1] += r0;
        }
      }
    }
  }
  STOP_TIMER(section0,timers)
  /* End section0 */

  return 0;
```