### PR TITLE
install: Update to intel-oneapi-mpi-devel

### DIFF
--- a/docker/Dockerfile.cpu
+++ b/docker/Dockerfile.cpu
@@ -33,7 +33,7 @@ RUN wget -O- https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRO
 RUN echo "deb [signed-by=/usr/share/keyrings/oneapi-archive-keyring.gpg] https://apt.repos.intel.com/oneapi all main" > /etc/apt/sources.list.d/oneAPI.list
 
 # Install wanted components only (icc and mpiicc)
-RUN apt-get update -y && apt-get install -y intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic intel-oneapi-mpi
+RUN apt-get update -y && apt-get install -y intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic intel-oneapi-mpi-devel
 
 # Set en vars by hand since we can't use entrypoint for intermediate image
 ENV ICC_HOME=/opt/intel/oneapi/compiler/latest/


### PR DESCRIPTION
Adds mpicc compiler to the image.
Before it was runtime only:

```bash
root@90fab5c37e20:/# /opt/intel/oneapi/mpi/latest/bin/
IMB-MPI1            IMB-P2P             hydra_nameserver    mpiexec.hydra       tune/
IMB-MPI1-GPU        IMB-RMA             hydra_pmi_proxy     mpirun              tune_fast/
IMB-MT              cpuinfo             impi_info           mpitune             
IMB-NBC             hydra_bstrap_proxy  mpiexec             mpitune_fast
```

Now:

```bash
root@dfcf4ccd986f:/# /opt/intel/oneapi/mpi/latest/bin/
IMB-MPI1            cpuinfo             mpicxx              mpigcc              mpitune
IMB-MPI1-GPU        hydra_bstrap_proxy  mpiexec             mpigxx              mpitune_fast
IMB-MT              hydra_nameserver    mpiexec.hydra       mpiicc              tune/
IMB-NBC             hydra_pmi_proxy     mpif77              mpiicpc             tune_fast/
IMB-P2P             impi_info           mpif90              mpiifort            
IMB-RMA             mpicc               mpifc               mpirun 
```