### PR TITLE
compiler: Revamp generation of implicit equations

### DIFF
--- a/devito/core/cpu.py
+++ b/devito/core/cpu.py
@@ -5,7 +5,7 @@ from devito.exceptions import InvalidOperator
 from devito.passes.equations import collect_derivatives
 from devito.passes.clusters import (Lift, blocking, buffering, cire, cse,
                                     extract_increments, factorize, fission, fuse,
-                                    optimize_pows, optimize_msds, optimize_hyperplanes)
+                                    optimize_pows, optimize_hyperplanes)
 from devito.passes.iet import (CTarget, OmpTarget, avoid_denormals, linearize, mpiize,
                                hoist_prodders, relax_incr_dimensions)
 from devito.tools import timed_pass
@@ -176,9 +176,6 @@ class Cpu64AdvOperator(Cpu64OperatorMixin, CoreOperator):
         options = kwargs['options']
         platform = kwargs['platform']
         sregistry = kwargs['sregistry']
-
-        # Optimize MultiSubDomains
-        clusters = optimize_msds(clusters)
 
         # Toposort+Fusion (the former to expose more fusion opportunities)
         clusters = fuse(clusters, toposort=True)

--- a/devito/core/gpu.py
+++ b/devito/core/gpu.py
@@ -7,7 +7,7 @@ from devito.exceptions import InvalidOperator
 from devito.passes.equations import collect_derivatives
 from devito.passes.clusters import (Lift, Streaming, Tasker, blocking, buffering,
                                     cire, cse, extract_increments, factorize,
-                                    fission, fuse, optimize_pows, optimize_msds)
+                                    fission, fuse, optimize_pows)
 from devito.passes.iet import (DeviceOmpTarget, DeviceAccTarget, mpiize, hoist_prodders,
                                is_on_device, linearize, relax_incr_dimensions)
 from devito.tools import as_tuple, timed_pass
@@ -162,9 +162,6 @@ class DeviceAdvOperator(DeviceOperatorMixin, CoreOperator):
         options = kwargs['options']
         platform = kwargs['platform']
         sregistry = kwargs['sregistry']
-
-        # Optimize MultiSubDomains
-        clusters = optimize_msds(clusters)
 
         # Toposort+Fusion (the former to expose more fusion opportunities)
         clusters = fuse(clusters, toposort=True, options=options)

--- a/devito/ir/equations/algorithms.py
+++ b/devito/ir/equations/algorithms.py
@@ -6,9 +6,9 @@ from sympy import sympify
 from devito.symbolics import (retrieve_functions, retrieve_indexed, split_affine,
                               uxreplace)
 from devito.tools import PartialOrderTuple, filter_sorted, flatten, as_tuple
-from devito.types import Dimension, Eq, IgnoreDimSort
+from devito.types import Dimension, IgnoreDimSort
 
-__all__ = ['dimension_sort', 'generate_implicit_exprs', 'lower_exprs']
+__all__ = ['dimension_sort', 'lower_exprs']
 
 
 def dimension_sort(expr):
@@ -71,43 +71,6 @@ def dimension_sort(expr):
     ordering = PartialOrderTuple(extra, relations=(relations | implicit_relations))
 
     return ordering
-
-
-def generate_implicit_exprs(expressions):
-    """
-    Create and add implicit expressions.
-
-    Implicit expressions are those not explicitly defined by the user
-    but instead are requisites of some specified functionality.
-
-    Currently, implicit expressions stem from the following:
-
-        * MultiSubDomains attached to input equations.
-    """
-    found = {}
-    processed = []
-    for e in expressions:
-        if e.subdomain:
-            try:
-                dims = [d.root for d in e.free_symbols if isinstance(d, Dimension)]
-                sub_dims = [d.root for d in e.subdomain.dimensions]
-                sub_dims.extend(e.subdomain.implicit_dimensions)
-                dims = [d for d in dims if d not in frozenset(sub_dims)]
-                dims.extend(e.subdomain.implicit_dimensions)
-                if e.subdomain not in found:
-                    grid = list(retrieve_functions(e, mode='unique'))[0].grid
-                    found[e.subdomain] = [i.func(*i.args, implicit_dims=dims) for i in
-                                          e.subdomain._create_implicit_exprs(grid)]
-                processed.extend(found[e.subdomain])
-                dims.extend(e.subdomain.dimensions)
-                new_e = Eq(e.lhs, e.rhs, subdomain=e.subdomain, implicit_dims=dims)
-                processed.append(new_e)
-            except AttributeError:
-                # Not a MultiSubDomain
-                processed.append(e)
-        else:
-            processed.append(e)
-    return processed
 
 
 def lower_exprs(expressions, **kwargs):

--- a/devito/ir/support/space.py
+++ b/devito/ir/support/space.py
@@ -730,7 +730,11 @@ class IterationSpace(Space):
                      self.directions))
 
     def __getitem__(self, key):
-        return self.intervals[key]
+        retval = self.intervals[key]
+        if isinstance(key, slice):
+            return self.project(lambda d: d in retval.dimensions)
+        else:
+            return retval
 
     @classmethod
     def union(cls, *others):
@@ -759,6 +763,9 @@ class IterationSpace(Space):
                 ret.extend([d for d in v if d not in ret])
 
         return IterationSpace(intervals, sub_iterators, directions)
+
+    def index(self, key):
+        return self.intervals.index(key)
 
     def add(self, other):
         return IterationSpace(self.intervals.add(other), self.sub_iterators,

--- a/devito/passes/clusters/__init__.py
+++ b/devito/passes/clusters/__init__.py
@@ -5,4 +5,5 @@ from .cse import *  # noqa
 from .factorization import *  # noqa
 from .blocking import *  # noqa
 from .asynchrony import *  # noqa
+from .subdomains import *  # noqa
 from .misc import *  # noqa

--- a/devito/passes/clusters/__init__.py
+++ b/devito/passes/clusters/__init__.py
@@ -5,5 +5,5 @@ from .cse import *  # noqa
 from .factorization import *  # noqa
 from .blocking import *  # noqa
 from .asynchrony import *  # noqa
-from .subdomains import *  # noqa
+from .implicit import *  # noqa
 from .misc import *  # noqa

--- a/devito/passes/clusters/implicit.py
+++ b/devito/passes/clusters/implicit.py
@@ -48,6 +48,9 @@ class LowerMultiSubDimensions(Queue):
         Cluster([Eq(f[t1, xi_n, yi_n], f[t0, xi_n, yi_n] + 1)])
     """
 
+    def _make_key_hook(self, cluster, level):
+        return (tuple(cluster.guards.get(i.dim) for i in cluster.itintervals[:level]),)
+
     def callback(self, clusters, prefix):
         try:
             dd = prefix[-1].dim

--- a/devito/passes/clusters/misc.py
+++ b/devito/passes/clusters/misc.py
@@ -7,10 +7,9 @@ from devito.passes.clusters.utils import cluster_pass
 from devito.symbolics import pow_to_mul
 from devito.tools import DAG, Stamp, as_tuple, flatten, frozendict, timed_pass
 from devito.types import Hyperplane, Symbol
-from devito.types.grid import MultiSubDimension
 
 __all__ = ['Lift', 'fuse', 'optimize_pows', 'extract_increments',
-           'fission', 'optimize_msds', 'optimize_hyperplanes']
+           'fission', 'optimize_hyperplanes']
 
 
 class Lift(Queue):
@@ -367,71 +366,6 @@ def fission(clusters):
                                    ..
     """
     return Fission().process(clusters)
-
-
-class MSDOptimizer(Queue):
-
-    """
-    Implement MultiSubDomains optimization.
-
-    Currently, the following optimizations are performed:
-
-        * Removal of redundant thicknesses assignments. These stem from Eqs
-          defined over the same MultiSubDomain in the very same loop nest.
-          The redundant assignments obviously do not impact correctness,
-          but they may affect other optimizations, such as fusion.
-    """
-
-    def callback(self, clusters, prefix):
-        if not prefix or any(isinstance(i.dim, MultiSubDimension) for i in prefix):
-            return clusters
-
-        msds = {d for d in set().union(*[c.dimensions for c in clusters])
-                if isinstance(d, MultiSubDimension)}
-        if not msds:
-            return clusters
-
-        # Remove redundant thicknesses assignments
-
-        thicknesses = set().union(*[list(i._thickness_map) for i in msds])
-        candidates = [c for c in clusters if set(c.scope.writes) & thicknesses]
-
-        # First of all, make sure we analyze all and only the thicknesses assignments
-        # at the same depth
-        d = prefix[-1].dim
-        if any(c.itintervals[-1].dim is not d for c in candidates):
-            return clusters
-
-        # Then, attempt extirpation of redundancies
-        schedulable = set(thicknesses)
-        processed = []
-        for c in clusters:
-            if c in candidates:
-                exprs = []
-                for e in c.exprs:
-                    try:
-                        schedulable.remove(e.lhs)
-                        exprs.append(e)
-                    except KeyError:
-                        # Already scheduled, no-op
-                        pass
-                if exprs:
-                    processed.append(c.rebuild(exprs=exprs))
-            else:
-                processed.append(c)
-
-        # Sanity check
-        assert len(schedulable) == 0
-
-        return processed
-
-
-@timed_pass()
-def optimize_msds(clusters):
-    """
-    Optimize clusters defined over MultiSubDomains.
-    """
-    return MSDOptimizer().process(clusters)
 
 
 @timed_pass()

--- a/devito/passes/clusters/subdomains.py
+++ b/devito/passes/clusters/subdomains.py
@@ -1,0 +1,89 @@
+"""
+Passes to gather and form implicit equations from MultiSubDomains.
+"""
+
+from devito.ir import Interval, IntervalGroup, IterationSpace, Queue
+from devito.tools import timed_pass
+from devito.types.grid import MultiSubDimension
+
+__all__ = ['generate_implicit']
+
+
+@timed_pass()
+def generate_implicit(clusters):
+    """
+    Create and add implicit expressions from high-level abstractions.
+
+    Implicit expressions are those not explicitly defined by the user
+    but instead are requisites of some specified functionality.
+
+    Currently, implicit expressions stem from the following:
+
+        * MultiSubDomains attached to input equations.
+    """
+    clusters = LowerMultiSubDimensions().process(clusters)
+
+    return clusters
+
+
+class LowerMultiSubDimensions(Queue):
+
+    """
+    Bind the free thickness symbols defined by MultiSubDimensions to
+    suitable values.
+
+    Examples
+    --------
+    Given:
+
+        Cluster([Eq(f[t1, xi_n, yi_n], f[t0, xi_n, yi_n] + 1)])
+
+    where `xi_n` and `yi_n` are MultiSubDimensions, generate:
+
+        Cluster([Eq(xi_n_ltkn, xi_n_m[n])
+                 Eq(xi_n_rtkn, xi_n_M[n])
+                 Eq(yi_n_ltkn, yi_n_m[n])
+                 Eq(yi_n_rtkn, yi_n_M[n])])
+        Cluster([Eq(f[t1, xi_n, yi_n], f[t0, xi_n, yi_n] + 1)])
+    """
+
+    def callback(self, clusters, prefix):
+        if not prefix:
+            return clusters
+
+        d = prefix[-1].dim
+        try:
+            pd = prefix[-2].dim
+        except IndexError:
+            pd = None
+
+        # The bulk of the pass is done by the first MultiSubDimension
+        if not isinstance(d, MultiSubDimension) or isinstance(pd, MultiSubDimension):
+            return clusters
+
+        # The implicit objects induced by the MultiSubDomain
+        exprs = d.msd._implicit_exprs
+        idims = d.msd.implicit_dimensions
+
+        processed = []
+        for c in clusters:
+            # We ultimately need to inject the implicit Dimensions, if any, in
+            # between the MultiSubDimensions and the outer Dimensions. We then
+            # decouple the IterationSpace into two parts -- before and after the
+            # first MultiSubDimension
+            ispace0 = c.ispace.project(lambda i: not isinstance(i, MultiSubDimension))
+            ispace1 = c.ispace.project(lambda i: isinstance(i, MultiSubDimension))
+
+            # The local IterationSpace of the implicit Dimensions, if any
+            intervals = [Interval(i, 0, 0) for i in idims]
+            relations = (ispace0.itdimensions + idims,
+                         idims + ispace1.itdimensions)
+            ispaceN = IterationSpace(IntervalGroup(intervals, relations=relations))
+
+            ispace = IterationSpace.union(ispace0, ispaceN)
+            processed.append(c.rebuild(exprs=exprs, ispace=ispace))
+
+            ispace = IterationSpace.union(ispace0, ispaceN, ispace1)
+            processed.append(c.rebuild(ispace=ispace))
+
+        return processed

--- a/devito/tools/threading.py
+++ b/devito/tools/threading.py
@@ -1,6 +1,26 @@
 import threading
 
-__all__ = ['sympy_mutex']
+__all__ = ['sympy_mutex', 'safe_dict_copy']
 
 
 sympy_mutex = threading.RLock()
+
+
+def safe_dict_copy(v):
+    """
+    Thread-safe copy of a dict.
+
+    Being implemented as a retry loop around the copy(), this function is
+    indicated for situations in which concurrent dict updates are unlikely,
+    otherwise it might eventually cause performance degradations (in which
+    case, lock-based solutions would be preferable).
+
+    Notes
+    -----
+    See https://bugs.python.org/issue40327
+    """
+    while True:
+        try:
+            return v.copy()
+        except RuntimeError:
+            pass

--- a/devito/types/caching.py
+++ b/devito/types/caching.py
@@ -4,6 +4,8 @@ import weakref
 import sympy
 from sympy.core import cache
 
+from devito.tools import safe_dict_copy
+
 
 __all__ = ['Cached', '_SymbolCache', 'CacheManager']
 
@@ -161,11 +163,7 @@ class CacheManager(object):
 
         # Take a copy of the dictionary so we can safely iterate over it
         # even if another thread is making changes
-
-        # mydict.copy() is safer than list(mydict) for getting an unchanging list
-        # See https://bugs.python.org/issue40327 for terrifying discussion
-        # on this issue.
-        cache_copied = _SymbolCache.copy()
+        cache_copied = safe_dict_copy(_SymbolCache)
 
         # Maybe trigger garbage collection
         if force is False:

--- a/devito/types/grid.py
+++ b/devito/types/grid.py
@@ -551,12 +551,22 @@ class MultiSubDimension(SubDimension):
 
         super().__init_finalize__(name, parent, left, right, ((lst, 0), (rst, 0)), False)
 
+    def __hash__(self):
+        # There is no possibility for two MultiSubDimensions to ever hash the same, since
+        # a MultiSubDimension carries a reference to a MultiSubDomain, which is unique
+        return id(self)
+
 
 class MultiSubDomain(AbstractSubDomain):
 
     """
     Abstract base class for types representing groups of SubDomains.
     """
+
+    def __hash__(self):
+        # There is no possibility for two MultiSubDomains to ever hash the same since
+        # they are by construction unique and different from each other
+        return id(self)
 
     @classmethod
     def _bounds_glb_to_loc(cls, dec, m, M):

--- a/devito/types/grid.py
+++ b/devito/types/grid.py
@@ -543,6 +543,12 @@ class MultiSubDimension(SubDimension):
     """
 
     def __init_finalize__(self, name, parent, msd):
+        # NOTE: a MultiSubDimension stashes a reference to the originating MultiSubDomain.
+        # This creates a circular pattern as the `msd` itself carries references to
+        # its MultiSubDimensions. This is currently necessary because during compilation
+        # we drop the MultiSubDomain early, but when the MultiSubDimensions are processed
+        # we still need it to create the implicit equations. Untangling this is
+        # definitely possible, but not straightforward
         self.msd = msd
 
         lst, rst = self._symbolic_thickness(name)

--- a/devito/types/grid.py
+++ b/devito/types/grid.py
@@ -610,13 +610,6 @@ class MultiSubDomain(AbstractSubDomain):
         """
         raise NotImplementedError
 
-    @property
-    def implicit_dimensions(self):
-        """
-        The Dimensions implicitly defined by the MultiSubDomain.
-        """
-        return ()
-
 
 class SubDomainSet(MultiSubDomain):
     """
@@ -782,10 +775,6 @@ class SubDomainSet(MultiSubDomain):
     @property
     def bounds(self):
         return self._local_bounds
-
-    @property
-    def implicit_dimensions(self):
-        return (self.implicit_dimension,)
 
 
 # Preset SubDomains

--- a/tests/test_subdomains.py
+++ b/tests/test_subdomains.py
@@ -162,6 +162,9 @@ class TestSubdomains(object):
 
         assert u0.data.all() == u1.data.all() == u2.data.all() == u3.data.all()
 
+
+class TestSubDomainSet(object):
+
     @pytest.mark.parametrize('opt', opts_tiling)
     def test_iterate_NDomains(self, opt):
         """
@@ -540,3 +543,24 @@ class TestSubdomains(object):
         assert_structure(op, ['x,y', 't,m', 't,m,xi_m,yi_m',
                               't,n', 't,n,xi_n,yi_n', 't,m', 't,m,xi_m,yi_m'],
                          'x,y,t,m,xi_m,yi_m,n,xi_n,yi_n,m,xi_m,yi_m')
+
+    def test_3D(self):
+
+        class Dummy(SubDomainSet):
+            name = 'dummy'
+
+        dummy = Dummy(N=0, bounds=[(), (), (), (), (), ()])
+
+        grid = Grid(shape=(10, 10, 10), subdomains=(dummy,))
+
+        f = TimeFunction(name='f', grid=grid)
+
+        eqn = Eq(f.forward, f + 1, subdomain=grid.subdomains['dummy'])
+
+        op = Operator(eqn)
+
+        # Make sure it jit-compiles
+        op.cfunction
+
+        assert_structure(op, ['t,n', 't,n,xi_n0_blk0,yi_n0_blk0,xi_n,yi_n,zi_n'],
+                         't,n,xi_n0_blk0,yi_n0_blk0,xi_n,yi_n,zi_n')


### PR DESCRIPTION
At last...

The reason I had to rework this now is that I have a compiler pass in Pro where, during clustering (!), I create a further equation that requires the MultiSubDomain thickness assignments, which wouldn't be generated due to premature lowering without this PR