### PR TITLE
compiler: Ensure order invariance of candidates in ReducerMap.unique

### DIFF
--- a/devito/tools/data_structures.py
+++ b/devito/tools/data_structures.py
@@ -118,10 +118,7 @@ class ReducerMap(MultiDict):
                 else:
                     return first in v
             elif isinstance(first, Set):
-                if isinstance(v, Set):
-                    return not first.isdisjoint(v)
-                else:
-                    return v in first
+                return v in first
             else:
                 return first == v
 

--- a/devito/tools/data_structures.py
+++ b/devito/tools/data_structures.py
@@ -117,6 +117,11 @@ class ReducerMap(MultiDict):
                     return not v.isdisjoint(first)
                 else:
                     return first in v
+            elif isinstance(first, Set):
+                if isinstance(v, Set):
+                    return not first.isdisjoint(v)
+                else:
+                    return v in first
             else:
                 return first == v
 


### PR DESCRIPTION
When looking for unique values in `ReducerMap.unique`, the order of candidates alters the result:

- If the candidates are `[1, frozenset({1, 2, 3})]` the method will run as expected.
- If the candidates are `[frozenset({1, 2, 3}), 1]` the method will fail to find a unique value among the candidates

This is fixed by adding another branch to the local function `compare_to_first` checking if `first` is a `Set`.