### PR TITLE
compiler: Minor blocking.py refactorings

### DIFF
--- a/devito/data/utils.py
+++ b/devito/data/utils.py
@@ -108,7 +108,7 @@ def index_handle_oob(idx):
     elif isinstance(idx, (tuple, list)):
         return [i for i in idx if i is not None]
     elif isinstance(idx, np.ndarray):
-        if idx.dtype == np.bool_:
+        if idx.dtype == bool:
             # A boolean mask, nothing to do
             return idx
         elif idx.ndim == 1:

--- a/devito/ir/clusters/algorithms.py
+++ b/devito/ir/clusters/algorithms.py
@@ -226,7 +226,7 @@ class Stepper(Queue):
 
         d = prefix[-1].dim
 
-        subiters = flatten([c.ispace.sub_iterators.get(d, []) for c in clusters])
+        subiters = flatten([c.ispace.sub_iterators[d] for c in clusters])
         subiters = {i for i in subiters if i.is_Stepping}
         if not subiters:
             return clusters

--- a/devito/ir/clusters/analysis.py
+++ b/devito/ir/clusters/analysis.py
@@ -75,7 +75,7 @@ class Parallelism(Detector):
 
     def _callback(self, clusters, d, prefix):
         # Rule out if non-unitary increment Dimension (e.g., `t0=(time+1)%2`)
-        if any(c.sub_iterators.get(d) for c in clusters):
+        if any(c.sub_iterators[d] for c in clusters):
             return SEQUENTIAL
 
         # All Dimensions up to and including `i-1`

--- a/devito/ir/support/space.py
+++ b/devito/ir/support/space.py
@@ -845,9 +845,9 @@ class IterationSpace(Space):
 
     def promote(self, cond):
         intervals = self.intervals.promote(cond)
-        sub_iterators = {i.promote(cond).dim: self.sub_iterators.get(i.dim, ())
+        sub_iterators = {i.promote(cond).dim: self.sub_iterators[i.dim]
                          for i in self.intervals}
-        directions = {i.promote(cond).dim: self.directions.get(i.dim, ())
+        directions = {i.promote(cond).dim: self.directions[i.dim]
                       for i in self.intervals}
 
         return IterationSpace(intervals, sub_iterators, directions)

--- a/devito/passes/clusters/buffering.py
+++ b/devito/passes/clusters/buffering.py
@@ -438,7 +438,7 @@ class Buffer(object):
                 d = d.root
                 interval, si, direction = self.itintervals_mapper[d]
             intervals.append(interval)
-            sub_iterators[d] = si + as_tuple(self.sub_iterators.get(d))
+            sub_iterators[d] = si + as_tuple(self.sub_iterators[d])
             directions[d] = direction
 
         relations = (tuple(i.dim for i in intervals),)

--- a/examples/seismic/tti/tti_example.py
+++ b/examples/seismic/tti/tti_example.py
@@ -34,7 +34,7 @@ def run(shape=(50, 50, 50), spacing=(20.0, 20.0, 20.0), tn=250.0,
     # with 'save=True' if we compute the gradient without checkpointing, if we use
     # checkpointing, PyRevolve will take care of the time history
     save = full_run and not checkpointing
-    # Define receiver geometry (spread across x, just below surface)
+    # Define receiver geometry (spread across `x, y`` just below surface)
     rec, u, v, summary = solver.forward(save=save, autotune=autotune)
 
     if preset == 'constant':

--- a/tests/test_interpolation.py
+++ b/tests/test_interpolation.py
@@ -496,7 +496,7 @@ def test_position(shape):
     src.coordinates.data[0, :] = np.array(model.domain_size) * .5 + 100.
     src.coordinates.data[0, -1] = 130.
 
-    # Define receiver geometry (same as source, but spread across x)
+    # Define receiver geometry (same as source, but spread across `x, y`)
     rec2 = Receiver(name='rec', grid=model.grid, time_range=time_range, npoint=nrec)
     rec2.coordinates.data[:, 0] = np.linspace(100., 100. + model.domain_size[0],
                                               num=nrec)

--- a/tests/test_operator.py
+++ b/tests/test_operator.py
@@ -821,7 +821,7 @@ class TestApplyArguments(object):
         self.verify_arguments(arguments, expected)
         # Verify execution
         op(**args)
-        mask = np.ones((5, 6, 7), dtype=np.bool)
+        mask = np.ones((5, 6, 7), dtype=bool)
         mask[1:4, 2:5, 3:6] = False
         assert (g.data[mask] == 0.).all()
         assert (g.data[1:4, 2:5, 3:6] == 1.).all()
@@ -852,7 +852,7 @@ class TestApplyArguments(object):
         self.verify_arguments(arguments, expected)
         # Verify execution
         op(**args)
-        mask = np.ones((1, 5, 6, 7), dtype=np.bool)
+        mask = np.ones((1, 5, 6, 7), dtype=bool)
         mask[:, 1:4, 2:5, 3:6] = False
         assert (f.data[mask] == 0.).all()
         assert (f.data[:, 1:4, 2:5, 3:6] == 1.).all()


### PR DESCRIPTION
- minor refresh in `def decompose`
- do not `AnalyzeSkewing` if not needed
- Ensure `sub_iterator` keys exist in mappers rather than always defaulting to `None` (see: https://github.com/devitocodes/devito/pull/1845/files#r822563785)