### PR TITLE
compiler: Use int64_t, not unsigned int, for linearization

### DIFF
--- a/devito/passes/iet/linearization.py
+++ b/devito/passes/iet/linearization.py
@@ -54,10 +54,7 @@ def linearization(iet, **kwargs):
     iet = linearize_pointers(iet)
     iet = linearize_transfers(iet, sregistry)
 
-    # Include header files for int64_t and uint_64
-    includes = ['stdint.h']
-
-    return iet, {'headers': headers, 'includes': includes, 'args': args}
+    return iet, {'headers': headers, 'args': args}
 
 
 def linearize_accesses(iet, key, cache, sregistry):

--- a/devito/passes/iet/linearization.py
+++ b/devito/passes/iet/linearization.py
@@ -54,7 +54,10 @@ def linearization(iet, **kwargs):
     iet = linearize_pointers(iet)
     iet = linearize_transfers(iet, sregistry)
 
-    return iet, {'headers': headers, 'args': args}
+    # Include header files for int64_t and uint_64
+    includes = ['stdint.h']
+
+    return iet, {'headers': headers, 'includes': includes, 'args': args}
 
 
 def linearize_accesses(iet, key, cache, sregistry):
@@ -105,7 +108,7 @@ def linearize_accesses(iet, key, cache, sregistry):
                 stmt = built[expr]
             except KeyError:
                 name = sregistry.make_name(prefix='%s_stride' % d.name)
-                s = Symbol(name=name, dtype=np.uint32, is_const=True)
+                s = Symbol(name=name, dtype=np.int64, is_const=True)
                 stmt = built[expr] = DummyExpr(s, expr, init=True)
             mapper[f][d] = stmt.write
             cache[f].stmts1.append(stmt)
@@ -178,14 +181,14 @@ def _generate_fsz(f, d, sregistry):
 @_generate_fsz.register(DiscreteFunction)
 def _(f, d, sregistry):
     name = sregistry.make_name(prefix='%s_fsz' % d.name)
-    s = Symbol(name=name, dtype=np.uint32, is_const=True)
+    s = Symbol(name=name, dtype=np.int64, is_const=True)
     return DummyExpr(s, f._C_get_field(FULL, d).size, init=True)
 
 
 @_generate_fsz.register(Array)
 def _(f, d, sregistry):
     name = sregistry.make_name(prefix='%s_fsz' % d.name)
-    s = Symbol(name=name, dtype=np.uint32, is_const=True)
+    s = Symbol(name=name, dtype=np.int64, is_const=True)
     return DummyExpr(s, f.symbolic_shape[d], init=True)
 
 

--- a/devito/tools/utils.py
+++ b/devito/tools/utils.py
@@ -8,6 +8,7 @@ import types
 
 import numpy as np
 import sympy
+from cgen import dtype_to_ctype as cgen_dtype_to_ctype
 
 __all__ = ['prod', 'as_tuple', 'is_integer', 'generator', 'grouper', 'split', 'roundm',
            'powerset', 'invert', 'flatten', 'single_or', 'filter_ordered', 'as_mapper',
@@ -190,54 +191,8 @@ def filter_sorted(elements, key=None):
 
 
 def dtype_to_cstr(dtype):
-    """
-    Translate a numpy.dtype into C string.
-
-    This is mostly copy-pasted from:
-
-        https://github.com/inducer/cgen/blob/main/cgen/__init__.py
-
-    The following changes were made:
-
-        * np.int64 => `int64_t`, NOT `long` OR `long long`
-        * np.uint64 => `uint64_t`, NOT `long` or `long long`
-
-    This is because we want to map numpy.dtypes to C types such that the
-    C equivalents have *at least* as many bits irrespective on the underlying
-    compiler and architecture.
-    """
-    if dtype is None:
-        raise ValueError("dtype may not be None")
-
-    dtype = np.dtype(dtype)
-    if dtype == np.int64:
-        return "int64_t"
-    elif dtype == np.uint64:
-        return "uint64_t"
-    elif dtype == np.int32:
-        return "int"
-    elif dtype == np.uint32:
-        return "unsigned int"
-    elif dtype == np.int16:
-        return "short int"
-    elif dtype == np.uint16:
-        return "short unsigned int"
-    elif dtype == np.int8:
-        return "signed char"
-    elif dtype == np.uint8:
-        return "unsigned char"
-    elif dtype == np.float32:
-        return "float"
-    elif dtype == np.float64:
-        return "double"
-    elif dtype == np.complex64:
-        return "std::complex<float>"
-    elif dtype == np.complex128:
-        return "std::complex<double>"
-    elif dtype == np.void:
-        return "void"
-    else:
-        raise ValueError("unable to map dtype '%s'" % dtype)
+    """Translate numpy.dtype into C string."""
+    return cgen_dtype_to_ctype(dtype)
 
 
 def dtype_to_ctype(dtype):

--- a/devito/tools/utils.py
+++ b/devito/tools/utils.py
@@ -8,7 +8,6 @@ import types
 
 import numpy as np
 import sympy
-from cgen import dtype_to_ctype as cgen_dtype_to_ctype
 
 __all__ = ['prod', 'as_tuple', 'is_integer', 'generator', 'grouper', 'split', 'roundm',
            'powerset', 'invert', 'flatten', 'single_or', 'filter_ordered', 'as_mapper',
@@ -191,8 +190,54 @@ def filter_sorted(elements, key=None):
 
 
 def dtype_to_cstr(dtype):
-    """Translate numpy.dtype into C string."""
-    return cgen_dtype_to_ctype(dtype)
+    """
+    Translate a numpy.dtype into C string.
+
+    This is mostly copy-pasted from:
+
+        https://github.com/inducer/cgen/blob/main/cgen/__init__.py
+
+    The following changes were made:
+
+        * np.int64 => `int64_t`, NOT `long` OR `long long`
+        * np.uint64 => `uint64_t`, NOT `long` or `long long`
+
+    This is because we want to map numpy.dtypes to C types such that the
+    C equivalents have *at least* as many bits irrespective on the underlying
+    compiler and architecture.
+    """
+    if dtype is None:
+        raise ValueError("dtype may not be None")
+
+    dtype = np.dtype(dtype)
+    if dtype == np.int64:
+        return "int64_t"
+    elif dtype == np.uint64:
+        return "uint64_t"
+    elif dtype == np.int32:
+        return "int"
+    elif dtype == np.uint32:
+        return "unsigned int"
+    elif dtype == np.int16:
+        return "short int"
+    elif dtype == np.uint16:
+        return "short unsigned int"
+    elif dtype == np.int8:
+        return "signed char"
+    elif dtype == np.uint8:
+        return "unsigned char"
+    elif dtype == np.float32:
+        return "float"
+    elif dtype == np.float64:
+        return "double"
+    elif dtype == np.complex64:
+        return "std::complex<float>"
+    elif dtype == np.complex128:
+        return "std::complex<double>"
+    elif dtype == np.void:
+        return "void"
+    else:
+        raise ValueError("unable to map dtype '%s'" % dtype)
 
 
 def dtype_to_ctype(dtype):

--- a/tests/test_linearize.py
+++ b/tests/test_linearize.py
@@ -167,7 +167,7 @@ def test_codegen_quality0():
 
     exprs = FindNodes(Expression).visit(op)
     assert len(exprs) == 6
-    assert all('const unsigned int' in str(i) for i in exprs[:-2])
+    assert all('const int64_t' in str(i) for i in exprs[:-2])
 
     # Only four access macros necessary, namely `uL0`, `aL0`, `bufL0`, `bufL1` (the
     # other three obviously are _POSIX_C_SOURCE, START_TIMER, STOP_TIMER)
@@ -188,8 +188,8 @@ def test_codegen_quality1():
     # 11 expressions in total are expected, 8 of which are for the linearized accesses
     exprs = FindNodes(Expression).visit(op)
     assert len(exprs) == 11
-    assert all('const unsigned int' in str(i) for i in exprs[:-3])
-    assert all('const unsigned int' not in str(i) for i in exprs[-3:])
+    assert all('const int64_t' in str(i) for i in exprs[:-3])
+    assert all('const int64_t' not in str(i) for i in exprs[-3:])
 
     # Only two access macros necessary, namely `uL0` and `r1L0` (the other five
     # obviously are _POSIX_C_SOURCE, MIN, MAX, START_TIMER, STOP_TIMER)

--- a/tests/test_linearize.py
+++ b/tests/test_linearize.py
@@ -167,7 +167,7 @@ def test_codegen_quality0():
 
     exprs = FindNodes(Expression).visit(op)
     assert len(exprs) == 6
-    assert all('const int64_t' in str(i) for i in exprs[:-2])
+    assert all('const long' in str(i) for i in exprs[:-2])
 
     # Only four access macros necessary, namely `uL0`, `aL0`, `bufL0`, `bufL1` (the
     # other three obviously are _POSIX_C_SOURCE, START_TIMER, STOP_TIMER)
@@ -188,8 +188,8 @@ def test_codegen_quality1():
     # 11 expressions in total are expected, 8 of which are for the linearized accesses
     exprs = FindNodes(Expression).visit(op)
     assert len(exprs) == 11
-    assert all('const int64_t' in str(i) for i in exprs[:-3])
-    assert all('const int64_t' not in str(i) for i in exprs[-3:])
+    assert all('const long' in str(i) for i in exprs[:-3])
+    assert all('const long' not in str(i) for i in exprs[-3:])
 
     # Only two access macros necessary, namely `uL0` and `r1L0` (the other five
     # obviously are _POSIX_C_SOURCE, MIN, MAX, START_TIMER, STOP_TIMER)


### PR DESCRIPTION
fixes #1771 