### PR TITLE
dependencies: sympy 1.11 compatibility

### DIFF
--- a/.github/workflows/pytest-core-nompi.yml
+++ b/.github/workflows/pytest-core-nompi.yml
@@ -71,7 +71,7 @@ jobs:
           os: ubuntu-18.04
           arch: "gcc-8"
           language: "openmp"
-          sympy: "1.7"
+          sympy: "1.11"
 
         - name: pytest-ubuntu-py39-gcc9-omp
           python-version: '3.9'
@@ -99,7 +99,7 @@ jobs:
           os: ubuntu-18.04
           arch: "icc"
           language: "openmp"
-          sympy: "1.9"
+          sympy: "1.11"
 
         - set: base
           test-set: 'not adjoint'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 pip>=9.0.1
 numpy>1.16
-sympy>=1.7,<1.11
+sympy>=1.7,<1.12
 scipy
 flake8>=2.1.0
 nbval


### PR DESCRIPTION
Small PR than fixes the newly introduced bug in sympy for `_print_Add`. We should keep that bug fix in our printer even once 1.12 is released so that we stay compatible with sympy 1.11