### PR TITLE
compiler: Move derivative.evaluate

### DIFF
--- a/devito/finite_differences/derivative.py
+++ b/devito/finite_differences/derivative.py
@@ -325,14 +325,15 @@ class Derivative(sympy.Derivative, Differentiable):
     def _eval_fd(self, expr):
         """
         Evaluate finite difference approximation of the Derivative.
-        Evaluation is carried out via the following four steps:
+        Evaluation is carried out via the following three steps:
 
         - 1: Evaluate derivatives within the expression. For example given
             `f.dx * g`, `f.dx` will be evaluated first.
         - 2: Evaluate the finite difference for the (new) expression.
-        - 3: Evaluate remaining terms (as `g` may need to be evaluated
-        at a different point).
-        - 4: Apply substitutions.
+             This in turn is a two-step procedure, for Functions that may
+             may need to be evaluated at a different point due to e.g. a
+             shited derivative.
+        - 3: Apply substitutions.
         """
         # Step 1: Evaluate derivatives within expression
         expr = getattr(expr, '_eval_deriv', expr)
@@ -348,9 +349,6 @@ class Derivative(sympy.Derivative, Differentiable):
         else:
             res = generic_derivative(expr, *self.dims, self.fd_order, self.deriv_order,
                                      matvec=self.transpose, x0=self.x0)
-
-        # Step 3: Evaluate remaining part of expression
-        res = res.evaluate
 
         # Step 4: Apply substitution
         for e in self._ppsubs:

--- a/devito/finite_differences/derivative.py
+++ b/devito/finite_differences/derivative.py
@@ -350,7 +350,7 @@ class Derivative(sympy.Derivative, Differentiable):
             res = generic_derivative(expr, *self.dims, self.fd_order, self.deriv_order,
                                      matvec=self.transpose, x0=self.x0)
 
-        # Step 4: Apply substitution
+        # Step 3: Apply substitutions
         for e in self._ppsubs:
             res = res.xreplace(e)
 

--- a/devito/finite_differences/finite_difference.py
+++ b/devito/finite_differences/finite_difference.py
@@ -280,11 +280,19 @@ def indices_weights_to_fd(expr, dim, inds, weights, matvec=1):
             iloc = sympify(i).xreplace(mapper)
         # Enforce fixed precision FD coefficients to avoid variations in results
         c = sympify(c).evalf(_PRECISION)
-        terms.append(expr._subs(dim, iloc - (expr.indices_ref[dim] - dim)) * c)
+
+        # The FD term
+        term = expr._subs(dim, iloc - (expr.indices_ref[dim] - dim)) * c
+
+        # Re-evaluate any off-the-grid Functions potentially impacted by the FD
+        try:
+            term = term.evaluate
+        except AttributeError:
+            # Pure number
+            pass
+
+        terms.append(term)
 
     deriv = EvalDerivative(*terms, base=expr)
-
-    # Evaluate remaining part of expression
-    deriv = deriv.evaluate
 
     return deriv

--- a/devito/finite_differences/finite_difference.py
+++ b/devito/finite_differences/finite_difference.py
@@ -284,4 +284,7 @@ def indices_weights_to_fd(expr, dim, inds, weights, matvec=1):
 
     deriv = EvalDerivative(*terms, base=expr)
 
+    # Evaluate remaining part of expression
+    deriv = deriv.evaluate
+
     return deriv


### PR DESCRIPTION
This is in preparation for the "derivative evaluation overhaul" (DEO from now on!) that we've talked about recently.

-- A glimpse of the future --

I will need to introduce an `evaluate_partial` to `Derivative` (I cannot touch `evaluate` because we don't want API-level surprises). Such `evaluate_partial` (better name needed) will expand the `Derivative` to an intermediate high-level object, for example

```
Derivative(f, x).dx.evaluate_partial
->
DotDerivative(f, coeff)
```

Representing the dot product between `f` and an array of coefficients, that is, a "rolled" Derivative. This will be the object used by Devito throughout compilation and in particular throughout (and until) Cluster specialization.

So, back to this PR... moving that `.evaluate` will allow me to share the first two steps of `Derivative.evaluate` with `Derivative.evaluate_partial` by moving them to a common function, or perhaps better, by having `Derivative.evaluate` calling `Derivative.evaluate_partial` first. Not sure yet, still very much work in progress, and I'm doing this only part time