### PR TITLE
mpi: Do not send padding region when doing pythonland halo exchange

### DIFF
--- a/devito/types/dense.py
+++ b/devito/types/dense.py
@@ -565,8 +565,11 @@ class DiscreteFunction(AbstractFunction, ArgProvider, Differentiable):
         self._is_halo_dirty = True
         offset = getattr(getattr(self, '_offset_%s' % region.name)[dim], side.name)
         size = getattr(getattr(self, '_size_%s' % region.name)[dim], side.name)
-        index_array = [slice(offset, offset+size) if d is dim else slice(None)
-                       for d in self.dimensions]
+        index_array = [
+            slice(offset, offset+size) if d is dim else slice(pl, s - pr)
+            for d, s, (pl, pr)
+            in zip(self.dimensions, self.shape_allocated, self._padding)
+        ]
         return np.asarray(self._data[index_array])
 
     @property

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -132,7 +132,7 @@ def parallel(item):
         # OpenMPI requires an explicit flag for oversubscription. We need it as some
         # of the MPI tests will spawn lots of processes
         if mpi_distro == 'OpenMPI':
-            call = [mpi_exec, '--oversubscribe'] + args
+            call = [mpi_exec, '--oversubscribe', '--timeout', '30'] + args
         else:
             call = [mpi_exec] + args
 

--- a/tests/test_mpi.py
+++ b/tests/test_mpi.py
@@ -228,8 +228,14 @@ class TestFunction(object):
         assert np.all(f._data_ro_with_inhalo[:, 0] == 0.)
         assert np.all(f._data_ro_with_inhalo[:, -1] == 0.)
 
+    @pytest.mark.parametrize("paddings", [
+        (None, None),
+        ((0, 0), (0, 0)),
+        ((0, 0), (0, 1)),
+        ((1, 0), (0, 1)),
+    ])
     @pytest.mark.parallel(mode=2)
-    def test_halo_exchange_bilateral_asymmetric(self):
+    def test_halo_exchange_bilateral_asymmetric(self, paddings):
         """
         Test halo exchange between two processes organised in a 2x1 cartesian grid.
 
@@ -258,8 +264,9 @@ class TestFunction(object):
         """
         grid = Grid(shape=(12, 12))
         x, y = grid.dimensions
+        padding = paddings[grid.distributor.comm.rank]
 
-        f = Function(name='f', grid=grid, space_order=(1, 1, 2))
+        f = Function(name='f', grid=grid, space_order=(1, 1, 2), padding=padding)
         f.data[:] = grid.distributor.myrank + 1
 
         # Now trigger a halo exchange...


### PR DESCRIPTION
This change is both a tiny optimisation and also a fix for a potential correctness issue in the case where the application provides a customised padding, since the provided padding is not required to be the same on all ranks.

There are three commits here which hopefully make sense. 

* add a timeout to MPI tests
* add a test which fails with the two ranks having different padding (it hangs without the first commit)
* a fix

The timeout one can be a separate PR if you like, or we can drop it altogether. It's needed for the tests to behave as expected (i.e. fail) with the second commit, but after the third commit they pass again (and obviously don't hang) so I don't mind either way. 

I'm also not sure if 30s is an appropriate timeout, or if we should make it e.g. an environment variable to be set in the test environment script?