### PR TITLE
CI-Docker: Publish CPU image with tag latest

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -49,6 +49,7 @@ jobs:
           tags: |
             devitocodes/devito:cpu-latest
             devitocodes/devito:cpu-${{ github.event.release.tag_name }}
+            devitocodes/devito:latest
 
   deploy-docker-gpu:
     runs-on: [self-hosted, gpu, docker]


### PR DESCRIPTION
I think this is the only change needed. Now we publish CPU images under 3 tags - `devitocodes/devito:latest`, `devitocodes/devito:cpu-latest`, `devitocodes/devito:version`. 

So the command `docker pull devitocodes/devito` which maps automatically to `devitocodes/devito:latest`, should successfully download the latest cpu image. 