### PR TITLE
compiler: Prevent reordering of existing temps in CSE

### DIFF
--- a/devito/core/cpu.py
+++ b/devito/core/cpu.py
@@ -139,7 +139,7 @@ class Cpu64AdvOperator(Cpu64OperatorMixin, CoreOperator):
         clusters = fuse(clusters)
 
         # Reduce flops
-        clusters = cse(clusters, sregistry)
+        clusters = cse(clusters, sregistry, cls.CSE_MIN_COST)
 
         # Blocking to improve data locality
         if options['blocklazy']:
@@ -234,7 +234,7 @@ class Cpu64CustomOperator(Cpu64OperatorMixin, CustomOperator):
             'lift': lambda i: Lift().process(cire(i, 'invariants', sregistry,
                                                   options, platform)),
             'cire-sops': lambda i: cire(i, 'sops', sregistry, options, platform),
-            'cse': lambda i: cse(i, sregistry),
+            'cse': lambda i: cse(i, sregistry, cls.CSE_MIN_COST),
             'opt-pows': optimize_pows,
             'opt-hyperplanes': optimize_hyperplanes,
             'topofuse': lambda i: fuse(i, toposort=True, options=options)

--- a/devito/core/cpu.py
+++ b/devito/core/cpu.py
@@ -33,6 +33,9 @@ class Cpu64OperatorMixin(object):
         # Fusion
         o['fuse-tasks'] = oo.pop('fuse-tasks', False)
 
+        # CSE
+        o['cse-min-cost'] = oo.pop('cse-min-cost', cls.CSE_MIN_COST)
+
         # Blocking
         o['blockinner'] = oo.pop('blockinner', False)
         o['blocklevels'] = oo.pop('blocklevels', cls.BLOCK_LEVELS)
@@ -139,7 +142,7 @@ class Cpu64AdvOperator(Cpu64OperatorMixin, CoreOperator):
         clusters = fuse(clusters)
 
         # Reduce flops
-        clusters = cse(clusters, sregistry, cls.CSE_MIN_COST)
+        clusters = cse(clusters, sregistry, options)
 
         # Blocking to improve data locality
         if options['blocklazy']:
@@ -234,7 +237,7 @@ class Cpu64CustomOperator(Cpu64OperatorMixin, CustomOperator):
             'lift': lambda i: Lift().process(cire(i, 'invariants', sregistry,
                                                   options, platform)),
             'cire-sops': lambda i: cire(i, 'sops', sregistry, options, platform),
-            'cse': lambda i: cse(i, sregistry, cls.CSE_MIN_COST),
+            'cse': lambda i: cse(i, sregistry, options),
             'opt-pows': optimize_pows,
             'opt-hyperplanes': optimize_hyperplanes,
             'topofuse': lambda i: fuse(i, toposort=True, options=options)

--- a/devito/core/gpu.py
+++ b/devito/core/gpu.py
@@ -156,7 +156,7 @@ class DeviceAdvOperator(DeviceOperatorMixin, CoreOperator):
         clusters = fuse(clusters)
 
         # Reduce flops
-        clusters = cse(clusters, sregistry)
+        clusters = cse(clusters, sregistry, cls.CSE_MIN_COST)
 
         # Blocking to define thread blocks
         if options['blocklazy']:
@@ -241,7 +241,7 @@ class DeviceCustomOperator(DeviceOperatorMixin, CustomOperator):
             'lift': lambda i: Lift().process(cire(i, 'invariants', sregistry,
                                                   options, platform)),
             'cire-sops': lambda i: cire(i, 'sops', sregistry, options, platform),
-            'cse': lambda i: cse(i, sregistry),
+            'cse': lambda i: cse(i, sregistry, cls.CSE_MIN_COST),
             'opt-pows': optimize_pows,
             'topofuse': lambda i: fuse(i, toposort=True, options=options)
         }

--- a/devito/core/gpu.py
+++ b/devito/core/gpu.py
@@ -44,6 +44,9 @@ class DeviceOperatorMixin(object):
         # Fusion
         o['fuse-tasks'] = oo.pop('fuse-tasks', False)
 
+        # CSE
+        o['cse-min-cost'] = oo.pop('cse-min-cost', cls.CSE_MIN_COST)
+
         # Blocking
         o['blockinner'] = oo.pop('blockinner', True)
         o['blocklevels'] = oo.pop('blocklevels', cls.BLOCK_LEVELS)
@@ -156,7 +159,7 @@ class DeviceAdvOperator(DeviceOperatorMixin, CoreOperator):
         clusters = fuse(clusters)
 
         # Reduce flops
-        clusters = cse(clusters, sregistry, cls.CSE_MIN_COST)
+        clusters = cse(clusters, sregistry, options)
 
         # Blocking to define thread blocks
         if options['blocklazy']:
@@ -241,7 +244,7 @@ class DeviceCustomOperator(DeviceOperatorMixin, CustomOperator):
             'lift': lambda i: Lift().process(cire(i, 'invariants', sregistry,
                                                   options, platform)),
             'cire-sops': lambda i: cire(i, 'sops', sregistry, options, platform),
-            'cse': lambda i: cse(i, sregistry, cls.CSE_MIN_COST),
+            'cse': lambda i: cse(i, sregistry, options),
             'opt-pows': optimize_pows,
             'topofuse': lambda i: fuse(i, toposort=True, options=options)
         }

--- a/devito/core/operator.py
+++ b/devito/core/operator.py
@@ -17,6 +17,11 @@ __all__ = ['CoreOperator', 'CustomOperator',
 class BasicOperator(Operator):
 
     # Default values for various optimization options
+    CSE_MIN_COST = 1
+    """
+    Minimum computational cost of an operation to be eliminated as a
+    common sub=expression.
+    """
 
     BLOCK_LEVELS = 1
     """


### PR DESCRIPTION
Make sure that exsiting temps stay as "first statement". Nested index as function get extracted as temp and end up mixed up with the case extracted temps without this patch.
