### PR TITLE
compiler: Relax _mark_overlappable

### DIFF
--- a/.github/workflows/pytest-core-nompi.yml
+++ b/.github/workflows/pytest-core-nompi.yml
@@ -54,7 +54,7 @@ jobs:
 
         - name: pytest-ubuntu-py36-gcc7-omp
           python-version: '3.6'
-          os: ubuntu-18.04
+          os: ubuntu-20.04
           arch: "gcc-7"
           language: "openmp"
           sympy: "1.9"
@@ -68,7 +68,7 @@ jobs:
 
         - name: pytest-ubuntu-py38-gcc8-omp
           python-version: '3.8'
-          os: ubuntu-18.04
+          os: ubuntu-20.04
           arch: "gcc-8"
           language: "openmp"
           sympy: "1.11"
@@ -89,14 +89,14 @@ jobs:
 
         - name: pytest-docker-py37-gcc-omp
           python-version: '3.7'
-          os: ubuntu-18.04
+          os: ubuntu-latest
           arch: "gcc"
           language: "openmp"
           sympy: "1.10"
 
         - name: pytest-docker-py37-icc-omp
           python-version: '3.7'
-          os: ubuntu-18.04
+          os: ubuntu-22.04
           arch: "icc"
           language: "openmp"
           sympy: "1.11"

--- a/.github/workflows/tutorials.yml
+++ b/.github/workflows/tutorials.yml
@@ -33,7 +33,7 @@ jobs:
 
         include:
           - name: tutos-ubuntu-gcc-py37
-            os: ubuntu-18.04
+            os: ubuntu-latest
             compiler: gcc
             language: "openmp"
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ thereof.
 - [About Devito](#about-devito)
 - [Installation](#installation)
 - [Resources](#resources)
-- [FAQs](https://github.com/devitocodes/devito/FAQ.md)
+- [FAQs](https://github.com/devitocodes/devito/blob/master/FAQ.md)
 - [Performance](#performance)
 - [Get in touch](#get-in-touch)
 - [Interactive jupyter notebooks](#interactive-jupyter-notebooks)

--- a/devito/passes/iet/mpi.py
+++ b/devito/passes/iet/mpi.py
@@ -250,15 +250,9 @@ def _mark_overlappable(iet):
         # along a non-halo Dimension
         for dep in scope.d_all_gen():
             if dep.function in hs.functions:
-                if not dep.cause:
-                    # E.g. increments
-                    # for x
-                    #   for y
-                    #     f[x, y] = f[x, y] + 1
-                    test = False
-                    break
-                elif dep.cause & hs.dimensions:
-                    # E.g. dependences across PARALLEL iterations
+                cause = dep.cause & hs.dimensions
+                if any(dep.distance_mapper[d] is S.Infinity for d in cause):
+                    # E.g., dependences across PARALLEL iterations
                     # for x
                     #   for y
                     #     ... = ... f[x, y-1] ...


### PR DESCRIPTION
Works around an issue in PRO in which diag2 fallbacks to basic due to too conservative data dependence analysis

the tests are in PRO... I can't think of an easy way of testing this here. Not ideal, but this fixes an issue @jkwashbourne is facing