### PR TITLE
compiler: Uncache data carriers

### DIFF
--- a/devito/types/basic.py
+++ b/devito/types/basic.py
@@ -439,12 +439,6 @@ class DataSymbol(AbstractSymbol, Uncached):
 
     __hash__ = Uncached.__hash__
 
-    # Pickling support
-
-    @property
-    def _pickle_reconstruct(self):
-        return self.__class__.__base__
-
 
 class Scalar(Symbol, ArgProvider):
 

--- a/devito/types/basic.py
+++ b/devito/types/basic.py
@@ -1246,6 +1246,9 @@ class Object(AbstractObject, ArgProvider):
         super(Object, self).__init__(name, dtype)
         self.value = value
 
+    def __hash__(self):
+        return id(self)
+
     @property
     def _arg_names(self):
         return (self.name,)
@@ -1266,7 +1269,8 @@ class Object(AbstractObject, ArgProvider):
             Dictionary of user-provided argument overrides.
         """
         if self.name in kwargs:
-            return {self.name: kwargs.pop(self.name)}
+            obj = kwargs.pop(self.name)
+            return {self.name: obj._arg_defaults()[obj.name]}
         else:
             return self._arg_defaults()
 
@@ -1305,9 +1309,6 @@ class CompositeObject(Object):
     @property
     def fields(self):
         return [i for i, _ in self.pfields]
-
-    def _hashable_content(self):
-        return (self.name, self.pfields)
 
     @cached_property
     def _C_typedecl(self):

--- a/devito/types/caching.py
+++ b/devito/types/caching.py
@@ -7,7 +7,7 @@ from sympy.core import cache
 from devito.tools import safe_dict_copy
 
 
-__all__ = ['Cached', '_SymbolCache', 'CacheManager']
+__all__ = ['Cached', 'Uncached', '_SymbolCache', 'CacheManager']
 
 _SymbolCache = {}
 """The symbol cache."""
@@ -19,6 +19,17 @@ class AugmentedWeakRef(weakref.ref):
         obj = super().__new__(cls, obj)
         obj.nbytes = meta.get('nbytes', 0)
         return obj
+
+
+class Uncached(object):
+
+    """
+    Mixin class for unique, and therefore uncached, symbolic objects
+    (e.g., data carriers).
+    """
+
+    def __hash__(self):
+        return id(self)
 
 
 class Cached(object):

--- a/examples/compiler/04_iet-B.ipynb
+++ b/examples/compiler/04_iet-B.ipynb
@@ -98,7 +98,7 @@
      "text": [
       "<Expression a = b + c[i] + 5.0>\n",
       "<Expression d[j, k] = e[t0, t1, i] - f[t, x, y]>\n",
-      "<Expression a = 4*a*b>\n",
+      "<Expression a = 4*b*a>\n",
       "<Expression a = 8.0*a + 6.0/b>\n"
      ]
     }
@@ -184,7 +184,7 @@
       "  <Iteration j::j::(0, 5, 1)>\n",
       "    <Iteration k::k::(0, 7, 1)>\n",
       "      <Expression d[j, k] = e[t0, t1, i] - f[t, x, y]>\n",
-      "      <Expression a = 4*a*b>\n",
+      "      <Expression a = 4*b*a>\n",
       "  <Iteration t1::t1::(0, 4, 1)>\n",
       "    <Expression a = 8.0*a + 6.0/b>\n"
      ]
@@ -293,7 +293,7 @@
       "      for (int k = 0; k <= 7; k += 1)\n",
       "      {\n",
       "        d[j][k] = e[t0][t1][i] - f[t][x][y];\n",
-      "        a = 4*a*b;\n",
+      "        a = 4*b*a;\n",
       "      }\n",
       "    }\n",
       "    for (int t1 = 0; t1 <= 4; t1 += 1)\n",

--- a/examples/performance/01_gpu.ipynb
+++ b/examples/performance/01_gpu.ipynb
@@ -303,7 +303,7 @@
       "      for (int y = y_m; y <= y_M; y += 1)\n",
       "      {\n",
       "        float r3 = -2.0F*u[time][x + 2][y + 2];\n",
-      "        u[time + 1][x + 2][y + 2] = dt*(r0*u[time][x + 2][y + 2] + c*(r1*r3 + r1*u[time][x + 1][y + 2] + r1*u[time][x + 3][y + 2] + r2*r3 + r2*u[time][x + 2][y + 1] + r2*u[time][x + 2][y + 3]));\n",
+      "        u[time + 1][x + 2][y + 2] = dt*(c*(r1*r3 + r1*u[time][x + 1][y + 2] + r1*u[time][x + 3][y + 2] + r2*r3 + r2*u[time][x + 2][y + 1] + r2*u[time][x + 2][y + 3]) + r0*u[time][x + 2][y + 2]);\n",
       "      }\n",
       "    }\n",
       "    STOP_TIMER(section0,timers)\n",

--- a/tests/test_caching.py
+++ b/tests/test_caching.py
@@ -1,3 +1,4 @@
+from ctypes import byref, c_void_p
 import weakref
 
 import numpy as np
@@ -7,7 +8,8 @@ from devito import (Grid, Function, TimeFunction, SparseFunction, SparseTimeFunc
                     ConditionalDimension, SubDimension, Constant, Operator, Eq, Dimension,
                     DefaultDimension, _SymbolCache, clear_cache, solve, VectorFunction,
                     TensorFunction, TensorTimeFunction, VectorTimeFunction)
-from devito.types import Scalar, Symbol, NThreadsBase, DeviceID, NPThreads, ThreadID
+from devito.types import (DeviceID, NThreadsBase, NPThreads, Object, Scalar, Symbol,
+                          ThreadID)
 
 
 @pytest.fixture
@@ -167,6 +169,28 @@ class TestHashing(object):
         assert u0._C_symbol is not u1._C_symbol  # Obviously
         assert hash(u0._C_symbol) != hash(u1._C_symbol)
         assert u0._C_symbol != u1._C_symbol
+
+    def test_objects(self):
+        v0 = byref(c_void_p(3))
+        v1 = byref(c_void_p(4))
+
+        dtype = type('Bar', (c_void_p,), {})
+
+        foo0 = Object('foo', dtype, v0)
+        foo1 = Object('foo', dtype, v0)
+        foo2 = Object('foo', dtype, v1)
+
+        # Obviously:
+        assert foo0 is not foo1
+        assert foo0 is not foo2
+        assert foo1 is not foo2
+
+        # Carried value doesn't matter -- an Object is always unique
+        assert hash(foo0) != hash(foo1)
+
+        # And obviously:
+        assert hash(foo0) != hash(foo2)
+        assert hash(foo1) != hash(foo2)
 
 
 class TestCaching(object):
@@ -358,7 +382,7 @@ class TestCaching(object):
         assert dd0 is not dd1
 
     def test_constant_new(self):
-        """Test that new u[x, y] instances don't cache"""
+        """Test that new Constant instances don't cache."""
         u0 = Constant(name='u')
         u0.data = 6.
         u1 = Constant(name='u')


### PR DESCRIPTION
Scalar data carriers are unique, so why attempt to cache them?