### PR TITLE
arch: Fix CustomCompiler instantiation

### DIFF
--- a/devito/arch/compiler.py
+++ b/devito/arch/compiler.py
@@ -612,7 +612,7 @@ class CustomCompiler(Compiler):
         platform = kwargs.pop('platform', configuration['platform'])
 
         if any(i in environ for i in ['CC', 'CXX', 'CFLAGS', 'LDFLAGS']):
-            obj = super().__new__(cls, *args, **kwargs)
+            obj = super().__new__(cls)
             obj.__init__(*args, **kwargs)
             return obj
         elif platform is M1:


### PR DESCRIPTION
Hello guys,
I was here packaging devito for my distribution and got into a bug saying
```
TypeError: object.__new__() takes exactly one argument (the type to instantiate)
```
for the line I changed with this simple commit. As a consequence I simply fixed the issue. I've made some tests and this shouldnt and mustn't break anything on anyone's computer.

This may sound simple and non important, but Devito is written in Python, which is a distro agnostic language. It is expected that the code will run on any linux or mac, and if it doesn't I think it should be treated as a bug (at least in my humble opinion).

I have every intention to make Devito work on [NixOS package manager (Nix)](https://nixos.org/) since it is completely reproducible and distro agnostic, which will relieve me from the necessity of using a Docker container for developement.

Thx for your time.