### PR TITLE
operator: made the unrecognized argument error clearer

### DIFF
--- a/devito/operator/operator.py
+++ b/devito/operator/operator.py
@@ -439,7 +439,7 @@ class Operator(Callable):
         if not configuration['ignore-unknowns']:
             for k, v in kwargs.items():
                 if k not in self._known_arguments:
-                    raise ValueError("Unrecognized argument %s=%s" % (k, v))
+                    raise ValueError("Unrecognized argument %s=%s. It most likely is missing from the expressions passed to the operator." % (k, v))
 
         overrides, defaults = split(self.input, lambda p: p.name in kwargs)
 


### PR DESCRIPTION
Hey folks,

I was working on something on devito, and got stuck up to an hour trying to figure out that this error:
```
ValueError: Unrecognized argument damp=damp(x, y).
```
meant the operator expressions didn't have the function damp. Thinking back it is obvious but the error message could have been cleaerer. I'm just making this commit as way to prevent another person to go through this. If I encounter other situations such as this I will open another PR so that we can make the error messages and error catching mechanisms work better.

I'm not sure if that is the final solution to the problem, but I hope this can at least start a discussion.

Cheers!