### PR TITLE
misc: Address Nvidia CUDA_HOME has been deprecated warning

### DIFF
--- a/docker/Dockerfile.nvidia
+++ b/docker/Dockerfile.nvidia
@@ -90,7 +90,7 @@ RUN echo "$HPCSDK_HOME/cuda/lib" >> /etc/ld.so.conf.d/nvidia.conf && \
     echo "$HPCSDK_HOME/math_libs/lib64" >> /etc/ld.so.conf.d/nvidia.conf    
     
 # Compiler, CUDA, and Library paths
-ENV CUDA_HOME $HPCSDK_HOME/cuda
+ENV NVHPC_CUDA_HOME $HPCSDK_HOME/cuda
 ENV CUDA_ROOT $HPCSDK_HOME/cuda/bin
 ENV PATH $HPCSDK_HOME/compilers/bin:$HPCSDK_HOME/cuda/bin:$HPCSDK_HOME/comm_libs/mpi/bin:${PATH}
 ENV LD_LIBRARY_PATH $HPCSDK_HOME/cuda/lib:$HPCSDK_HOME/cuda/lib64:$HPCSDK_HOME/compilers/lib:$HPCSDK_HOME/math_libs/lib64:$HPCSDK_HOME/comm_libs/mpi/lib:$HPCSDK_CUPTI/lib64:bitcomp_DIR:${LD_LIBRARY_PATH}

--- a/docker/Singularity.nvidia.def
+++ b/docker/Singularity.nvidia.def
@@ -40,7 +40,7 @@ export HPCSDK_CUPTI=/opt/nvidia/hpc_sdk/Linux_x86_64/2022/cuda/11.6/extras/CUPTI
 export NVCOMP_EXTS_ROOT=/app/nvcomp_exts/ubuntu18.04/11.6
 export bitcomp_DIR=$NVCOMP_EXTS_ROOT/lib/
 
-export CUDA_HOME=$HPCSDK_HOME/cuda
+export NVHPC_CUDA_HOME=$HPCSDK_HOME/cuda
 export CUDA_ROOT=$HPCSDK_HOME/cuda/bin
 export PATH=$HPCSDK_HOME/compilers/bin:$HPCSDK_HOME/cuda/bin:$HPCSDK_HOME/comm_libs/mpi/bin:${PATH}
 export LD_LIBRARY_PATH=$HPCSDK_HOME/cuda/lib:$HPCSDK_HOME/cuda/lib64:$HPCSDK_HOME/compilers/lib:$HPCSDK_HOME/math_libs/lib64:$HPCSDK_HOME/comm_libs/mpi/lib:$HPCSDK_CUPTI/lib64:bitcomp_DIR:${LD_LIBRARY_PATH}
@@ -114,7 +114,7 @@ export HPCSDK_HOME=/opt/nvidia/hpc_sdk/Linux_x86_64/2022
 export HPCSDK_CUPTI=/opt/nvidia/hpc_sdk/Linux_x86_64/2022/cuda/11.6/extras/CUPTI
   
 # Compiler, CUDA, and Library paths
-export CUDA_HOME=$HPCSDK_HOME/cuda
+export NVHPC_CUDA_HOME=$HPCSDK_HOME/cuda
 export CUDA_ROOT=$HPCSDK_HOME/cuda/bin
 export PATH=$HPCSDK_HOME/compilers/bin:$HPCSDK_HOME/cuda/bin:$HPCSDK_HOME/comm_libs/mpi/bin:${PATH}
 export LD_LIBRARY_PATH=$HPCSDK_HOME/cuda/lib:$HPCSDK_HOME/cuda/lib64:$HPCSDK_HOME/compilers/lib:$HPCSDK_HOME/math_libs/lib64:$HPCSDK_HOME/comm_libs/mpi/lib:$HPCSDK_CUPTI/lib64:${LD_LIBRARY_PATH}


### PR DESCRIPTION
Addresses the compiler warning

nvc++-Warning-CUDA_HOME has been deprecated. Please, use NVHPC_CUDA_HOME instead.