### PR TITLE
api: Add support for subdomain allocation for Functions

### DIFF
--- a/tests/test_subdomains.py
+++ b/tests/test_subdomains.py
@@ -50,8 +50,10 @@ class TestSubdomains(object):
         dim = s_d0.shape
 
         f = Function(name='f', grid=grid.subdomains['d0'], dtype=np.int32)
+        g = TimeFunction(name='g', grid=grid.subdomains['d0'], dtype=np.int32)
 
         assert dim == f.data.shape
+        assert dim == g.data.shape[1:]
 
     def test_multiple_middle(self):
         """

--- a/tests/test_subdomains.py
+++ b/tests/test_subdomains.py
@@ -38,6 +38,21 @@ class TestSubdomains(object):
             expr = Operator._lower_exprs([eq0])[0]
         assert expr.rhs == x1 * f[x1 + 1, y1 + 1] + y1
 
+    def test_subfunctions_dimensions (self):
+        class sd0(SubDomain):
+            name = 'd0'
+
+            def define(self, dimensions):
+                x, y = dimensions
+                return {x: ('middle', 3, 4), y: ('middle', 4, 3)}
+        s_d0 = sd0()
+        grid = Grid(shape=(10, 10), subdomains=(s_d0,))
+        dim = s_d0.shape
+
+        f = Function(name='f', grid=grid.subdomains['d0'], dtype=np.int32)
+
+        assert dim == f.data.shape
+
     def test_multiple_middle(self):
         """
         Test Operator with two basic 'middle' subdomains defined.


### PR DESCRIPTION
Hello folks,

This is the first commit for a series of commits adding support for functions to be allocated within a subdomain (let's call those subfunctions for brevity), and operated along other normal functions . This only first commit only adds allocation support for the Function class, I still need to add it for the TimeFunction class, not to mention that I still have to add support for it for the Operator class.
This is only but the first step in the right direction, or so I hope.

Cheers!

Authored by Átila Saraiva Quintela Soares (atilasaraiva@gmail.com)
SENAI CIMATEC geophysicist researcher.