### PR TITLE
CI: update codecov action version

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -84,7 +84,7 @@ jobs:
 
     - name: Upload coverage to Codecov
       if: matrix.name != 'pytest-docker-py37-gcc-omp'
-      uses: codecov/codecov-action@v1.0.6
+      uses: codecov/codecov-action@v2
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         name: ${{ matrix.name }}

--- a/.github/workflows/pytest-core-mpi.yml
+++ b/.github/workflows/pytest-core-mpi.yml
@@ -44,7 +44,7 @@ jobs:
         python3 -m pytest --cov --cov-config=.coveragerc --cov-report=xml -m parallel tests/
 
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v1.0.15
+      uses: codecov/codecov-action@v2
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         name: pytest-mpi

--- a/.github/workflows/pytest-core-nompi.yml
+++ b/.github/workflows/pytest-core-nompi.yml
@@ -154,7 +154,7 @@ jobs:
 
     - name: Upload coverage to Codecov
       if: matrix.name != 'pytest-docker-py37-gcc-omp'
-      uses: codecov/codecov-action@v1.0.6
+      uses: codecov/codecov-action@v2
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         name: ${{ matrix.name }}

--- a/.github/workflows/pytest-gpu.yml
+++ b/.github/workflows/pytest-gpu.yml
@@ -113,7 +113,7 @@ jobs:
         DEVITO_MPI=1 mpirun -n 2 pytest examples/seismic/viscoelastic/viscoelastic_example.py
 
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v1.0.6
+      uses: codecov/codecov-action@v2
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         name: ${{ matrix.name }}


### PR DESCRIPTION
Fixes #1812 

According to their repo, `v1` will be retired Feb 1st so switching to v2.
https://github.com/codecov/codecov-action