### PR TITLE
Corrected 2D kernel when sintheta==0

### DIFF
--- a/examples/seismic/tti/operators.py
+++ b/examples/seismic/tti/operators.py
@@ -109,10 +109,18 @@ def Gzz_centered_2d(model, field, costheta, sintheta, space_order):
     Rotated second order derivative w.r.t. z.
     """
     order1 = space_order // 2
-    Gz = -(sintheta * field.dx(fd_order=order1) +
-           costheta * field.dy(fd_order=order1))
-    Gzz = ((Gz * sintheta).dx(fd_order=order1).T +
-           (Gz * costheta).dy(fd_order=order1).T)
+
+    # Add rotated derivative if angles are not zero. If angles are
+    # zeros then `0*Gz = 0` and doesn't have any `.dy` ....
+    if sintheta != 0:
+        Gz = -(sintheta * field.dx(fd_order=order1) +
+              costheta * field.dy(fd_order=order1))
+        Gzz = ((Gz * sintheta).dx(fd_order=order1).T +
+               (Gz * costheta).dy(fd_order=order1).T)
+    else:
+        Gz = costheta * field.dy(fd_order=order1)
+        Gzz = (Gz * costheta).dy(fd_order=order1).T
+
     return Gzz
 
 


### PR DESCRIPTION
When sin(theta) is 0, the Zero object has no attribute `dy`