### PR TITLE
compiler: Fix MPI mode diag2 does not need a MPIRegion

### DIFF
--- a/devito/mpi/routines.py
+++ b/devito/mpi/routines.py
@@ -797,6 +797,9 @@ class Diag2HaloExchangeBuilder(Overlap2HaloExchangeBuilder):
         compute()
     """
 
+    def _make_region(self, hs, key):
+        return
+
     def _make_compute(self, hs, key, *args):
         return
 


### PR DESCRIPTION
`Diag2HaloExchangeBuilder` does not use or require the `MPIRegion` that the base class `Overlap2HaloExchangeBuilder` wants to create.