### PR TITLE
dsl: Patched cross-derivative fd_order bug

### DIFF
--- a/devito/finite_differences/derivative.py
+++ b/devito/finite_differences/derivative.py
@@ -184,7 +184,7 @@ class Derivative(sympy.Derivative, Differentiable):
         _x0 = dict(self._x0)
         _fd_order = dict(self.fd_order._getters)
         try:
-            _fd_order.update(**(fd_order or {}))
+            _fd_order.update(fd_order or {})
             _fd_order = tuple(_fd_order.values())
             _fd_order = DimensionTuple(*_fd_order, getters=self.dims)
             _x0.update(x0)

--- a/devito/finite_differences/derivative.py
+++ b/devito/finite_differences/derivative.py
@@ -187,7 +187,7 @@ class Derivative(sympy.Derivative, Differentiable):
             _fd_order.update(fd_order or {})
             _fd_order = tuple(_fd_order.values())
             _fd_order = DimensionTuple(*_fd_order, getters=self.dims)
-            _x0.update(x0)
+            _x0.update(x0 or {})
         except AttributeError:
             raise TypeError("Multi-dimensional Derivative, input expected as a dict")
 

--- a/tests/test_derivatives.py
+++ b/tests/test_derivatives.py
@@ -689,6 +689,18 @@ class TestTwoStageEvaluation(object):
         assert Add(*term0.expand().args) == term1.expand()
 
 
+class TestCallAPI(object):
+    """Tests for the f.dx(x0=..., fd_order=...) API"""
+    def test_xderiv_order(self):
+        grid = Grid(shape=(11, 11), extent=(10., 10.))
+        x, y = grid.dimensions
+        f = Function(name='f', grid=grid, space_order=4)
+        
+        # Check that supplying a dictionary to fd_order for x-derivs functions correctly
+        expr = f.dxdy(fd_order={x: 2, y: 2}).evaluate - f.dx(fd_order=2).dy(fd_order=2).evaluate
+        assert simplify(expr) == 0
+
+
 def bypass_uneval(expr):
     unevals = expr.find(EvalDerivative)
     mapper = {i: Add(*i.args) for i in unevals}

--- a/tests/test_derivatives.py
+++ b/tests/test_derivatives.py
@@ -323,6 +323,28 @@ class TestFD(object):
         assert str(u.dx(fd_order=so//2).evaluate) == str(u1.dx.evaluate)
         assert str(u.dx(fd_order=2*so).evaluate) == str(u2.dx.evaluate)
 
+    def test_xderiv_order(self):
+        grid = Grid(shape=(11, 11), extent=(10., 10.))
+        x, y = grid.dimensions
+        f = Function(name='f', grid=grid, space_order=4)
+
+        # Check that supplying a dictionary to fd_order for x-derivs functions correctly
+        expr = f.dxdy(fd_order={x: 2, y: 2}).evaluate \
+            - f.dx(fd_order=2).dy(fd_order=2).evaluate
+        assert simplify(expr) == 0
+
+    def test_xderiv_x0(self):
+        grid = Grid(shape=(11, 11), extent=(10., 10.))
+        x, y = grid.dimensions
+        h_x = x.spacing
+        h_y = y.spacing
+        f = Function(name='f', grid=grid, space_order=4)
+
+        # Check that supplying a dictionary to x0 for x-derivs functions correctly
+        expr = f.dxdy(x0={x: x+h_x/2, y: y+h_y/2}).evaluate \
+            - f.dx(x0=x+h_x/2).dy(x0=y+h_y/2).evaluate
+        assert simplify(expr) == 0
+
     def test_fd_new_side(self):
         grid = Grid((10,))
         u = Function(name="u", grid=grid, space_order=4)
@@ -687,19 +709,6 @@ class TestTwoStageEvaluation(object):
         # Through expansion and casting we also check that `term0`
         # is indeed mathematically equivalent to `term1`
         assert Add(*term0.expand().args) == term1.expand()
-
-
-class TestCallAPI(object):
-    """Tests for the f.dx(x0=..., fd_order=...) API"""
-    def test_xderiv_order(self):
-        grid = Grid(shape=(11, 11), extent=(10., 10.))
-        x, y = grid.dimensions
-        f = Function(name='f', grid=grid, space_order=4)
-        
-        # Check that supplying a dictionary to fd_order for x-derivs functions correctly
-        expr = f.dxdy(fd_order={x: 2, y: 2}).evaluate \
-            - f.dx(fd_order=2).dy(fd_order=2).evaluate
-        assert simplify(expr) == 0
 
 
 def bypass_uneval(expr):

--- a/tests/test_derivatives.py
+++ b/tests/test_derivatives.py
@@ -697,7 +697,8 @@ class TestCallAPI(object):
         f = Function(name='f', grid=grid, space_order=4)
         
         # Check that supplying a dictionary to fd_order for x-derivs functions correctly
-        expr = f.dxdy(fd_order={x: 2, y: 2}).evaluate - f.dx(fd_order=2).dy(fd_order=2).evaluate
+        expr = f.dxdy(fd_order={x: 2, y: 2}).evaluate \
+            - f.dx(fd_order=2).dy(fd_order=2).evaluate
         assert simplify(expr) == 0
 
 


### PR DESCRIPTION
Fix for manually specifying the derivative order of cross-derivatives via the call API. Makes `f.dxdy(fd_order={x: 2, y: 2})` behave as expected rather than raising `TypeError`.