### PR TITLE
compiler: Fix checkpoint size when save != None

### DIFF
--- a/devito/checkpointing/checkpoint.py
+++ b/devito/checkpointing/checkpoint.py
@@ -72,7 +72,7 @@ class DevitoCheckpoint(Checkpoint):
     @property
     def size(self):
         """The memory consumption of the data contained in a checkpoint."""
-        return sum([int((o.size_allocated/(o.time_order+1))*o.time_order)
+        return sum([int((o.size_allocated/(o.time_size))*o.time_order)
                    for o in self.objects])
 
     def save(*args):

--- a/devito/types/dense.py
+++ b/devito/types/dense.py
@@ -1411,6 +1411,10 @@ class TimeFunction(Function):
         return self.shape_allocated[self._time_position]
 
     @property
+    def time_size(self):
+        return self._time_size
+
+    @property
     def _time_buffering(self):
         return not is_integer(self.save)
 


### PR DESCRIPTION
When using Checkpoint and `save != None` (eg. `save != time_order + 1`) the value returned for size of a TimeFunction will be larger than necessary. 

Closes #1907 