### PR TITLE
ci: remove jupyter formatting from output as it breaks with ipynb+mpi.

### DIFF
--- a/examples/mpi/overview.ipynb
+++ b/examples/mpi/overview.ipynb
@@ -159,193 +159,27 @@
    },
    "outputs": [
     {
-     "data": {
-      "text/plain": [
-       "[output:0]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "\u001b[0;31mOut[0:5]: \u001b[0m\n",
-       "Data([[0., 0.],\n",
-       "      [0., 0.]], dtype=float32)"
-      ]
-     },
-     "metadata": {
-      "after": [],
-      "completed": "2022-11-08T10:57:45.029623Z",
-      "data": {},
-      "engine_id": 0,
-      "engine_uuid": "05cdbd79-7ab6281f5b5b6ab3779c1caf",
-      "error": null,
-      "execute_input": "u.data[0]\n",
-      "execute_result": {
-       "data": {
-        "text/plain": "Data([[0., 0.],\n      [0., 0.]], dtype=float32)"
-       },
-       "execution_count": 5,
-       "metadata": {}
-      },
-      "follow": [],
-      "is_broadcast": false,
-      "is_coalescing": false,
-      "msg_id": "95369d33-be708cfcf370f6da2acbf883_88297_17",
-      "outputs": [],
-      "received": "2022-11-08T10:57:45.030666Z",
-      "started": "2022-11-08T10:57:45.018599Z",
-      "status": "ok",
-      "stderr": "",
-      "stdout": "",
-      "submitted": "2022-11-08T10:57:45.017025Z"
-     },
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "[output:1]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "\u001b[0;31mOut[1:5]: \u001b[0m\n",
-       "Data([[0., 0.],\n",
-       "      [0., 0.]], dtype=float32)"
-      ]
-     },
-     "metadata": {
-      "after": [],
-      "completed": "2022-11-08T10:57:45.029691Z",
-      "data": {},
-      "engine_id": 1,
-      "engine_uuid": "7fc04624-73e795bad718b5e339566ff4",
-      "error": null,
-      "execute_input": "u.data[0]\n",
-      "execute_result": {
-       "data": {
-        "text/plain": "Data([[0., 0.],\n      [0., 0.]], dtype=float32)"
-       },
-       "execution_count": 5,
-       "metadata": {}
-      },
-      "follow": [],
-      "is_broadcast": false,
-      "is_coalescing": false,
-      "msg_id": "95369d33-be708cfcf370f6da2acbf883_88297_18",
-      "outputs": [],
-      "received": "2022-11-08T10:57:45.031041Z",
-      "started": "2022-11-08T10:57:45.018767Z",
-      "status": "ok",
-      "stderr": "",
-      "stdout": "",
-      "submitted": "2022-11-08T10:57:45.017249Z"
-     },
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "[output:2]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "\u001b[0;31mOut[2:5]: \u001b[0m\n",
-       "Data([[0., 0.],\n",
-       "      [0., 0.]], dtype=float32)"
-      ]
-     },
-     "metadata": {
-      "after": [],
-      "completed": "2022-11-08T10:57:45.029772Z",
-      "data": {},
-      "engine_id": 2,
-      "engine_uuid": "a23db01e-e003618a39ef4bff2150e225",
-      "error": null,
-      "execute_input": "u.data[0]\n",
-      "execute_result": {
-       "data": {
-        "text/plain": "Data([[0., 0.],\n      [0., 0.]], dtype=float32)"
-       },
-       "execution_count": 5,
-       "metadata": {}
-      },
-      "follow": [],
-      "is_broadcast": false,
-      "is_coalescing": false,
-      "msg_id": "95369d33-be708cfcf370f6da2acbf883_88297_19",
-      "outputs": [],
-      "received": "2022-11-08T10:57:45.031366Z",
-      "started": "2022-11-08T10:57:45.019188Z",
-      "status": "ok",
-      "stderr": "",
-      "stdout": "",
-      "submitted": "2022-11-08T10:57:45.017378Z"
-     },
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "[output:3]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "\u001b[0;31mOut[3:5]: \u001b[0m\n",
-       "Data([[0., 0.],\n",
-       "      [0., 0.]], dtype=float32)"
-      ]
-     },
-     "metadata": {
-      "after": [],
-      "completed": "2022-11-08T10:57:45.030140Z",
-      "data": {},
-      "engine_id": 3,
-      "engine_uuid": "b750ce5d-e040b2201c51070606409a4c",
-      "error": null,
-      "execute_input": "u.data[0]\n",
-      "execute_result": {
-       "data": {
-        "text/plain": "Data([[0., 0.],\n      [0., 0.]], dtype=float32)"
-       },
-       "execution_count": 5,
-       "metadata": {}
-      },
-      "follow": [],
-      "is_broadcast": false,
-      "is_coalescing": false,
-      "msg_id": "95369d33-be708cfcf370f6da2acbf883_88297_20",
-      "outputs": [],
-      "received": "2022-11-08T10:57:45.031689Z",
-      "started": "2022-11-08T10:57:45.018889Z",
-      "status": "ok",
-      "stderr": "",
-      "stdout": "",
-      "submitted": "2022-11-08T10:57:45.017437Z"
-     },
-     "output_type": "display_data"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[stdout:0] \n",
+      "[[0. 0.]\n",
+      " [0. 0.]]\n",
+      "[stdout:1] \n",
+      "[[0. 0.]\n",
+      " [0. 0.]]\n",
+      "[stdout:2] \n",
+      "[[0. 0.]\n",
+      " [0. 0.]]\n",
+      "[stdout:3] \n",
+      "[[0. 0.]\n",
+      " [0. 0.]]\n"
+     ]
     }
    ],
    "source": [
     "%%px --no-stream --group-outputs=engine\n",
-    "u.data[0]"
+    "print(u.data[0])"
    ]
   },
   {
@@ -371,193 +205,27 @@
    "metadata": {},
    "outputs": [
     {
-     "data": {
-      "text/plain": [
-       "[output:0]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "\u001b[0;31mOut[0:7]: \u001b[0m\n",
-       "Data([[0., 0.],\n",
-       "      [0., 1.]], dtype=float32)"
-      ]
-     },
-     "metadata": {
-      "after": [],
-      "completed": "2022-11-08T10:57:45.054745Z",
-      "data": {},
-      "engine_id": 0,
-      "engine_uuid": "05cdbd79-7ab6281f5b5b6ab3779c1caf",
-      "error": null,
-      "execute_input": "u.data[0]\n",
-      "execute_result": {
-       "data": {
-        "text/plain": "Data([[0., 0.],\n      [0., 1.]], dtype=float32)"
-       },
-       "execution_count": 7,
-       "metadata": {}
-      },
-      "follow": [],
-      "is_broadcast": false,
-      "is_coalescing": false,
-      "msg_id": "95369d33-be708cfcf370f6da2acbf883_88297_25",
-      "outputs": [],
-      "received": "2022-11-08T10:57:45.055811Z",
-      "started": "2022-11-08T10:57:45.052528Z",
-      "status": "ok",
-      "stderr": "",
-      "stdout": "",
-      "submitted": "2022-11-08T10:57:45.051031Z"
-     },
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "[output:1]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "\u001b[0;31mOut[1:7]: \u001b[0m\n",
-       "Data([[0., 0.],\n",
-       "      [1., 0.]], dtype=float32)"
-      ]
-     },
-     "metadata": {
-      "after": [],
-      "completed": "2022-11-08T10:57:45.054788Z",
-      "data": {},
-      "engine_id": 1,
-      "engine_uuid": "7fc04624-73e795bad718b5e339566ff4",
-      "error": null,
-      "execute_input": "u.data[0]\n",
-      "execute_result": {
-       "data": {
-        "text/plain": "Data([[0., 0.],\n      [1., 0.]], dtype=float32)"
-       },
-       "execution_count": 7,
-       "metadata": {}
-      },
-      "follow": [],
-      "is_broadcast": false,
-      "is_coalescing": false,
-      "msg_id": "95369d33-be708cfcf370f6da2acbf883_88297_26",
-      "outputs": [],
-      "received": "2022-11-08T10:57:45.056159Z",
-      "started": "2022-11-08T10:57:45.052657Z",
-      "status": "ok",
-      "stderr": "",
-      "stdout": "",
-      "submitted": "2022-11-08T10:57:45.051162Z"
-     },
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "[output:2]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "\u001b[0;31mOut[2:7]: \u001b[0m\n",
-       "Data([[0., 1.],\n",
-       "      [0., 0.]], dtype=float32)"
-      ]
-     },
-     "metadata": {
-      "after": [],
-      "completed": "2022-11-08T10:57:45.054957Z",
-      "data": {},
-      "engine_id": 2,
-      "engine_uuid": "a23db01e-e003618a39ef4bff2150e225",
-      "error": null,
-      "execute_input": "u.data[0]\n",
-      "execute_result": {
-       "data": {
-        "text/plain": "Data([[0., 1.],\n      [0., 0.]], dtype=float32)"
-       },
-       "execution_count": 7,
-       "metadata": {}
-      },
-      "follow": [],
-      "is_broadcast": false,
-      "is_coalescing": false,
-      "msg_id": "95369d33-be708cfcf370f6da2acbf883_88297_27",
-      "outputs": [],
-      "received": "2022-11-08T10:57:45.056879Z",
-      "started": "2022-11-08T10:57:45.052710Z",
-      "status": "ok",
-      "stderr": "",
-      "stdout": "",
-      "submitted": "2022-11-08T10:57:45.051407Z"
-     },
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "[output:3]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "\u001b[0;31mOut[3:7]: \u001b[0m\n",
-       "Data([[1., 0.],\n",
-       "      [0., 0.]], dtype=float32)"
-      ]
-     },
-     "metadata": {
-      "after": [],
-      "completed": "2022-11-08T10:57:45.054908Z",
-      "data": {},
-      "engine_id": 3,
-      "engine_uuid": "b750ce5d-e040b2201c51070606409a4c",
-      "error": null,
-      "execute_input": "u.data[0]\n",
-      "execute_result": {
-       "data": {
-        "text/plain": "Data([[1., 0.],\n      [0., 0.]], dtype=float32)"
-       },
-       "execution_count": 7,
-       "metadata": {}
-      },
-      "follow": [],
-      "is_broadcast": false,
-      "is_coalescing": false,
-      "msg_id": "95369d33-be708cfcf370f6da2acbf883_88297_28",
-      "outputs": [],
-      "received": "2022-11-08T10:57:45.056552Z",
-      "started": "2022-11-08T10:57:45.052752Z",
-      "status": "ok",
-      "stderr": "",
-      "stdout": "",
-      "submitted": "2022-11-08T10:57:45.051558Z"
-     },
-     "output_type": "display_data"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[stdout:0] \n",
+      "[[0. 0.]\n",
+      " [0. 1.]]\n",
+      "[stdout:1] \n",
+      "[[0. 0.]\n",
+      " [1. 0.]]\n",
+      "[stdout:2] \n",
+      "[[0. 1.]\n",
+      " [0. 0.]]\n",
+      "[stdout:3] \n",
+      "[[1. 0.]\n",
+      " [0. 0.]]\n"
+     ]
     }
    ],
    "source": [
     "%%px --no-stream --group-outputs=engine\n",
-    "u.data[0]"
+    "print(u.data[0])"
    ]
   },
   {
@@ -614,193 +282,27 @@
    "metadata": {},
    "outputs": [
     {
-     "data": {
-      "text/plain": [
-       "[output:0]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "\u001b[0;31mOut[0:9]: \u001b[0m\n",
-       "Data([[1., 1.],\n",
-       "      [1., 2.]], dtype=float32)"
-      ]
-     },
-     "metadata": {
-      "after": [],
-      "completed": "2022-11-08T10:57:45.195844Z",
-      "data": {},
-      "engine_id": 0,
-      "engine_uuid": "05cdbd79-7ab6281f5b5b6ab3779c1caf",
-      "error": null,
-      "execute_input": "u.data[1]\n",
-      "execute_result": {
-       "data": {
-        "text/plain": "Data([[1., 1.],\n      [1., 2.]], dtype=float32)"
-       },
-       "execution_count": 9,
-       "metadata": {}
-      },
-      "follow": [],
-      "is_broadcast": false,
-      "is_coalescing": false,
-      "msg_id": "95369d33-be708cfcf370f6da2acbf883_88297_33",
-      "outputs": [],
-      "received": "2022-11-08T10:57:45.196960Z",
-      "started": "2022-11-08T10:57:45.193672Z",
-      "status": "ok",
-      "stderr": "",
-      "stdout": "",
-      "submitted": "2022-11-08T10:57:45.191879Z"
-     },
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "[output:1]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "\u001b[0;31mOut[1:9]: \u001b[0m\n",
-       "Data([[1., 1.],\n",
-       "      [2., 1.]], dtype=float32)"
-      ]
-     },
-     "metadata": {
-      "after": [],
-      "completed": "2022-11-08T10:57:45.195955Z",
-      "data": {},
-      "engine_id": 1,
-      "engine_uuid": "7fc04624-73e795bad718b5e339566ff4",
-      "error": null,
-      "execute_input": "u.data[1]\n",
-      "execute_result": {
-       "data": {
-        "text/plain": "Data([[1., 1.],\n      [2., 1.]], dtype=float32)"
-       },
-       "execution_count": 9,
-       "metadata": {}
-      },
-      "follow": [],
-      "is_broadcast": false,
-      "is_coalescing": false,
-      "msg_id": "95369d33-be708cfcf370f6da2acbf883_88297_34",
-      "outputs": [],
-      "received": "2022-11-08T10:57:45.197624Z",
-      "started": "2022-11-08T10:57:45.193623Z",
-      "status": "ok",
-      "stderr": "",
-      "stdout": "",
-      "submitted": "2022-11-08T10:57:45.192046Z"
-     },
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "[output:2]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "\u001b[0;31mOut[2:9]: \u001b[0m\n",
-       "Data([[1., 2.],\n",
-       "      [1., 1.]], dtype=float32)"
-      ]
-     },
-     "metadata": {
-      "after": [],
-      "completed": "2022-11-08T10:57:45.196115Z",
-      "data": {},
-      "engine_id": 2,
-      "engine_uuid": "a23db01e-e003618a39ef4bff2150e225",
-      "error": null,
-      "execute_input": "u.data[1]\n",
-      "execute_result": {
-       "data": {
-        "text/plain": "Data([[1., 2.],\n      [1., 1.]], dtype=float32)"
-       },
-       "execution_count": 9,
-       "metadata": {}
-      },
-      "follow": [],
-      "is_broadcast": false,
-      "is_coalescing": false,
-      "msg_id": "95369d33-be708cfcf370f6da2acbf883_88297_35",
-      "outputs": [],
-      "received": "2022-11-08T10:57:45.197313Z",
-      "started": "2022-11-08T10:57:45.193721Z",
-      "status": "ok",
-      "stderr": "",
-      "stdout": "",
-      "submitted": "2022-11-08T10:57:45.192111Z"
-     },
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "[output:3]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "\u001b[0;31mOut[3:9]: \u001b[0m\n",
-       "Data([[2., 1.],\n",
-       "      [1., 1.]], dtype=float32)"
-      ]
-     },
-     "metadata": {
-      "after": [],
-      "completed": "2022-11-08T10:57:45.196075Z",
-      "data": {},
-      "engine_id": 3,
-      "engine_uuid": "b750ce5d-e040b2201c51070606409a4c",
-      "error": null,
-      "execute_input": "u.data[1]\n",
-      "execute_result": {
-       "data": {
-        "text/plain": "Data([[2., 1.],\n      [1., 1.]], dtype=float32)"
-       },
-       "execution_count": 9,
-       "metadata": {}
-      },
-      "follow": [],
-      "is_broadcast": false,
-      "is_coalescing": false,
-      "msg_id": "95369d33-be708cfcf370f6da2acbf883_88297_36",
-      "outputs": [],
-      "received": "2022-11-08T10:57:45.197927Z",
-      "started": "2022-11-08T10:57:45.193806Z",
-      "status": "ok",
-      "stderr": "",
-      "stdout": "",
-      "submitted": "2022-11-08T10:57:45.192163Z"
-     },
-     "output_type": "display_data"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[stdout:0] \n",
+      "[[1. 1.]\n",
+      " [1. 2.]]\n",
+      "[stdout:1] \n",
+      "[[1. 1.]\n",
+      " [2. 1.]]\n",
+      "[stdout:2] \n",
+      "[[1. 2.]\n",
+      " [1. 1.]]\n",
+      "[stdout:3] \n",
+      "[[2. 1.]\n",
+      " [1. 1.]]\n"
+     ]
     }
    ],
    "source": [
     "%%px --no-stream --group-outputs=engine\n",
-    "u.data[1]"
+    "print(u.data[1])"
    ]
   },
   {
@@ -1093,201 +595,35 @@
    "metadata": {},
    "outputs": [
     {
-     "data": {
-      "text/plain": [
-       "[output:0]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "\u001b[0;31mOut[0:13]: \u001b[0m\n",
-       "Data([[0., 0., 0., 0.],\n",
-       "      [0., 0., 0., 0.],\n",
-       "      [0., 0., 0., 0.],\n",
-       "      [0., 0., 0., 1.]], dtype=float32)"
-      ]
-     },
-     "metadata": {
-      "after": [],
-      "completed": "2022-11-08T10:57:45.594863Z",
-      "data": {},
-      "engine_id": 0,
-      "engine_uuid": "05cdbd79-7ab6281f5b5b6ab3779c1caf",
-      "error": null,
-      "execute_input": "u.data_with_halo[0]\n# Uncomment to see halo for the next (computed) timestep\n# u.data_with_halo[1]\n",
-      "execute_result": {
-       "data": {
-        "text/plain": "Data([[0., 0., 0., 0.],\n      [0., 0., 0., 0.],\n      [0., 0., 0., 0.],\n      [0., 0., 0., 1.]], dtype=float32)"
-       },
-       "execution_count": 13,
-       "metadata": {}
-      },
-      "follow": [],
-      "is_broadcast": false,
-      "is_coalescing": false,
-      "msg_id": "95369d33-be708cfcf370f6da2acbf883_88297_43",
-      "outputs": [],
-      "received": "2022-11-08T10:57:45.595889Z",
-      "started": "2022-11-08T10:57:45.590056Z",
-      "status": "ok",
-      "stderr": "",
-      "stdout": "",
-      "submitted": "2022-11-08T10:57:45.589019Z"
-     },
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "[output:1]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "\u001b[0;31mOut[1:11]: \u001b[0m\n",
-       "Data([[0., 0., 0., 0.],\n",
-       "      [0., 0., 0., 0.],\n",
-       "      [0., 0., 0., 0.],\n",
-       "      [1., 0., 0., 0.]], dtype=float32)"
-      ]
-     },
-     "metadata": {
-      "after": [],
-      "completed": "2022-11-08T10:57:45.594991Z",
-      "data": {},
-      "engine_id": 1,
-      "engine_uuid": "7fc04624-73e795bad718b5e339566ff4",
-      "error": null,
-      "execute_input": "u.data_with_halo[0]\n# Uncomment to see halo for the next (computed) timestep\n# u.data_with_halo[1]\n",
-      "execute_result": {
-       "data": {
-        "text/plain": "Data([[0., 0., 0., 0.],\n      [0., 0., 0., 0.],\n      [0., 0., 0., 0.],\n      [1., 0., 0., 0.]], dtype=float32)"
-       },
-       "execution_count": 11,
-       "metadata": {}
-      },
-      "follow": [],
-      "is_broadcast": false,
-      "is_coalescing": false,
-      "msg_id": "95369d33-be708cfcf370f6da2acbf883_88297_44",
-      "outputs": [],
-      "received": "2022-11-08T10:57:45.596242Z",
-      "started": "2022-11-08T10:57:45.591369Z",
-      "status": "ok",
-      "stderr": "",
-      "stdout": "",
-      "submitted": "2022-11-08T10:57:45.589484Z"
-     },
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "[output:2]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "\u001b[0;31mOut[2:11]: \u001b[0m\n",
-       "Data([[0., 0., 0., 1.],\n",
-       "      [0., 0., 0., 0.],\n",
-       "      [0., 0., 0., 0.],\n",
-       "      [0., 0., 0., 0.]], dtype=float32)"
-      ]
-     },
-     "metadata": {
-      "after": [],
-      "completed": "2022-11-08T10:57:45.595357Z",
-      "data": {},
-      "engine_id": 2,
-      "engine_uuid": "a23db01e-e003618a39ef4bff2150e225",
-      "error": null,
-      "execute_input": "u.data_with_halo[0]\n# Uncomment to see halo for the next (computed) timestep\n# u.data_with_halo[1]\n",
-      "execute_result": {
-       "data": {
-        "text/plain": "Data([[0., 0., 0., 1.],\n      [0., 0., 0., 0.],\n      [0., 0., 0., 0.],\n      [0., 0., 0., 0.]], dtype=float32)"
-       },
-       "execution_count": 11,
-       "metadata": {}
-      },
-      "follow": [],
-      "is_broadcast": false,
-      "is_coalescing": false,
-      "msg_id": "95369d33-be708cfcf370f6da2acbf883_88297_45",
-      "outputs": [],
-      "received": "2022-11-08T10:57:45.596875Z",
-      "started": "2022-11-08T10:57:45.591985Z",
-      "status": "ok",
-      "stderr": "",
-      "stdout": "",
-      "submitted": "2022-11-08T10:57:45.589676Z"
-     },
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "[output:3]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "\u001b[0;31mOut[3:11]: \u001b[0m\n",
-       "Data([[1., 0., 0., 0.],\n",
-       "      [0., 0., 0., 0.],\n",
-       "      [0., 0., 0., 0.],\n",
-       "      [0., 0., 0., 0.]], dtype=float32)"
-      ]
-     },
-     "metadata": {
-      "after": [],
-      "completed": "2022-11-08T10:57:45.595218Z",
-      "data": {},
-      "engine_id": 3,
-      "engine_uuid": "b750ce5d-e040b2201c51070606409a4c",
-      "error": null,
-      "execute_input": "u.data_with_halo[0]\n# Uncomment to see halo for the next (computed) timestep\n# u.data_with_halo[1]\n",
-      "execute_result": {
-       "data": {
-        "text/plain": "Data([[1., 0., 0., 0.],\n      [0., 0., 0., 0.],\n      [0., 0., 0., 0.],\n      [0., 0., 0., 0.]], dtype=float32)"
-       },
-       "execution_count": 11,
-       "metadata": {}
-      },
-      "follow": [],
-      "is_broadcast": false,
-      "is_coalescing": false,
-      "msg_id": "95369d33-be708cfcf370f6da2acbf883_88297_46",
-      "outputs": [],
-      "received": "2022-11-08T10:57:45.596566Z",
-      "started": "2022-11-08T10:57:45.591904Z",
-      "status": "ok",
-      "stderr": "",
-      "stdout": "",
-      "submitted": "2022-11-08T10:57:45.590646Z"
-     },
-     "output_type": "display_data"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[stdout:0] \n",
+      "[[0. 0. 0. 0.]\n",
+      " [0. 0. 0. 0.]\n",
+      " [0. 0. 0. 0.]\n",
+      " [0. 0. 0. 1.]]\n",
+      "[stdout:1] \n",
+      "[[0. 0. 0. 0.]\n",
+      " [0. 0. 0. 0.]\n",
+      " [0. 0. 0. 0.]\n",
+      " [1. 0. 0. 0.]]\n",
+      "[stdout:2] \n",
+      "[[0. 0. 0. 1.]\n",
+      " [0. 0. 0. 0.]\n",
+      " [0. 0. 0. 0.]\n",
+      " [0. 0. 0. 0.]]\n",
+      "[stdout:3] \n",
+      "[[1. 0. 0. 0.]\n",
+      " [0. 0. 0. 0.]\n",
+      " [0. 0. 0. 0.]\n",
+      " [0. 0. 0. 0.]]\n"
+     ]
     }
    ],
    "source": [
     "%%px --no-stream --group-outputs=engine\n",
-    "u.data_with_halo[0]\n",
+    "print(u.data_with_halo[0])\n",
     "# Uncomment to see halo for the next (computed) timestep\n",
     "# u.data_with_halo[1]"
    ]
@@ -1317,222 +653,56 @@
    "metadata": {},
    "outputs": [
     {
-     "data": {
-      "text/plain": [
-       "[output:0]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "\u001b[0;31mOut[0:15]: \u001b[0m\n",
-       "Data([[[1., 1., 1., 1.],\n",
-       "       [1., 1., 1., 1.],\n",
-       "       [1., 1., 1., 1.],\n",
-       "       [1., 1., 1., 1.]],\n",
-       "\n",
-       "      [[1., 1., 1., 1.],\n",
-       "       [1., 1., 1., 1.],\n",
-       "       [1., 1., 1., 1.],\n",
-       "       [1., 1., 1., 1.]]], dtype=float32)"
-      ]
-     },
-     "metadata": {
-      "after": [],
-      "completed": "2022-11-08T10:57:45.617609Z",
-      "data": {},
-      "engine_id": 0,
-      "engine_uuid": "05cdbd79-7ab6281f5b5b6ab3779c1caf",
-      "error": null,
-      "execute_input": "# Note: Both time buffer slices are now printed\nu.data_with_halo[:]\n",
-      "execute_result": {
-       "data": {
-        "text/plain": "Data([[[1., 1., 1., 1.],\n       [1., 1., 1., 1.],\n       [1., 1., 1., 1.],\n       [1., 1., 1., 1.]],\n\n      [[1., 1., 1., 1.],\n       [1., 1., 1., 1.],\n       [1., 1., 1., 1.],\n       [1., 1., 1., 1.]]], dtype=float32)"
-       },
-       "execution_count": 15,
-       "metadata": {}
-      },
-      "follow": [],
-      "is_broadcast": false,
-      "is_coalescing": false,
-      "msg_id": "95369d33-be708cfcf370f6da2acbf883_88297_51",
-      "outputs": [],
-      "received": "2022-11-08T10:57:45.618692Z",
-      "started": "2022-11-08T10:57:45.613692Z",
-      "status": "ok",
-      "stderr": "",
-      "stdout": "",
-      "submitted": "2022-11-08T10:57:45.611912Z"
-     },
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "[output:1]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "\u001b[0;31mOut[1:13]: \u001b[0m\n",
-       "Data([[[1., 1., 1., 1.],\n",
-       "       [1., 1., 1., 1.],\n",
-       "       [1., 1., 1., 1.],\n",
-       "       [1., 1., 1., 1.]],\n",
-       "\n",
-       "      [[1., 1., 1., 1.],\n",
-       "       [1., 1., 1., 1.],\n",
-       "       [1., 1., 1., 1.],\n",
-       "       [1., 1., 1., 1.]]], dtype=float32)"
-      ]
-     },
-     "metadata": {
-      "after": [],
-      "completed": "2022-11-08T10:57:45.617105Z",
-      "data": {},
-      "engine_id": 1,
-      "engine_uuid": "7fc04624-73e795bad718b5e339566ff4",
-      "error": null,
-      "execute_input": "# Note: Both time buffer slices are now printed\nu.data_with_halo[:]\n",
-      "execute_result": {
-       "data": {
-        "text/plain": "Data([[[1., 1., 1., 1.],\n       [1., 1., 1., 1.],\n       [1., 1., 1., 1.],\n       [1., 1., 1., 1.]],\n\n      [[1., 1., 1., 1.],\n       [1., 1., 1., 1.],\n       [1., 1., 1., 1.],\n       [1., 1., 1., 1.]]], dtype=float32)"
-       },
-       "execution_count": 13,
-       "metadata": {}
-      },
-      "follow": [],
-      "is_broadcast": false,
-      "is_coalescing": false,
-      "msg_id": "95369d33-be708cfcf370f6da2acbf883_88297_52",
-      "outputs": [],
-      "received": "2022-11-08T10:57:45.618185Z",
-      "started": "2022-11-08T10:57:45.613674Z",
-      "status": "ok",
-      "stderr": "",
-      "stdout": "",
-      "submitted": "2022-11-08T10:57:45.611987Z"
-     },
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "[output:2]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "\u001b[0;31mOut[2:13]: \u001b[0m\n",
-       "Data([[[1., 1., 1., 1.],\n",
-       "       [1., 1., 1., 1.],\n",
-       "       [1., 1., 1., 1.],\n",
-       "       [1., 1., 1., 1.]],\n",
-       "\n",
-       "      [[1., 1., 1., 1.],\n",
-       "       [1., 1., 1., 1.],\n",
-       "       [1., 1., 1., 1.],\n",
-       "       [1., 1., 1., 1.]]], dtype=float32)"
-      ]
-     },
-     "metadata": {
-      "after": [],
-      "completed": "2022-11-08T10:57:45.616913Z",
-      "data": {},
-      "engine_id": 2,
-      "engine_uuid": "a23db01e-e003618a39ef4bff2150e225",
-      "error": null,
-      "execute_input": "# Note: Both time buffer slices are now printed\nu.data_with_halo[:]\n",
-      "execute_result": {
-       "data": {
-        "text/plain": "Data([[[1., 1., 1., 1.],\n       [1., 1., 1., 1.],\n       [1., 1., 1., 1.],\n       [1., 1., 1., 1.]],\n\n      [[1., 1., 1., 1.],\n       [1., 1., 1., 1.],\n       [1., 1., 1., 1.],\n       [1., 1., 1., 1.]]], dtype=float32)"
-       },
-       "execution_count": 13,
-       "metadata": {}
-      },
-      "follow": [],
-      "is_broadcast": false,
-      "is_coalescing": false,
-      "msg_id": "95369d33-be708cfcf370f6da2acbf883_88297_53",
-      "outputs": [],
-      "received": "2022-11-08T10:57:45.617859Z",
-      "started": "2022-11-08T10:57:45.613734Z",
-      "status": "ok",
-      "stderr": "",
-      "stdout": "",
-      "submitted": "2022-11-08T10:57:45.612039Z"
-     },
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "[output:3]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "\u001b[0;31mOut[3:13]: \u001b[0m\n",
-       "Data([[[1., 1., 1., 1.],\n",
-       "       [1., 1., 1., 1.],\n",
-       "       [1., 1., 1., 1.],\n",
-       "       [1., 1., 1., 1.]],\n",
-       "\n",
-       "      [[1., 1., 1., 1.],\n",
-       "       [1., 1., 1., 1.],\n",
-       "       [1., 1., 1., 1.],\n",
-       "       [1., 1., 1., 1.]]], dtype=float32)"
-      ]
-     },
-     "metadata": {
-      "after": [],
-      "completed": "2022-11-08T10:57:45.617619Z",
-      "data": {},
-      "engine_id": 3,
-      "engine_uuid": "b750ce5d-e040b2201c51070606409a4c",
-      "error": null,
-      "execute_input": "# Note: Both time buffer slices are now printed\nu.data_with_halo[:]\n",
-      "execute_result": {
-       "data": {
-        "text/plain": "Data([[[1., 1., 1., 1.],\n       [1., 1., 1., 1.],\n       [1., 1., 1., 1.],\n       [1., 1., 1., 1.]],\n\n      [[1., 1., 1., 1.],\n       [1., 1., 1., 1.],\n       [1., 1., 1., 1.],\n       [1., 1., 1., 1.]]], dtype=float32)"
-       },
-       "execution_count": 13,
-       "metadata": {}
-      },
-      "follow": [],
-      "is_broadcast": false,
-      "is_coalescing": false,
-      "msg_id": "95369d33-be708cfcf370f6da2acbf883_88297_54",
-      "outputs": [],
-      "received": "2022-11-08T10:57:45.619002Z",
-      "started": "2022-11-08T10:57:45.613980Z",
-      "status": "ok",
-      "stderr": "",
-      "stdout": "",
-      "submitted": "2022-11-08T10:57:45.612087Z"
-     },
-     "output_type": "display_data"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[stdout:0] \n",
+      "[[[1. 1. 1. 1.]\n",
+      "  [1. 1. 1. 1.]\n",
+      "  [1. 1. 1. 1.]\n",
+      "  [1. 1. 1. 1.]]\n",
+      "\n",
+      " [[1. 1. 1. 1.]\n",
+      "  [1. 1. 1. 1.]\n",
+      "  [1. 1. 1. 1.]\n",
+      "  [1. 1. 1. 1.]]]\n",
+      "[stdout:1] \n",
+      "[[[1. 1. 1. 1.]\n",
+      "  [1. 1. 1. 1.]\n",
+      "  [1. 1. 1. 1.]\n",
+      "  [1. 1. 1. 1.]]\n",
+      "\n",
+      " [[1. 1. 1. 1.]\n",
+      "  [1. 1. 1. 1.]\n",
+      "  [1. 1. 1. 1.]\n",
+      "  [1. 1. 1. 1.]]]\n",
+      "[stdout:2] \n",
+      "[[[1. 1. 1. 1.]\n",
+      "  [1. 1. 1. 1.]\n",
+      "  [1. 1. 1. 1.]\n",
+      "  [1. 1. 1. 1.]]\n",
+      "\n",
+      " [[1. 1. 1. 1.]\n",
+      "  [1. 1. 1. 1.]\n",
+      "  [1. 1. 1. 1.]\n",
+      "  [1. 1. 1. 1.]]]\n",
+      "[stdout:3] \n",
+      "[[[1. 1. 1. 1.]\n",
+      "  [1. 1. 1. 1.]\n",
+      "  [1. 1. 1. 1.]\n",
+      "  [1. 1. 1. 1.]]\n",
+      "\n",
+      " [[1. 1. 1. 1.]\n",
+      "  [1. 1. 1. 1.]\n",
+      "  [1. 1. 1. 1.]\n",
+      "  [1. 1. 1. 1.]]]\n"
+     ]
     }
    ],
    "source": [
     "%%px --no-stream --group-outputs=engine\n",
     "# Note: Both time buffer slices are now printed\n",
-    "u.data_with_halo[:]"
+    "print(u.data_with_halo[:])"
    ]
   },
   {
@@ -1654,193 +824,27 @@
    "metadata": {},
    "outputs": [
     {
-     "data": {
-      "text/plain": [
-       "[output:0]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "\u001b[0;31mOut[0:18]: \u001b[0m\n",
-       "Data([[1.25, 1.25],\n",
-       "      [1.25, 2.5 ]], dtype=float32)"
-      ]
-     },
-     "metadata": {
-      "after": [],
-      "completed": "2022-11-08T10:57:46.024126Z",
-      "data": {},
-      "engine_id": 0,
-      "engine_uuid": "05cdbd79-7ab6281f5b5b6ab3779c1caf",
-      "error": null,
-      "execute_input": "f.data\n",
-      "execute_result": {
-       "data": {
-        "text/plain": "Data([[1.25, 1.25],\n      [1.25, 2.5 ]], dtype=float32)"
-       },
-       "execution_count": 18,
-       "metadata": {}
-      },
-      "follow": [],
-      "is_broadcast": false,
-      "is_coalescing": false,
-      "msg_id": "95369d33-be708cfcf370f6da2acbf883_88297_63",
-      "outputs": [],
-      "received": "2022-11-08T10:57:46.025839Z",
-      "started": "2022-11-08T10:57:46.021884Z",
-      "status": "ok",
-      "stderr": "",
-      "stdout": "",
-      "submitted": "2022-11-08T10:57:46.020219Z"
-     },
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "[output:1]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "\u001b[0;31mOut[1:16]: \u001b[0m\n",
-       "Data([[0.  , 0.  ],\n",
-       "      [2.5 , 1.25]], dtype=float32)"
-      ]
-     },
-     "metadata": {
-      "after": [],
-      "completed": "2022-11-08T10:57:46.024360Z",
-      "data": {},
-      "engine_id": 1,
-      "engine_uuid": "7fc04624-73e795bad718b5e339566ff4",
-      "error": null,
-      "execute_input": "f.data\n",
-      "execute_result": {
-       "data": {
-        "text/plain": "Data([[0.  , 0.  ],\n      [2.5 , 1.25]], dtype=float32)"
-       },
-       "execution_count": 16,
-       "metadata": {}
-      },
-      "follow": [],
-      "is_broadcast": false,
-      "is_coalescing": false,
-      "msg_id": "95369d33-be708cfcf370f6da2acbf883_88297_64",
-      "outputs": [],
-      "received": "2022-11-08T10:57:46.026357Z",
-      "started": "2022-11-08T10:57:46.022070Z",
-      "status": "ok",
-      "stderr": "",
-      "stdout": "",
-      "submitted": "2022-11-08T10:57:46.020414Z"
-     },
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "[output:2]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "\u001b[0;31mOut[2:16]: \u001b[0m\n",
-       "Data([[0.  , 2.5 ],\n",
-       "      [0.  , 1.25]], dtype=float32)"
-      ]
-     },
-     "metadata": {
-      "after": [],
-      "completed": "2022-11-08T10:57:46.025164Z",
-      "data": {},
-      "engine_id": 2,
-      "engine_uuid": "a23db01e-e003618a39ef4bff2150e225",
-      "error": null,
-      "execute_input": "f.data\n",
-      "execute_result": {
-       "data": {
-        "text/plain": "Data([[0.  , 2.5 ],\n      [0.  , 1.25]], dtype=float32)"
-       },
-       "execution_count": 16,
-       "metadata": {}
-      },
-      "follow": [],
-      "is_broadcast": false,
-      "is_coalescing": false,
-      "msg_id": "95369d33-be708cfcf370f6da2acbf883_88297_65",
-      "outputs": [],
-      "received": "2022-11-08T10:57:46.026874Z",
-      "started": "2022-11-08T10:57:46.022402Z",
-      "status": "ok",
-      "stderr": "",
-      "stdout": "",
-      "submitted": "2022-11-08T10:57:46.020479Z"
-     },
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "[output:3]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "\u001b[0;31mOut[3:16]: \u001b[0m\n",
-       "Data([[3.75, 1.25],\n",
-       "      [1.25, 0.  ]], dtype=float32)"
-      ]
-     },
-     "metadata": {
-      "after": [],
-      "completed": "2022-11-08T10:57:46.024206Z",
-      "data": {},
-      "engine_id": 3,
-      "engine_uuid": "b750ce5d-e040b2201c51070606409a4c",
-      "error": null,
-      "execute_input": "f.data\n",
-      "execute_result": {
-       "data": {
-        "text/plain": "Data([[3.75, 1.25],\n      [1.25, 0.  ]], dtype=float32)"
-       },
-       "execution_count": 16,
-       "metadata": {}
-      },
-      "follow": [],
-      "is_broadcast": false,
-      "is_coalescing": false,
-      "msg_id": "95369d33-be708cfcf370f6da2acbf883_88297_66",
-      "outputs": [],
-      "received": "2022-11-08T10:57:46.025303Z",
-      "started": "2022-11-08T10:57:46.022238Z",
-      "status": "ok",
-      "stderr": "",
-      "stdout": "",
-      "submitted": "2022-11-08T10:57:46.020532Z"
-     },
-     "output_type": "display_data"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[stdout:0] \n",
+      "[[1.25 1.25]\n",
+      " [1.25 2.5 ]]\n",
+      "[stdout:1] \n",
+      "[[0.   0.  ]\n",
+      " [2.5  1.25]]\n",
+      "[stdout:2] \n",
+      "[[0.   2.5 ]\n",
+      " [0.   1.25]]\n",
+      "[stdout:3] \n",
+      "[[3.75 1.25]\n",
+      " [1.25 0.  ]]\n"
+     ]
     }
    ],
    "source": [
     "%%px --no-stream --group-outputs=engine\n",
-    "f.data"
+    "print(f.data)"
    ]
   },
   {
@@ -1918,7 +922,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.6"
+   "version": "3.8.10"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Depending on the version of python/jupyter, there are some differences in the formatting of objects when you let jupyter+ipyparallel/mpi simply echo the object by writing the object as a statement at the end of a cell vs running the notebook using nbval. 

Resolved by explicitly passing the object to `print()` at the end of the cell.