### PR TITLE
reqs: Fix for matplotlib >=3.6.3

### DIFF
--- a/examples/cfd/tools.py
+++ b/examples/cfd/tools.py
@@ -35,7 +35,7 @@ def plot_field(field, xmin=0., xmax=2., ymin=0., ymax=2., zmin=None, zmax=None,
     x_coord = np.linspace(xmin, xmax, field.shape[0])
     y_coord = np.linspace(ymin, ymax, field.shape[1])
     fig = pyplot.figure(figsize=(11, 7), dpi=100)
-    ax = fig.gca(projection='3d')
+    ax = fig.add_subplot(111, projection='3d')
     X, Y = np.meshgrid(x_coord, y_coord, indexing='ij')
     ax.plot_surface(X, Y, field[:], cmap=cm.viridis, rstride=1, cstride=1,
                     linewidth=linewidth, antialiased=False)


### PR DESCRIPTION
Temporary fix to avoid breaking since this update...

```
TypeError                                 Traceback (most recent call last)
Cell In[15], line 15
     12 init_smooth(field=u.data[0], dx=grid.spacing[0], dy=grid.spacing[1])
     13 init_smooth(field=u.data[1], dx=grid.spacing[0], dy=grid.spacing[1])
---> 15 plot_field(u.data[0])

File ~/Desktop/Work/devito/examples/cfd/tools.py:38, in plot_field(field, xmin, xmax, ymin, ymax, zmin, zmax, view, linewidth)
     36 y_coord = np.linspace(ymin, ymax, field.shape[1])
     37 fig = pyplot.figure(figsize=(11, 7), dpi=100)
---> 38 ax = fig.gca(projection='3d')
     39 X, Y = np.meshgrid(x_coord, y_coord, indexing='ij')
     40 ax.plot_surface(X, Y, field[:], cmap=cm.viridis, rstride=1, cstride=1,
     41                 linewidth=linewidth, antialiased=False)

TypeError: FigureBase.gca() got an unexpected keyword argument 'projection'
```