### PR TITLE
ci: Update examples miniconda action version

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -33,7 +33,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Setup conda
-      uses: conda-incubator/setup-miniconda@v2
+      uses: conda-incubator/setup-miniconda@v2.1.1
       with:
        python-version: 3.8
        activate-environment: devito


### PR DESCRIPTION
Testing if the examples workflow using conda hangs with this version of the action.