### PR TITLE
compiler: Revamp compilation of halo exchanges

### DIFF
--- a/devito/arch/compiler.py
+++ b/devito/arch/compiler.py
@@ -605,7 +605,7 @@ class CudaCompiler(Compiler):
                 elif i.startswith('-Wl'):
                     # E.g., `-Wl,-rpath` -> `-Xcompiler "-Wl\,-rpath"`
                     proc_link_flags.extend([
-                        '-Xcompiler', '"%s"' % i.replace(',', '\,')
+                        '-Xcompiler', '"%s"' % i.replace(',', r'\,')
                     ])
                 else:
                     proc_link_flags.append(i)

--- a/devito/arch/compiler.py
+++ b/devito/arch/compiler.py
@@ -105,7 +105,7 @@ def sniff_mpi_distro(mpiexec):
 
 
 @memoized_func
-def sniff_mpi_flags():
+def sniff_mpi_flags(mpicc='mpicc'):
     mpi_distro = sniff_mpi_distro('mpiexec')
     if mpi_distro != 'OpenMPI':
         raise NotImplementedError("Unable to detect MPI compile and link flags")
@@ -584,35 +584,45 @@ class CudaCompiler(Compiler):
         self.cflags.remove('-fPIC')
         self.cflags.extend(['-std=c++14', '-Xcompiler', '-fPIC'])
 
+        if configuration['mpi']:
+            # We rather use `nvcc` to compile MPI, but for this we have to
+            # explicitly pass the flags that an `mpicc` would implicitly use
+            compile_flags, link_flags = sniff_mpi_flags('mpicxx')
+
+            try:
+                # No idea why `-pthread` would pop up among the `compile_flags`
+                compile_flags.remove('-pthread')
+            except ValueError:
+                # Just in case they fix it, we wrap it up within a try-except
+                pass
+            self.cflags.extend(compile_flags)
+
+            # Some arguments are for the host compiler
+            proc_link_flags = []
+            for i in link_flags:
+                if i == '-pthread':
+                    proc_link_flags.extend(['-Xcompiler', '-pthread'])
+                elif i.startswith('-Wl'):
+                    # E.g., `-Wl,-rpath` -> `-Xcompiler "-Wl\,-rpath"`
+                    proc_link_flags.extend([
+                        '-Xcompiler', '"%s"' % i.replace(',', '\,')
+                    ])
+                else:
+                    proc_link_flags.append(i)
+            self.ldflags.extend(proc_link_flags)
+
+        self.cflags.append('-arch=native')
+
         # Disable `warning #1650-D: result of call is not used`
         # See `https://gist.github.com/gavinb/f2320f9eaa0e0a7efca6877a34047a9d` about
         # disabling specific warnings with nvcc
-        if configuration['mpi']:
-            # mpicc/mpicxx default to `nvc++ ...` (add `--showme` to print out the
-            # actual command line that results from expanding out the mpicc/mpicxx
-            # wrappers). However, mpicc/mpicxx also use the `'-Wl,-rpath'`
-            # GCC-specific options, which means we can't use `nvc++` as host
-            # compiler via `-ccbin=nvc++` either, as otherwise it will complain that
-            # `nvcc fatal   : Unknown option '-Wl,-rpath'`. So the simplest option
-            # for now is to avoid adding the flags below in the `else` branch as
-            # they are `nvcc` specific; `nvc++`, used by mpicc/mpicxx+, will use
-            # `nvcc` eventually (since it reads the file suffix .cu), but somehow
-            # it won't digest the options provided in this format...
+        self.cflags.extend(['-Xcudafe', '--display_error_number',
+                            '--diag-suppress', '1650'])
+        # Same as above but for the host compiler
+        self.cflags.extend(['-Xcompiler', '-Wno-unused-result'])
 
-            # Also, no need to specify the compute capability via e.g. `-gpu=cc70`,
-            # as nvc++ will automatically compile for the GPU installed in this
-            # system by default
-
-            pass
-        else:
-            self.cflags.append('-arch=native')
-            self.cflags.extend(['-Xcudafe', '--display_error_number',
-                                '--diag-suppress', '1650'])
-            # Same as above but for the host compiler
-            self.cflags.extend(['-Xcompiler', '-Wno-unused-result'])
-
-            if not configuration['safe-math']:
-                self.cflags.append('--use_fast_math')
+        if not configuration['safe-math']:
+            self.cflags.append('--use_fast_math')
 
         self.src_ext = 'cu'
 
@@ -625,8 +635,8 @@ class CudaCompiler(Compiler):
     def __lookup_cmds__(self):
         self.CC = 'nvcc'
         self.CXX = 'nvcc'
-        self.MPICC = 'mpic++'
-        self.MPICXX = 'mpicxx'
+        self.MPICC = 'nvcc'
+        self.MPICXX = 'nvcc'
 
 
 class HipCompiler(Compiler):

--- a/devito/core/operator.py
+++ b/devito/core/operator.py
@@ -339,7 +339,7 @@ class ParTile(tuple, OptOption):
             if not default:
                 raise ValueError("Expected `default` value, got None")
             items = (ParTileArg(as_tuple(default)),)
-        elif isinstance(items, tuple):
+        elif isinstance(items, (list, tuple)):
             if not items:
                 raise ValueError("Expected at least one value")
 
@@ -349,6 +349,10 @@ class ParTile(tuple, OptOption):
             if is_integer(x):
                 # E.g., (32, 4, 8)
                 items = (ParTileArg(items),)
+
+            elif isinstance(x, ParTileArg):
+                # From a reconstruction
+                pass
 
             elif isinstance(x, Iterable):
                 if not x:
@@ -374,6 +378,9 @@ class ParTile(tuple, OptOption):
             else:
                 raise ValueError("Expected int or tuple, got %s instead" % type(x))
         else:
-            raise ValueError("Expected bool or tuple, got %s instead" % type(items))
+            raise ValueError("Expected bool or iterable, got %s instead" % type(items))
 
-        return super().__new__(cls, items)
+        obj = super().__new__(cls, items)
+        obj.default = as_tuple(default)
+
+        return obj

--- a/devito/ir/clusters/algorithms.py
+++ b/devito/ir/clusters/algorithms.py
@@ -341,6 +341,11 @@ class Stepper(Queue):
 
 class Communications(Queue):
 
+    """
+    Enrich a sequence of Clusters by adding special Clusters representing data
+    communications, or "halo exchanges", for distributed parallelism.
+    """
+
     _q_guards_in_key = True
 
     B = Symbol(name='⊥')

--- a/devito/ir/clusters/algorithms.py
+++ b/devito/ir/clusters/algorithms.py
@@ -40,11 +40,11 @@ def clusterize(exprs, **kwargs):
     # Determine relevant computational properties (e.g., parallelism)
     clusters = analyze(clusters)
 
-    # Derive the necessary communications for distributed-memory parallelism
-    clusters = Communications().process(clusters)
-
     # Input normalization (e.g., SSA)
     clusters = normalize(clusters, **kwargs)
+
+    # Derive the necessary communications for distributed-memory parallelism
+    clusters = Communications().process(clusters)
 
     return ClusterGroup(clusters)
 
@@ -408,10 +408,6 @@ def normalize_nested_indexeds(cluster, sregistry):
     """
     Recursively extract nested Indexeds in to temporaries.
     """
-
-    #TODO: place Comunications AFTER normalize?????
-    if cluster.is_halo_touch:
-        return cluster
 
     def pull_indexeds(expr, subs, mapper, parent=None):
         for i in retrieve_indexed(expr):

--- a/devito/ir/clusters/algorithms.py
+++ b/devito/ir/clusters/algorithms.py
@@ -11,11 +11,11 @@ from devito.ir.support import (Any, Backward, Forward, IterationSpace,
 from devito.ir.clusters.analysis import analyze
 from devito.ir.clusters.cluster import Cluster, ClusterGroup
 from devito.ir.clusters.visitors import Queue, QueueStateful, cluster_pass
-from devito.mpi.halo_scheme import HaloScheme, HaloSchemeException, HaloTouch
+from devito.mpi.halo_scheme import HaloScheme, HaloTouch
 from devito.symbolics import retrieve_indexed, uxreplace, xreplace_indices
-from devito.tools import (DefaultOrderedDict, Reconstructable, Stamp, as_mapper,
-                          flatten, is_integer, timed_pass)
-from devito.types import Array, Eq, Indexed, Symbol
+from devito.tools import (DefaultOrderedDict, Stamp, as_mapper, flatten,
+                          is_integer, timed_pass)
+from devito.types import Array, Eq, Symbol
 from devito.types.dimension import BOTTOM, ModuloDimension
 
 __all__ = ['clusterize']

--- a/devito/ir/clusters/algorithms.py
+++ b/devito/ir/clusters/algorithms.py
@@ -358,6 +358,9 @@ class Communications(Queue):
         # Construct the mock exprs representing the halo accesses
         exprs = []
         for c in clusters:
+            if c.properties.is_sequential(d):
+                continue
+
             halo_scheme = HaloScheme(c.exprs, c.ispace)
 
             if not halo_scheme.is_void and \

--- a/devito/ir/iet/efunc.py
+++ b/devito/ir/iet/efunc.py
@@ -24,7 +24,7 @@ class ElementalFunction(Callable):
 
     is_ElementalFunction = True
 
-    def __init__(self, name, body, retval, parameters=None, prefix=('static', 'inline'),
+    def __init__(self, name, body, retval='void', parameters=None, prefix=('static',),
                  dynamic_parameters=None):
         super(ElementalFunction, self).__init__(name, body, retval, parameters, prefix)
 
@@ -35,6 +35,11 @@ class ElementalFunction(Callable):
                                    parameters.index(i.symbolic_max))
             else:
                 self._mapper[i] = (parameters.index(i),)
+
+    @classmethod
+    def make(cls, name, body):
+        parameters = derive_parameters(body)
+        return cls(name, body, parameters=parameters)
 
     @cached_property
     def dynamic_defaults(self):
@@ -86,8 +91,9 @@ def make_efunc(name, iet, dynamic_parameters=None, retval='void', prefix='static
     """
     Shortcut to create an ElementalFunction.
     """
-    return ElementalFunction(name, iet, retval, derive_parameters(iet), prefix,
-                             dynamic_parameters)
+    return ElementalFunction(name, iet, retval=retval,
+                             parameters=derive_parameters(iet), prefix=prefix,
+                             dynamic_parameters=dynamic_parameters)
 
 
 # Callable machinery

--- a/devito/ir/iet/nodes.py
+++ b/devito/ir/iet/nodes.py
@@ -622,7 +622,31 @@ class Iteration(Node):
         return self.dimensions
 
 
-class While(Node):
+class DoIf(Node):
+
+    """
+    An abstract Node to express computation subjected to a condition.
+    """
+
+    def __init__(self, condition):
+        self.condition = condition
+
+    @property
+    def functions(self):
+        ret = []
+        for i in self.condition.free_symbols:
+            try:
+                ret.append(i.function)
+            except AttributeError:
+                pass
+        return tuple(ret)
+
+    @property
+    def expr_symbols(self):
+        return tuple(self.condition.free_symbols)
+
+
+class While(DoIf):
 
     """
     Implement a while-loop.
@@ -640,7 +664,7 @@ class While(Node):
     _traversable = ['body']
 
     def __init__(self, condition, body=None):
-        self.condition = condition
+        super().__init__(condition)
         self.body = as_tuple(body)
 
     def __repr__(self):
@@ -759,7 +783,7 @@ class CallableBody(Node):
                  len(self.frees)))
 
 
-class Conditional(Node):
+class Conditional(DoIf):
 
     """
     A node to express if-then-else blocks.
@@ -779,7 +803,7 @@ class Conditional(Node):
     _traversable = ['then_body', 'else_body']
 
     def __init__(self, condition, then_body, else_body=None):
-        self.condition = condition
+        super().__init__(condition)
         self.then_body = as_tuple(then_body)
         self.else_body = as_tuple(else_body)
 
@@ -789,20 +813,6 @@ class Conditional(Node):
                 (ccode(self.condition), repr(self.then_body), repr(self.else_body))
         else:
             return "<[%s] ? [%s]" % (ccode(self.condition), repr(self.then_body))
-
-    @property
-    def functions(self):
-        ret = []
-        for i in self.condition.free_symbols:
-            try:
-                ret.append(i.function)
-            except AttributeError:
-                pass
-        return tuple(ret)
-
-    @property
-    def expr_symbols(self):
-        return tuple(self.condition.free_symbols)
 
 
 # Second level IET nodes

--- a/devito/ir/iet/visitors.py
+++ b/devito/ir/iet/visitors.py
@@ -898,6 +898,12 @@ class FindSymbols(Visitor):
     def visit_Node(self, o):
         return self.Retval(self._visit(o.children), self.rule(o))
 
+    def visit_ThreadedProdder(self, o):
+        # TODO: this handle required because ThreadedProdder suffers from the
+        # long-standing issue affecting all Node subclasses which rely on
+        # multiple inheritance
+        return self.Retval(self._visit(o.then_body), self.rule(o))
+
     def visit_Operator(self, o):
         ret = self._visit(o.body)
         ret.extend(flatten(self._visit(v) for v in o._func_table.values()))

--- a/devito/ir/iet/visitors.py
+++ b/devito/ir/iet/visitors.py
@@ -1123,8 +1123,11 @@ class Uxreplace(Transformer):
 
     def visit_Iteration(self, o):
         nodes = self._visit(o.nodes)
+        dimension = uxreplace(o.dim, self.mapper)
         limits = [uxreplace(i, self.mapper) for i in o.limits]
-        return o._rebuild(nodes=nodes, limits=limits)
+        uindices = [uxreplace(i, self.mapper) for i in o.uindices]
+        return o._rebuild(nodes=nodes, dimension=dimension, limits=limits,
+                          uindices=uindices)
 
     def visit_Definition(self, o):
         try:

--- a/devito/ir/stree/algorithms.py
+++ b/devito/ir/stree/algorithms.py
@@ -4,14 +4,13 @@ from itertools import groupby
 from anytree import findall
 from sympy import And
 
-from devito.ir.clusters import Cluster, Queue
+from devito.ir.clusters import Cluster
 from devito.ir.stree.tree import (ScheduleTree, NodeIteration, NodeConditional,
-                                  NodeSync, NodeExprs, NodeSection, NodeHalo, insert)
-from devito.ir.support import (PARALLEL_IF_ATOMIC, SEQUENTIAL, Any, Interval,
-                               IterationInterval, IterationSpace, normalize_properties)
-from devito.mpi.halo_scheme import HaloScheme, HaloSchemeException
-from devito.parameters import configuration
-from devito.tools import Bunch, DefaultOrderedDict, flatten
+                                  NodeSync, NodeExprs, NodeSection, NodeHalo)
+from devito.ir.support import (SEQUENTIAL, Any, Interval, IterationInterval,
+                               IterationSpace, normalize_properties)
+from devito.mpi.halo_scheme import HaloScheme
+from devito.tools import Bunch, DefaultOrderedDict
 from devito.types.dimension import BOTTOM
 
 __all__ = ['stree_build']

--- a/devito/ir/stree/algorithms.py
+++ b/devito/ir/stree/algorithms.py
@@ -1,75 +1,62 @@
+from collections import defaultdict
+from itertools import groupby
+
 from anytree import findall
 from sympy import And
 
-from itertools import groupby
-
-from devito.ir.clusters import Cluster
+from devito.ir.clusters import Cluster, Queue
 from devito.ir.stree.tree import (ScheduleTree, NodeIteration, NodeConditional,
                                   NodeSync, NodeExprs, NodeSection, NodeHalo, insert)
-from devito.ir.support import SEQUENTIAL, IterationSpace, normalize_properties
+from devito.ir.support import (PARALLEL_IF_ATOMIC, SEQUENTIAL, Any, Interval,
+                               IterationInterval, IterationSpace, normalize_properties)
 from devito.mpi.halo_scheme import HaloScheme, HaloSchemeException
 from devito.parameters import configuration
 from devito.tools import Bunch, DefaultOrderedDict, flatten
+from devito.types.dimension import BOTTOM
 
 __all__ = ['stree_build']
 
 
-def stree_build(clusters, **kwargs):
+def stree_build(clusters, profiler=None, **kwargs):
     """
     Create a ScheduleTree from a ClusterGroup.
     """
-    # ClusterGroup -> ScheduleTree
-    stree = stree_schedule(clusters)
+    clusters, hsmap = preprocess(clusters)
 
-    # Add in section nodes
-    stree = stree_section(stree, **kwargs)
-
-    # Add in halo update nodes
-    stree = stree_make_halo(stree)
-
-    return stree
-
-
-def stree_schedule(clusters):
-    """
-    Arrange an iterable of Clusters into a ScheduleTree.
-    """
     stree = ScheduleTree()
+    section = None
 
+    base = IterationInterval(Interval(BOTTOM), [], Any)
     prev = Cluster(None)
+
     mapper = DefaultOrderedDict(lambda: Bunch(top=None, bottom=None))
-
-    def reuse_metadata(c0, c1, d):
-        return (c0.guards.get(d) == c1.guards.get(d) and
-                c0.syncs.get(d) == c1.syncs.get(d))
-
-    def attach_metadata(cluster, d, tip):
-        if d in cluster.guards:
-            tip = NodeConditional(cluster.guards[d], tip)
-        if d in cluster.syncs:
-            tip = NodeSync(cluster.syncs[d], tip)
-        return tip
+    mapper[base] = Bunch(top=stree, bottom=stree)
 
     for c in clusters:
-        index = 0
-
-        # Reuse or add in any Conditionals and Syncs outside of the outermost Iteration
-        if not reuse_metadata(c, prev, None):
-            tip = attach_metadata(c, None, stree)
-            maybe_reusable = []
-        else:
-            try:
-                tip = mapper[prev.itintervals[index]].top.parent
-            except IndexError:
-                tip = stree
+        if reuse_subtree(c, prev):
+            tip = mapper[base].bottom
             maybe_reusable = prev.itintervals
+        else:
+            # Add any guards/Syncs outside of the outermost Iteration
+            tip = augment_subtree(c, None, stree)
+            maybe_reusable = []
 
+        # Is there a HaloTouch to attach?
+        try:
+            hs = hsmap[c]
+        except KeyError:
+            hs = None
+
+        index = 0
         for it0, it1 in zip(c.itintervals, maybe_reusable):
             if it0 != it1:
                 break
-            index += 1
 
             d = it0.dim
+            if needs_nodehalo(d, hs):
+                break
+
+            index += 1
 
             # The reused sub-trees might acquire new sub-iterators as well as
             # new properties
@@ -80,28 +67,34 @@ def stree_schedule(clusters):
                 mapper[it0].top.properties, c.properties[it0.dim]
             )
 
-            # Different guards or SyncOps cannot further be nested
-            if not reuse_metadata(c, prev, d):
+            if reuse_subtree(c, prev, d):
+                tip = mapper[it0].bottom
+            else:
                 tip = mapper[it0].top
-                tip = attach_metadata(c, d, tip)
+                tip = augment_subtree(c, d, tip)
                 mapper[it0].bottom = tip
                 break
-            else:
-                tip = mapper[it0].bottom
 
         # Nested sub-trees, instead, will not be used anymore
         for it in prev.itintervals[index:]:
             mapper.pop(it)
+        prev = c
 
-        # Add in Iterations, Conditionals, and Syncs
+        # Add in Node{Iteration,Conditional,Sync}
         for it in c.itintervals[index:]:
             d = it.dim
             tip = NodeIteration(c.ispace.project([d]), tip, c.properties.get(d, ()))
             mapper[it].top = tip
-            tip = attach_metadata(c, d, tip)
+            tip = augment_subtree(c, d, tip)
             mapper[it].bottom = tip
 
-        # Add in Expressions
+        # Attach NodeHalo if necessary
+        for it, v in mapper.items():
+            if needs_nodehalo(it.dim, hs):
+                v.bottom.parent = NodeHalo(hs, v.bottom.parent)
+                break
+
+        # Add in NodeExprs
         exprs = []
         for conditionals, g in groupby(c.exprs, key=lambda e: e.conditionals):
             exprs = list(g)
@@ -115,106 +108,116 @@ def stree_schedule(clusters):
 
             NodeExprs(exprs, c.ispace, c.dspace, c.ops, c.traffic, parent)
 
-        # Prepare for next iteration
-        prev = c
+        # Nest within a NodeSection if possible
+        if profiler is None or \
+           any(i.is_Section for i in reversed(tip.ancestors)):
+            continue
 
-    return stree
-
-
-def stree_make_halo(stree):
-    """
-    Add NodeHalos to a ScheduleTree. A NodeHalo captures the halo exchanges
-    that should take place before executing the sub-tree; these are described
-    by means of a HaloScheme.
-    """
-    # Build a HaloScheme for each expression bundle
-    halo_schemes = {}
-    for n in findall(stree, lambda i: i.is_Exprs):
-        try:
-            halo_schemes[n] = HaloScheme(n.exprs, n.ispace)
-        except HaloSchemeException as e:
-            if configuration['mpi']:
-                raise RuntimeError(str(e))
-
-    # Split a HaloScheme based on where it should be inserted
-    # For example, it's possible that, for a given HaloScheme, a Function's
-    # halo needs to be exchanged at a certain `stree` depth, while another
-    # Function's halo needs to be exchanged before some other nodes
-    mapper = {}
-    for k, hs in halo_schemes.items():
-        for f, v in hs.fmapper.items():
-            spot = k
-            ancestors = [n for n in k.ancestors if n.is_Iteration]
-            for n in ancestors:
-                # Place the halo exchange before the first distributed Dimension
-                if n.dim._defines.intersection(f._dist_dimensions):
-                    spot = n
+        candidate = None
+        for i in reversed(tip.ancestors + (tip,)):
+            if i.is_Halo:
+                candidate = i
+            elif i.is_Sync:
+                attach_section(i)
+                section = None
+                break
+            elif i.is_Iteration:
+                if (i.dim.is_Time and SEQUENTIAL in i.properties):
+                    section = attach_section(candidate, section)
                     break
-            mapper.setdefault(spot, []).append(hs.project(f))
-
-    # Now fuse the HaloSchemes at the same `stree` depth and perform the insertion
-    for spot, halo_schemes in mapper.items():
-        insert(NodeHalo(HaloScheme.union(halo_schemes)), spot.parent, [spot])
-
-    return stree
-
-
-def stree_section(stree, profiler=None, **kwargs):
-    """
-    Add NodeSections to a ScheduleTree. A NodeSection, or simply "section",
-    defines a sub-tree with the following properties:
-
-        * The root is a node of type NodeSection;
-        * The immediate children of the root are nodes of type NodeIteration;
-        * The Dimensions of the immediate children are either:
-            * identical, OR
-            * different, but all of type SubDimension;
-        * The Dimension of the immediate children cannot be a TimeDimension.
-    """
-    if profiler is None:
-        return stree
-
-    class Section(object):
-        def __init__(self, node):
-            self.parent = node.parent
-            try:
-                self.dim = node.dim
-            except AttributeError:
-                self.dim = None
-            self.nodes = [node]
-
-        def is_compatible(self, node):
-            return self.parent == node.parent and self.dim.root == node.dim.root
-
-    # Search candidate sections
-    sections = []
-    for i in range(stree.height):
-        # Find all sections at depth `i`
-        section = None
-        for n in findall(stree, filter_=lambda n: n.depth == i):
-            if any(p in flatten(s.nodes for s in sections) for p in n.ancestors):
-                # Already within a section
-                continue
-            elif n.is_Sync:
-                # SyncNodes are self-contained
-                sections.append(Section(n))
-                section = None
-            elif n.is_Iteration:
-                if n.dim.is_Time and SEQUENTIAL in n.properties:
-                    # If n.dim.is_Time, we end up here in 99.9% of the cases.
-                    # Sometimes, however, time is a PARALLEL Dimension (e.g.,
-                    # think of `norm` Operators)
-                    section = None
-                elif section is None or not section.is_compatible(n):
-                    section = Section(n)
-                    sections.append(section)
                 else:
-                    section.nodes.append(n)
-            else:
-                section = None
-
-    # Transform the schedule tree by adding in sections
-    for i in sections:
-        insert(NodeSection(), i.parent, i.nodes)
+                    candidate = i
+        else:
+            attach_section(candidate, section)
 
     return stree
+
+
+# *** Utility functions to construct the ScheduleTree
+
+
+def preprocess(clusters):
+    """
+    Remove the HaloTouches from `clusters` and create a mapping associating
+    each removed HaloTouch to the first Cluster necessitating it.
+    """
+    processed = []
+    hsmap = defaultdict(list)
+
+    queue = []
+
+    for c in clusters:
+        if c.is_halo_touch:
+            queue.append(HaloScheme.union(e.rhs.halo_scheme for e in c.exprs))
+        else:
+            dims = set(c.ispace.promote(lambda d: d.is_Block).itdimensions)
+
+            for hs in list(queue):
+                if hs.distributed_aindices & dims:
+                    queue.remove(hs)
+                    hsmap[c].append(hs)
+
+            processed.append(c)
+
+    hsmap = {c: HaloScheme.union(hss) for c, hss in hsmap.items()}
+
+    return processed, hsmap
+
+
+def reuse_subtree(c0, c1, d=None):
+    return (c0.guards.get(d) == c1.guards.get(d) and
+            c0.syncs.get(d) == c1.syncs.get(d))
+
+
+def augment_subtree(cluster, d, tip):
+    if d in cluster.guards:
+        tip = NodeConditional(cluster.guards[d], tip)
+    if d in cluster.syncs:
+        tip = NodeSync(cluster.syncs[d], tip)
+    return tip
+
+
+def needs_nodehalo(d, hs):
+    return hs and d._defines.intersection(hs.distributed_aindices)
+
+
+def reuse_section(candidate, section):
+    try:
+        if not section or candidate.siblings[-1] is not section:
+            return False
+    except IndexError:
+        return False
+
+    key = lambda i: findall(i, lambda n: n.is_Iteration)
+    iters0 = key(section)
+    iters1 = key(candidate)
+
+    # Heuristics for NodeSection reuse:
+    # * Ignore some kinds of iteration Dimensions
+    key = lambda d: not (d.is_Custom or d.is_Stencil)
+    iters0 = [i for i in iters0 if key(i.dim)]
+    iters1 = [i for i in iters1 if key(i.dim)]
+
+    # * Same set of iteration Dimensions
+    key = lambda i: i.interval.promote(lambda d: d.is_Block).dim
+    test00 = len(iters0) == len(iters1)
+    test01 = all(key(i) is key(j) for i, j in zip(iters0, iters1))
+
+    # * All subtrees use at least one local SubDimension (i.e., BCs)
+    key = lambda iters: any(i.dim.is_Sub and i.dim.local for i in iters)
+    test1 = key(iters0) and key(iters1)
+
+    if (test00 and test01) or test1:
+        candidate.parent = section
+        return True
+    else:
+        return False
+
+
+def attach_section(candidate, section=None):
+    if candidate and not reuse_section(candidate, section):
+        section = NodeSection()
+        section.parent = candidate.parent
+        candidate.parent = section
+
+    return section

--- a/devito/ir/stree/tree.py
+++ b/devito/ir/stree/tree.py
@@ -133,21 +133,5 @@ class NodeHalo(ScheduleTree):
         return "<Halo>"
 
 
-def insert(node, parent, children):
-    """
-    Insert ``node`` between ``parent`` and ``children``, where ``children``
-    are a subset of nodes in ``parent.children``.
-    """
-    processed = []
-    for n in list(parent.children):
-        if n in children:
-            n.parent = node
-            if node not in processed:
-                processed.append(node)
-        else:
-            processed.append(n)
-    parent.children = processed
-
-
 def render(stree):
     return RenderTree(stree, style=ContStyle()).by_attr('__repr_render__')

--- a/devito/ir/stree/tree.py
+++ b/devito/ir/stree/tree.py
@@ -124,7 +124,8 @@ class NodeHalo(ScheduleTree):
 
     is_Halo = True
 
-    def __init__(self, halo_scheme):
+    def __init__(self, halo_scheme, parent=None):
+        super().__init__(parent)
         self.halo_scheme = halo_scheme
 
     @property

--- a/devito/ir/support/basic.py
+++ b/devito/ir/support/basic.py
@@ -2,7 +2,6 @@ from itertools import chain
 
 from cached_property import cached_property
 from sympy import S
-from sympy.tensor.indexed import IndexException
 
 from devito.ir.support.space import Backward, IterationSpace
 from devito.ir.support.utils import AccessMode
@@ -11,7 +10,7 @@ from devito.symbolics import (retrieve_terminals, q_constant, q_affine, q_routin
                               q_terminal)
 from devito.tools import (Tag, as_tuple, is_integer, filter_sorted, flatten,
                           memoized_meth, memoized_generator)
-from devito.types import Barrier, Dimension, DimensionTuple, Jump
+from devito.types import Barrier, Dimension, DimensionTuple, Jump, Symbol
 
 __all__ = ['IterationInstance', 'TimedAccess', 'Scope']
 
@@ -22,6 +21,11 @@ class IndexMode(Tag):
 AFFINE = IndexMode('affine')  # noqa
 REGULAR = IndexMode('regular')
 IRREGULAR = IndexMode('irregular')
+
+mocksym = Symbol(name='⋈')
+"""
+A Symbol to create mock data depdendencies.
+"""
 
 
 class IterationInstance(LabeledVector):
@@ -831,17 +835,13 @@ class Scope(object):
         # break statements, ...) are converted into mock dependences
         for i, e in enumerate(exprs):
             if e.find(Barrier) | e.find(Jump):
-                for a in self.accesses:
-                    f = a.function
-                    if not f.is_AbstractFunction:
-                        continue
-                    indices = [i if d in e.ispace else S.Infinity
-                               for i, d in zip(a, a.aindices)]
-                    v = self.writes.setdefault(f, [])
-                    try:
-                        v.append(TimedAccess(f[indices], 'W', i, e.ispace))
-                    except IndexException:
-                        pass
+                self.writes.setdefault(mocksym, []).append(
+                    TimedAccess(mocksym, 'W', i, e.ispace)
+                )
+                self.reads.setdefault(mocksym, []).extend([
+                    TimedAccess(mocksym, 'R', max(i, 0), e.ispace),
+                    TimedAccess(mocksym, 'R', i+1, e.ispace),
+                ])
 
         # A set of rules to drive the collection of dependencies
         self.rules = as_tuple(rules)

--- a/devito/ir/support/basic.py
+++ b/devito/ir/support/basic.py
@@ -847,9 +847,6 @@ class Scope(object):
         self.rules = as_tuple(rules)
         assert all(callable(i) for i in self.rules)
 
-        #if len(exprs) == 2 and "f[t1, x + 1], f[t0, x] + f[t0, x + 2]" in str(exprs[0]) and 'HaloTouch' in str(exprs[1]):
-        #    from IPython import embed; embed()
-
     def getreads(self, function):
         return as_tuple(self.reads.get(function))
 

--- a/devito/ir/support/properties.py
+++ b/devito/ir/support/properties.py
@@ -137,6 +137,10 @@ class Properties(frozendict):
             m[d] = set(self.get(d, [])) | set(as_tuple(properties))
         return Properties(m)
 
+    def filter(self, key):
+        m = {d: v for d, v in self.items() if key(d)}
+        return Properties(m)
+
     def drop(self, dims, properties=None):
         m = dict(self)
         for d in as_tuple(dims):

--- a/devito/ir/support/properties.py
+++ b/devito/ir/support/properties.py
@@ -42,6 +42,12 @@ VECTORIZED = Property('vector-dim')
 TILABLE = Property('tilable')
 """A fully parallel Dimension that would benefit from tiling (or "blocking")."""
 
+TILABLE_SMALL = Property('tilable*')
+"""
+Like TILABLE, but it would benefit from relatively small block, since the
+iteration space is likely to be very small.
+"""
+
 SKEWABLE = Property('skewable')
 """A fully parallel Dimension that would benefit from wavefront/skewed tiling."""
 
@@ -89,6 +95,11 @@ is used for iteration spaces that are larger than the data space.
 """
 
 
+# Bundles
+PARALLELS = {PARALLEL, PARALLEL_INDEP, PARALLEL_IF_ATOMIC, PARALLEL_IF_PVT}
+TILABLES = {TILABLE, TILABLE_SMALL}
+
+
 def normalize_properties(*args):
     if not args:
         return
@@ -100,7 +111,7 @@ def normalize_properties(*args):
     # to the most restrictive property, is:
     # SEQUENTIAL > PARALLEL_IF_* > PARALLEL > PARALLEL_INDEP
     if any(SEQUENTIAL in p for p in args):
-        drop = {PARALLEL, PARALLEL_INDEP, PARALLEL_IF_ATOMIC, PARALLEL_IF_PVT}
+        drop = PARALLELS
     elif any(PARALLEL_IF_ATOMIC in p for p in args):
         drop = {PARALLEL, PARALLEL_INDEP}
     elif any(PARALLEL_IF_PVT in p for p in args):
@@ -141,7 +152,9 @@ class Properties(frozendict):
         m = {d: v for d, v in self.items() if key(d)}
         return Properties(m)
 
-    def drop(self, dims, properties=None):
+    def drop(self, dims=None, properties=None):
+        if dims is None:
+            dims = list(self)
         m = dict(self)
         for d in as_tuple(dims):
             if properties is None:
@@ -171,6 +184,18 @@ class Properties(frozendict):
             m[d] = normalize_properties(set(self.get(d, [])), {SEQUENTIAL})
         return Properties(m)
 
+    def block(self, dims, kind='default'):
+        if kind == 'default':
+            p = TILABLE
+        elif kind == 'small':
+            p = TILABLE_SMALL
+        else:
+            raise ValueError
+        m = dict(self)
+        for d in as_tuple(dims):
+            m[d] = set(self.get(d, [])) | {p}
+        return Properties(m)
+
     def inbound(self, dims):
         m = dict(self)
         for d in as_tuple(dims):
@@ -182,8 +207,7 @@ class Properties(frozendict):
                    for d in as_tuple(dims))
 
     def is_parallel_relaxed(self, dims):
-        items = {PARALLEL, PARALLEL_INDEP, PARALLEL_IF_ATOMIC, PARALLEL_IF_PVT}
-        return any(len(self[d] & items) > 0 for d in as_tuple(dims))
+        return any(len(self[d] & PARALLELS) > 0 for d in as_tuple(dims))
 
     def is_affine(self, dims):
         return any(AFFINE in self.get(d, ()) for d in as_tuple(dims))
@@ -193,3 +217,13 @@ class Properties(frozendict):
 
     def is_sequential(self, dims):
         return any(SEQUENTIAL in self.get(d, ()) for d in as_tuple(dims))
+
+    def is_blockable(self, d):
+        return bool(self.get(d, set()) & {TILABLE, TILABLE_SMALL})
+
+    def is_blockable_small(self, d):
+        return TILABLE_SMALL in self.get(d, set())
+
+    @property
+    def nblockable(self):
+        return sum([self.is_blockable(d) for d in self])

--- a/devito/ir/support/space.py
+++ b/devito/ir/support/space.py
@@ -13,7 +13,7 @@ from devito.tools import (PartialOrderTuple, Stamp, as_list, as_tuple, filter_or
 from devito.types import Dimension, ModuloDimension
 
 __all__ = ['NullInterval', 'Interval', 'IntervalGroup', 'IterationSpace',
-           'DataSpace', 'Forward', 'Backward', 'Any']
+           'IterationInterval', 'DataSpace', 'Forward', 'Backward', 'Any']
 
 
 # The default Stamp, used by all new Intervals
@@ -122,7 +122,7 @@ class Interval(AbstractInterval):
 
     is_Defined = True
 
-    def __init__(self, dim, lower, upper, stamp=S0):
+    def __init__(self, dim, lower=0, upper=0, stamp=S0):
         super(Interval, self).__init__(dim, stamp)
 
         try:

--- a/devito/ir/support/syncs.py
+++ b/devito/ir/support/syncs.py
@@ -45,7 +45,8 @@ class SyncOp(Pickable):
                 self.origin == other.origin)
 
     def __hash__(self):
-        return id(self)
+        return hash((self.__class__, self.handle, self.target, self.tindex,
+                     self.function, self.findex, self.dim, self.size, self.origin))
 
     def __repr__(self):
         return "%s<%s>" % (self.__class__.__name__, self.handle)

--- a/devito/mpi/distributed.py
+++ b/devito/mpi/distributed.py
@@ -258,8 +258,11 @@ class Distributor(AbstractDistributor):
         return self._topology
 
     @property
-    def is_custom_topology(self):
-        return isinstance(self.topology, CustomTopology)
+    def topology_logical(self):
+        if isinstance(self.topology, CustomTopology):
+            return self.topology.logical
+        else:
+            return None
 
     @cached_property
     def is_boundary_rank(self):
@@ -571,9 +574,14 @@ class CustomTopology(tuple):
                 raise ValueError("Custom topology must be only 1 or *")
 
             v = input_comm.size // nstars
-            items = [i if i == 1 else v for i in items]
+            processed = [i if i == 1 else v for i in items]
+        else:
+            processed = items
 
-        return super().__new__(cls, items)
+        obj = super().__new__(cls, processed)
+        obj.logical = items
+
+        return obj
 
 
 def compute_dims(nprocs, ndim):

--- a/devito/mpi/distributed.py
+++ b/devito/mpi/distributed.py
@@ -205,13 +205,8 @@ class Distributor(AbstractDistributor):
                 self._topology = compute_dims(self._input_comm.size, len(shape))
             else:
                 # A custom topology may contain integers or the wildcard '*', which
-                # implies `nprocs // nstars`. If a topology dimension is 1, then
-                # the dimension is removed from the Distributor, thus obtaining
-                # a lower dimensional decomposition. This may impact code generation
-                if self._input_comm.size == 1:
-                    topology = tuple(1 for _ in topology)
-                else:
-                    topology = CustomTopology(topology, self._input_comm)
+                # implies `nprocs // nstars`
+                topology = CustomTopology(topology, self._input_comm)
 
                 self._topology = topology
 

--- a/devito/mpi/distributed.py
+++ b/devito/mpi/distributed.py
@@ -565,6 +565,40 @@ class MPINeighborhood(CompositeObject):
 
 class CustomTopology(tuple):
 
+    """
+    A CustomTopology is a mechanism to describe parametric domain decompositions.
+
+    Examples
+    --------
+    Assuming a domain consisting of three distributed Dimensions x, y, and z, and
+    an MPI communicator comprising N processes, a CustomTopology might be:
+
+    With N known, say N=4:
+
+    * `(1, 1, 4)`: the z Dimension is decomposed into 4 chunks
+    * `(2, 1, 2)`: the x Dimension is decomposed into 2 chunks; the z Dimension
+                   is decomposed into 2 chunks
+
+    With N unknown:
+
+    * `(1, '*', 1)`: the wildcard `'*'` tells the runtime to decompose the y
+                     Dimension into N chunks
+    * `('*', '*', 1)`: the wildcard `'*'` tells the runtime to decompose both the
+                       x and y Dimensions into N / 2 chunks respectively.
+
+    Raises
+    ------
+    N must evenly divide the number of `'*'`, otherwise a ValueError exception
+    is raised.
+    If the wildcard `'*'` is used, then the CustomTopology can only contain either
+    `'*'` or 1's, otherwise a ValueError exception is raised.
+
+    Notes
+    -----
+    Users shouldn't use this class directly. It's up to the Devito runtime to
+    instantiate it based on the user input.
+    """
+
     def __new__(cls, items, input_comm):
         nstars = len([i for i in items if i == '*'])
         if nstars > 0:

--- a/devito/mpi/halo_scheme.py
+++ b/devito/mpi/halo_scheme.py
@@ -390,12 +390,13 @@ def classify(exprs, ispace):
             # TODO: improve me
             continue
 
-        # User attempting to specialize domain decomposition; we gonna ignore
-        # halo exchanges along Dimensions that are practically replicated
+        # In the case of custom topologies, we ignore the Dimensions that aren't
+        # practically subjected to domain decomposition
         dist = f.grid.distributor
-        if dist.is_custom_topology:
-            ignored = [d for i, d in zip(dist.topology, dist.dimensions) if i == 1]
-        else:
+        try:
+            ignored = [d for i, d in zip(dist.topology_logical, dist.dimensions)
+                       if i == 1]
+        except TypeError:
             ignored = []
 
         # For each data access, determine if (and what type of) a halo exchange

--- a/devito/mpi/halo_scheme.py
+++ b/devito/mpi/halo_scheme.py
@@ -98,16 +98,15 @@ class HaloScheme(object):
         return "HaloScheme<%s>" % fnames
 
     def __eq__(self, other):
-        return isinstance(other, HaloScheme) and self.fmapper == other.fmapper
+        return (isinstance(other, HaloScheme) and
+                self._mapper == other._mapper and
+                self._honored == other._honored)
 
     def __len__(self):
         return len(self._mapper)
 
     def __hash__(self):
         return (self._mapper.__hash__(), self.honored.__hash__())
-
-    def __eq__(self, other):
-        return self._mapper == other._mapper and self._honored == other._honored
 
     @classmethod
     def build(cls, fmapper, honored):

--- a/devito/mpi/routines.py
+++ b/devito/mpi/routines.py
@@ -341,8 +341,8 @@ class BasicHaloExchangeBuilder(HaloExchangeBuilder):
         fromrank = Symbol(name='fromrank')
         torank = Symbol(name='torank')
 
-        gather = Call('gather%s' % key, [bufg] + list(bufg.shape) + [f] + ofsg)
-        scatter = Call('scatter%s' % key, [bufs] + list(bufs.shape) + [f] + ofss)
+        gather = Gather('gather%s' % key, [bufg] + list(bufg.shape) + [f] + ofsg)
+        scatter = Scatter('scatter%s' % key, [bufs] + list(bufs.shape) + [f] + ofss)
 
         # The `gather` is unnecessary if sending to MPI.PROC_NULL
         gather = Conditional(CondNe(torank, Macro('MPI_PROC_NULL')), gather)
@@ -545,7 +545,7 @@ class OverlapHaloExchangeBuilder(DiagHaloExchangeBuilder):
         sizes = [FieldFromPointer('%s[%d]' % (msg._C_field_sizes, i), msg)
                  for i in range(len(f._dist_dimensions))]
 
-        gather = Call('gather%s' % key, [bufg] + sizes + [f] + ofsg)
+        gather = Gather('gather%s' % key, [bufg] + sizes + [f] + ofsg)
         # The `gather` is unnecessary if sending to MPI.PROC_NULL
         gather = Conditional(CondNe(torank, Macro('MPI_PROC_NULL')), gather)
 
@@ -601,7 +601,7 @@ class OverlapHaloExchangeBuilder(DiagHaloExchangeBuilder):
 
         sizes = [FieldFromPointer('%s[%d]' % (msg._C_field_sizes, i), msg)
                  for i in range(len(f._dist_dimensions))]
-        scatter = Call('scatter%s' % key, [bufs] + sizes + [f] + ofss)
+        scatter = Scatter('scatter%s' % key, [bufs] + sizes + [f] + ofss)
 
         # The `scatter` must be guarded as we must not alter the halo values along
         # the domain boundary, where the sender is actually MPI.PROC_NULL
@@ -708,7 +708,7 @@ class Overlap2HaloExchangeBuilder(OverlapHaloExchangeBuilder):
 
         # The `gather` is unnecessary if sending to MPI.PROC_NULL
 
-        gather = Call('gather%s' % key, [cast(bufg)] + sizes + [f] + ofsg)
+        gather = Gather('gather%s' % key, [cast(bufg)] + sizes + [f] + ofsg)
         gather = Conditional(CondNe(torank, Macro('MPI_PROC_NULL')), gather)
 
         # Make Irecv/Isend
@@ -752,7 +752,7 @@ class Overlap2HaloExchangeBuilder(OverlapHaloExchangeBuilder):
 
         # The `scatter` must be guarded as we must not alter the halo values along
         # the domain boundary, where the sender is actually MPI.PROC_NULL
-        scatter = Call('scatter%s' % key, [cast(bufs)] + sizes + [f] + ofss)
+        scatter = Scatter('scatter%s' % key, [cast(bufs)] + sizes + [f] + ofss)
         scatter = Conditional(CondNe(fromrank, Macro('MPI_PROC_NULL')), scatter)
 
         rrecv = Byref(FieldFromComposite(msg._C_field_rrecv, msgi))
@@ -956,6 +956,14 @@ class Remainder(ElementalFunction):
 
 
 # Call sub-hierarchy
+
+class Gather(Call):
+    pass
+
+
+class Scatter(Call):
+    pass
+
 
 class IsendCall(Call):
 

--- a/devito/mpi/routines.py
+++ b/devito/mpi/routines.py
@@ -9,9 +9,10 @@ from sympy import Integer
 
 from devito.data import OWNED, HALO, NOPAD, LEFT, CENTER, RIGHT
 from devito.ir.equations import DummyEq
-from devito.ir.iet import (Call, Callable, Conditional, Expression, ExpressionBundle,
-                           AugmentedExpression, Iteration, List, Prodder, Return,
-                           make_efunc, FindNodes, Transformer)
+from devito.ir.iet import (Call, Callable, Conditional, ElementalFunction,
+                           Expression, ExpressionBundle, AugmentedExpression,
+                           Iteration, List, Prodder, Return, make_efunc, FindNodes,
+                           Transformer)
 from devito.mpi import MPI
 from devito.symbolics import (Byref, CondNe, FieldFromPointer, FieldFromComposite,
                               IndexedPointer, Macro, cast_mapper, subs_op_args)
@@ -646,7 +647,7 @@ class OverlapHaloExchangeBuilder(DiagHaloExchangeBuilder):
     def _make_remainder(self, hs, key, callcompute, *args):
         assert callcompute.is_Call
         body = [callcompute._rebuild(dynamic_args_mapper=i) for _, i in hs.omapper.owned]
-        return make_efunc('remainder%d' % key, body)
+        return Remainder.make('remainder%d' % key, body)
 
     def _call_remainder(self, remainder):
         efunc = remainder.make_call()
@@ -793,7 +794,7 @@ class Overlap2HaloExchangeBuilder(OverlapHaloExchangeBuilder):
         # The -1 below is because an Iteration, by default, generates <=
         iet = Iteration(iet, dim, region.nregions - 1)
 
-        return make_efunc('remainder%d' % key, iet)
+        return Remainder.make('remainder%d' % key, iet)
 
 
 class Diag2HaloExchangeBuilder(Overlap2HaloExchangeBuilder):
@@ -948,6 +949,10 @@ class HaloUpdate(MPICallable):
 
     def __init__(self, name, body, parameters):
         super(HaloUpdate, self).__init__(name, body, parameters)
+
+
+class Remainder(ElementalFunction):
+    pass
 
 
 # Call sub-hierarchy

--- a/devito/mpi/routines.py
+++ b/devito/mpi/routines.py
@@ -835,8 +835,8 @@ class DualHaloExchangeBuilder(Overlap2HaloExchangeBuilder):
     Generates:
 
         remainder()
-        compute_core()
         haloupdate()
+        compute_core()
         halowait()
     """
 
@@ -846,10 +846,11 @@ class DualHaloExchangeBuilder(Overlap2HaloExchangeBuilder):
         assert remainder is not None
         body.append(self._call_remainder(remainder))
 
+        body.append(HaloUpdateList(body=haloupdates))
+
         assert callcompute is not None
         body.append(callcompute)
 
-        body.append(HaloUpdateList(body=haloupdates))
         body.append(HaloWaitList(body=halowaits))
 
         return List(body=body)

--- a/devito/operator/operator.py
+++ b/devito/operator/operator.py
@@ -15,7 +15,7 @@ from devito.ir.iet import (Callable, CInterface, EntryFunction, FindSymbols, Met
                            derive_parameters, iet_build)
 from devito.ir.support import AccessMode, SymbolRegistry
 from devito.ir.stree import stree_build
-from devito.operator.profiling import create_profile
+from devito.operator.profiling import AdvancedProfilerVerbose, create_profile
 from devito.operator.registry import operator_selector
 from devito.mpi import MPI
 from devito.parameters import configuration
@@ -894,6 +894,16 @@ class Operator(Callable):
             indent = " "*2
         else:
             indent = ""
+
+            if isinstance(self._profiler, AdvancedProfilerVerbose):
+                metrics = []
+
+                v = summary.globals.get('fdlike-nosetup')
+                if v is not None:
+                    metrics.append("%.2f GPts/s" % fround(v.gpointss))
+
+                if metrics:
+                    perf("Global performance <w/o setup>: [%s]" % ', '.join(metrics))
 
         # Emit local, i.e. "per-rank" performance. Without MPI, this is the only
         # thing that will be emitted

--- a/devito/operator/operator.py
+++ b/devito/operator/operator.py
@@ -443,7 +443,7 @@ class Operator(Callable):
         iet = EntryFunction(name, uiet, 'int', parameters, ())
 
         # Lower IET to a target-specific IET
-        graph = Graph(iet)
+        graph = Graph(iet, sregistry=sregistry)
         graph = cls._specialize_iet(graph, **kwargs)
 
         # Instrument the IET for C-level profiling
@@ -515,7 +515,8 @@ class Operator(Callable):
         # when processing the `defaults` arguments. A topological sorting is used
         # as DerivedDimensions may depend on their parents
         nodes = self.dimensions
-        edges = [(i, i.parent) for i in self.dimensions if i.is_Derived]
+        edges = [(i, i.parent) for i in self.dimensions
+                 if i.is_Derived and i.parent in nodes]
         toposort = DAG(nodes, edges).topological_sort()
         futures = {}
         for d in reversed(toposort):

--- a/devito/operator/operator.py
+++ b/devito/operator/operator.py
@@ -516,7 +516,7 @@ class Operator(Callable):
         # as DerivedDimensions may depend on their parents
         nodes = self.dimensions
         edges = [(i, i.parent) for i in self.dimensions
-                 if i.is_Derived and i.parent in nodes]
+                 if i.is_Derived and i.parent in set(nodes)]
         toposort = DAG(nodes, edges).topological_sort()
         futures = {}
         for d in reversed(toposort):

--- a/devito/operator/profiling.py
+++ b/devito/operator/profiling.py
@@ -1,4 +1,4 @@
-from collections import OrderedDict, namedtuple
+from collections import OrderedDict, defaultdict, namedtuple
 from contextlib import contextmanager
 from functools import reduce
 from operator import mul
@@ -290,7 +290,10 @@ class AdvancedProfiler(Profiler):
 
             # Same as above but without setup overheads (e.g., host-device
             # data transfers)
-            reduce_over_nosetup = sum(i.time for i in summary.values())
+            mapper = defaultdict(list)
+            for (name, rank), v in summary.items():
+                mapper[name].append(v.time)
+            reduce_over_nosetup = sum(max(i) for i in mapper.values())
             if reduce_over_nosetup == 0:
                 reduce_over_nosetup = reduce_over
             summary.add_glb_vanilla('vanilla-nosetup', reduce_over_nosetup)

--- a/devito/operator/profiling.py
+++ b/devito/operator/profiling.py
@@ -317,14 +317,18 @@ class AdvancedProfiler(Profiler):
         return summary
 
 
-class AdvancedProfilerVerbose1(AdvancedProfiler):
+class AdvancedProfilerVerbose(AdvancedProfiler):
+    pass
+
+
+class AdvancedProfilerVerbose1(AdvancedProfilerVerbose):
 
     @property
     def trackable_subsections(self):
         return (MPIList, RemainderCall, BusyWait)
 
 
-class AdvancedProfilerVerbose2(AdvancedProfiler):
+class AdvancedProfilerVerbose2(AdvancedProfilerVerbose):
 
     @property
     def trackable_subsections(self):

--- a/devito/operator/profiling.py
+++ b/devito/operator/profiling.py
@@ -36,7 +36,7 @@ class Profiler(object):
     _default_libs = []
     _ext_calls = []
 
-    """Metadata for a profiled code section."""
+    _supports_async_sections = False
 
     def __init__(self, name):
         self.name = name
@@ -208,6 +208,8 @@ class ProfilerVerbose2(Profiler):
 
 
 class AdvancedProfiler(Profiler):
+
+    _supports_async_sections = True
 
     # Override basic summary so that arguments other than runtime are computed.
     def summary(self, args, dtype, reduce_over=None):
@@ -394,7 +396,7 @@ class PerformanceSummary(OrderedDict):
         performance data is local, that is "per-rank".
         """
         # Do not show unexecuted Sections (i.e., loop trip count was 0)
-        if ops == 0 or traffic == 0:
+        if traffic == 0:
             return
         # Do not show dynamic Sections (i.e., loop trip counts varies dynamically)
         if traffic is not None and np.isnan(traffic):
@@ -403,7 +405,7 @@ class PerformanceSummary(OrderedDict):
 
         k = PerfKey(name, rank)
 
-        if ops is None:
+        if not ops:
             self[k] = PerfEntry(time, 0.0, 0.0, 0.0, 0, [])
         else:
             gflops = float(ops)/10**9

--- a/devito/passes/__init__.py
+++ b/devito/passes/__init__.py
@@ -23,8 +23,14 @@ def is_on_device(obj, gpu_fit):
     except AttributeError:
         functions = as_tuple(obj)
 
-    fsave = [f for f in functions
-             if isinstance(f, TimeFunction) and is_integer(f.save)]
+    fsave = []
+    for i in functions:
+        try:
+            f = i.alias or i
+        except AttributeError:
+            f = i
+        if isinstance(f, TimeFunction) and is_integer(f.save):
+            fsave.append(f)
 
     if 'all-fallback' in gpu_fit and fsave:
         warning("TimeFunction %s assumed to fit the GPU memory" % fsave)

--- a/devito/passes/clusters/misc.py
+++ b/devito/passes/clusters/misc.py
@@ -303,19 +303,10 @@ class Fusion(Queue):
                     break
 
                 # Any anti- and iaw-dependences impose that `cg1` follows `cg0`
-                # while not being its immediate successor (unless it already is),
-                # to avoid they are fused together (thus breaking the dependence)
-                # TODO: the "not being its immediate successor" part *seems* to be
-                # a work around to the fact that any two Clusters characterized
-                # by anti-dependence should have been given a different stamp,
-                # and same for guarded Clusters, but that is not the case (yet)
+                # and forbid any sort of fusion
                 elif any(scope.d_anti_gen()) or\
                         any(i.is_iaw for i in scope.d_output_gen()):
                     dag.add_edge(cg0, cg1)
-                    index = cgroups.index(cg1) - 1
-                    if index > n and self._key(cg0) == self._key(cg1):
-                        dag.add_edge(cg0, cgroups[index])
-                        dag.add_edge(cgroups[index], cg1)
 
                 # Any flow-dependences along an inner Dimension (i.e., a Dimension
                 # that doesn't appear in `prefix`) impose that `cg1` follows `cg0`

--- a/devito/passes/clusters/misc.py
+++ b/devito/passes/clusters/misc.py
@@ -4,7 +4,6 @@ from itertools import groupby, product
 from devito.ir.clusters import Cluster, ClusterGroup, Queue, cluster_pass
 from devito.ir.support import (SEQUENTIAL, SEPARABLE, Scope, ReleaseLock,
                                WaitLock, WithLock, FetchUpdate, PrefetchUpdate)
-from devito.mpi.halo_scheme import HaloTouch
 from devito.symbolics import pow_to_mul
 from devito.tools import DAG, Stamp, as_tuple, flatten, frozendict, timed_pass
 from devito.types import Hyperplane

--- a/devito/passes/iet/engine.py
+++ b/devito/passes/iet/engine.py
@@ -323,14 +323,15 @@ def _(i, mapper, sregistry):
     if i._depth != 2:
         return
 
-    p = i.parent.parent
+    p = i.parent
+    pp = i.parent.parent
 
-    name0 = p.name
+    name0 = pp.name
     base = sregistry.make_name(prefix=name0)
     name1 = sregistry.make_name(prefix='%s_blk' % base)
 
-    bd = i.parent._rebuild(name1, p)
-    d = i._rebuild(name0, bd)
+    bd = i.parent._rebuild(name1, pp)
+    d = i._rebuild(name0, bd, i._min.subs(p, bd), i._max.subs(p, bd))
 
     mapper.update({
         i: d,

--- a/devito/passes/iet/engine.py
+++ b/devito/passes/iet/engine.py
@@ -350,7 +350,7 @@ def _(i, mapper, counter):
     except KeyError:
         return
 
-    v = i._rebuild(i.name, mapper[i.parent])
+    v = i._rebuild(i.name, p)
 
     mapper[i] = v
 

--- a/devito/passes/iet/engine.py
+++ b/devito/passes/iet/engine.py
@@ -438,10 +438,11 @@ def update_args(root, efuncs, dag):
     efuncs[root.name] = root._rebuild(parameters=parameters)
 
     # Update all call sites to use the new signature
-    for n in dag.downstream(root.name):
+    call_sites = dag.downstream(root.name)
+    for n in call_sites:
         mapper = {c: c._rebuild(arguments=_filter(c.arguments))
                   for c in FindNodes(Call).visit(efuncs[n])
-                  if c.name == root.name}
+                  if c.name in [root.name] + call_sites}
         efuncs[n] = Transformer(mapper).visit(efuncs[n])
 
     return efuncs

--- a/devito/passes/iet/engine.py
+++ b/devito/passes/iet/engine.py
@@ -5,10 +5,11 @@ from devito.ir.iet import (Call, FindNodes, FindSymbols, MetaCall, Transformer,
                            EntryFunction, ThreadCallable, Uxreplace,
                            derive_parameters)
 from devito.tools import DAG, as_tuple, filter_ordered, timed_pass
-from devito.types import (Array, BlockDimension, CompositeObject, Lock,
-                          IncrDimension, Indirection, Temp)
+from devito.types import (Array, CompositeObject, Lock, IncrDimension, Indirection,
+                          Temp)
 from devito.types.args import ArgProvider
 from devito.types.dense import DiscreteFunction
+from devito.types.dimension import AbstractIncrDimension, BlockDimension
 
 __all__ = ['Graph', 'iet_pass', 'iet_visit']
 
@@ -242,15 +243,15 @@ def abstract_objects(objects):
     # higher priority objects
     priority = {
         DiscreteFunction: 1,
-        BlockDimension: 2,
+        AbstractIncrDimension: 2,
+        BlockDimension: 3,
     }
 
     def key(i):
-        try:
-            return priority[i]
-        except (KeyError, TypeError):
-            # TypeError is for unhashable objects
-            return 0
+        for cls in sorted(priority, key=priority.get, reverse=True):
+            if isinstance(i, cls):
+                return priority[cls]
+        return 0
 
     objects = sorted(objects, key=key, reverse=True)
 

--- a/devito/passes/iet/engine.py
+++ b/devito/passes/iet/engine.py
@@ -280,7 +280,7 @@ def _(i, mapper, counter):
     base = 'f'
     name = '%s%d' % (base, counter[base])
 
-    v = i._rebuild(name=name, initializer=None, alias=True)
+    v = i._rebuild(name=name, initializer=None, alias=i)
 
     mapper.update({
         i: v,

--- a/devito/passes/iet/engine.py
+++ b/devito/passes/iet/engine.py
@@ -401,7 +401,6 @@ def update_args(root, efuncs, dag):
     # The parameters/arguments lists may have changed since a pass may have:
     # 1) introduced a new symbol
     new_args = derive_parameters(root)
-    new_args = [a for a in new_args if not a._mem_internal_eager]
 
     # 2) defined a symbol for which no definition was available yet (e.g.
     # via a malloc, or a Dereference)
@@ -438,11 +437,10 @@ def update_args(root, efuncs, dag):
     efuncs[root.name] = root._rebuild(parameters=parameters)
 
     # Update all call sites to use the new signature
-    call_sites = dag.downstream(root.name)
-    for n in call_sites:
+    for n in dag.downstream(root.name):
         mapper = {c: c._rebuild(arguments=_filter(c.arguments))
                   for c in FindNodes(Call).visit(efuncs[n])
-                  if c.name in [root.name] + call_sites}
+                  if c.name == root.name}
         efuncs[n] = Transformer(mapper).visit(efuncs[n])
 
     return efuncs

--- a/devito/passes/iet/langbase.py
+++ b/devito/passes/iet/langbase.py
@@ -329,15 +329,8 @@ class DeviceAwareMixin(object):
         """
         True if the IET computation is offloadable to device, False otherwise.
         """
-        for e in FindNodes(Expression).visit(iet):
-            try:
-                a = e.write.alias
-                if is_on_device(a or e.write, self.gpu_fit):
-                    break
-            except AttributeError:
-                # E.g., a Symbol
-                continue
-        else:
+        expressions = FindNodes(Expression).visit(iet)
+        if any(not is_on_device(e.write, self.gpu_fit) for e in expressions):
             return False
 
         functions = FindSymbols().visit(iet)

--- a/devito/passes/iet/langbase.py
+++ b/devito/passes/iet/langbase.py
@@ -329,8 +329,15 @@ class DeviceAwareMixin(object):
         """
         True if the IET computation is offloadable to device, False otherwise.
         """
-        expressions = FindNodes(Expression).visit(iet)
-        if any(not is_on_device(e.write, self.gpu_fit) for e in expressions):
+        for e in FindNodes(Expression).visit(iet):
+            try:
+                a = e.write.alias
+                if is_on_device(a or e.write, self.gpu_fit):
+                    break
+            except AttributeError:
+                # E.g., a Symbol
+                continue
+        else:
             return False
 
         functions = FindSymbols().visit(iet)

--- a/devito/passes/iet/languages/openmp.py
+++ b/devito/passes/iet/languages/openmp.py
@@ -110,7 +110,7 @@ class ThreadedProdder(Conditional, Prodder):
         # Prod within a while loop until all communications have completed
         # In other words, the thread delegated to prodding is entrapped for as long
         # as it's required
-        prod_until = Not(DefFunction(prodder.name, [i.name for i in prodder.arguments]))
+        prod_until = Not(DefFunction(prodder.name, prodder.arguments))
         then_body = List(header=c.Comment('Entrap thread until comms have completed'),
                          body=While(prod_until))
         Conditional.__init__(self, condition, then_body)

--- a/devito/passes/iet/languages/targets.py
+++ b/devito/passes/iet/languages/targets.py
@@ -4,6 +4,7 @@ from devito.passes.iet.languages.openmp import (SimdOmpizer, Ompizer, DeviceOmpi
                                                 OmpOrchestrator, DeviceOmpOrchestrator)
 from devito.passes.iet.languages.openacc import (DeviceAccizer, DeviceAccDataManager,
                                                  AccOrchestrator)
+from devito.passes.iet.instrument import instrument
 
 __all__ = ['CTarget', 'OmpTarget', 'DeviceOmpTarget', 'DeviceAccTarget']
 
@@ -12,6 +13,14 @@ class Target(object):
     Parizer = None
     DataManager = None
     Orchestrator = None
+
+    @classmethod
+    def lang(cls):
+        return cls.Parizer.lang
+
+    @classmethod
+    def instrument(cls, *args, **kwargs):
+        instrument(*args, lang=cls.lang(), **kwargs)
 
 
 class CTarget(Target):

--- a/devito/passes/iet/mpi.py
+++ b/devito/passes/iet/mpi.py
@@ -32,19 +32,10 @@ def _drop_halospots(iet):
     """
     Remove HaloSpots that:
 
-        * Embed SEQUENTIAL Iterations
         * Would be used to compute Increments (in which case, a halo exchange
           is actually unnecessary)
     """
     mapper = defaultdict(set)
-
-    # If a HaloSpot Dimension turns out to be SEQUENTIAL, then the HaloSpot is useless
-    for hs, iterations in MapNodes(HaloSpot, Iteration).visit(iet).items():
-        dmapper = as_mapper(iterations, lambda i: i.dim.root)
-        for d, v in dmapper.items():
-            if d in hs.dimensions and all(i.is_Sequential for i in v):
-                mapper[hs].update(set(hs.functions))
-                break
 
     # If all HaloSpot reads pertain to reductions, then the HaloSpot is useless
     for hs, expressions in MapNodes(HaloSpot, Expression).visit(iet).items():

--- a/devito/symbolics/extended_sympy.py
+++ b/devito/symbolics/extended_sympy.py
@@ -542,11 +542,6 @@ class DefFunction(Function, Pickable):
     def arguments(self):
         return self._arguments
 
-    @property
-    def free_symbols(self):
-        return set().union(*[i.free_symbols for i in self.arguments
-                             if isinstance(i, Expr)])
-
     def __str__(self):
         return "%s(%s)" % (self.name, ', '.join(str(i) for i in self.arguments))
 

--- a/devito/types/parallel.py
+++ b/devito/types/parallel.py
@@ -282,7 +282,7 @@ class QueueID(Symbol):
 class Barrier(object):
 
     """
-    Mixin class for symbolic objects representing thread barriers.
+    Mixin class for symbolic objects representing synchronization barriers.
     """
 
     pass

--- a/tests/test_dle.py
+++ b/tests/test_dle.py
@@ -405,6 +405,49 @@ def test_cache_blocking_hierarchical(blockshape0, blockshape1, exception):
 @pytest.mark.parametrize("blockinner", [False, True])
 def test_cache_blocking_imperfect_nest(blockinner):
     """
+    Test that a non-perfect Iteration nest is blocked correctly.
+    """
+    grid = Grid(shape=(4, 4, 4), dtype=np.float64)
+
+    u = TimeFunction(name='u', grid=grid, space_order=2)
+    v = TimeFunction(name='v', grid=grid, space_order=2)
+
+    eqns = [Eq(u.forward, v.laplace),
+            Eq(v.forward, u.forward.dz)]
+
+    op0 = Operator(eqns, opt='noop')
+    op1 = Operator(eqns, opt=('advanced', {'blockinner': blockinner}))
+
+    # First, check the generated code
+    bns, _ = assert_blocking(op1, {'x0_blk0'})
+    trees = retrieve_iteration_tree(bns['x0_blk0'])
+    assert len(trees) == 2
+    assert len(trees[0]) == len(trees[1])
+    assert all(i is j for i, j in zip(trees[0][:4], trees[1][:4]))
+    assert trees[0][4] is not trees[1][4]
+    assert trees[0].root.dim.is_Block
+    assert trees[1].root.dim.is_Block
+    assert op1.parameters[7] is trees[0][0].step
+    assert op1.parameters[10] is trees[0][1].step
+
+    u.data[:] = 0.2
+    v.data[:] = 1.5
+    op0(time_M=0)
+
+    u1 = TimeFunction(name='u1', grid=grid, space_order=2)
+    v1 = TimeFunction(name='v1', grid=grid, space_order=2)
+
+    u1.data[:] = 0.2
+    v1.data[:] = 1.5
+    op1(u=u1, v=v1, time_M=0)
+
+    assert np.all(u.data == u1.data)
+    assert np.all(v.data == v1.data)
+
+
+@pytest.mark.parametrize("blockinner", [False, True])
+def test_cache_blocking_imperfect_nest_v2(blockinner):
+    """
     Test that a non-perfect Iteration nest is blocked correctly. This
     is slightly different than ``test_cache_blocking_imperfect_nest``
     as here only one Iteration gets blocked.

--- a/tests/test_iet.py
+++ b/tests/test_iet.py
@@ -208,11 +208,11 @@ def test_make_cpp_parfor():
         waitcall
     ]
 
-    parfor = ElementalFunction('parallel_for', body, 'void',
-                               [first, last, func, nthreads])
+    parfor = ElementalFunction('parallel_for', body,
+                               parameters=[first, last, func, nthreads])
 
     assert str(parfor) == """\
-static inline \
+static \
 void parallel_for(const int first, const int last, FuncType&& func, const int nthreads)
 {
   const int threshold = 1;
@@ -255,12 +255,12 @@ def test_make_cuda_stream():
     stream = CudaStream('stream')
 
     iet = Call('foo', stream)
-    iet = ElementalFunction('foo', iet, 'void')
+    iet = ElementalFunction('foo', iet, parameters=())
     dm = CDataManager(sregistry=None)
     iet = CDataManager.place_definitions.__wrapped__(dm, iet)[0]
 
     assert str(iet) == """\
-static inline void foo()
+static void foo()
 {
   cudaStream_t stream;
   cudaStreamCreate(&(stream));

--- a/tests/test_ir.py
+++ b/tests/test_ir.py
@@ -718,8 +718,12 @@ class TestDependenceAnalysis(object):
         exprs = [LoweredEq(i) for i in exprs]
 
         scope = Scope(exprs)
-        assert len(scope.d_all) == len(scope.d_flow) == 1
+        assert len(scope.d_all) == 2
+        assert len(scope.d_flow) == 1
         v = scope.d_flow.pop()
+        assert v.function is f
+        assert len(scope.d_anti) == 1
+        v = scope.d_anti.pop()
         assert v.function is f
 
     def test_indexedbase_across_jump(self):

--- a/tests/test_ir.py
+++ b/tests/test_ir.py
@@ -9,7 +9,7 @@ from devito.ir.equations import LoweredEq
 from devito.ir.equations.algorithms import dimension_sort
 from devito.ir.iet import Iteration, FindNodes
 from devito.ir.support.basic import (IterationInstance, TimedAccess, Scope,
-                                     Vector, AFFINE, REGULAR, IRREGULAR)
+                                     Vector, AFFINE, REGULAR, IRREGULAR, mocksym)
 from devito.ir.support.space import (NullInterval, Interval, Forward, Backward,
                                      IterationSpace)
 from devito.ir.support.guards import GuardOverflow
@@ -742,10 +742,11 @@ class TestDependenceAnalysis(object):
         exprs = [LoweredEq(i) for i in exprs]
 
         scope = Scope(exprs)
-        assert len(scope.d_all) == len(scope.d_flow) == 1
+        assert len(scope.d_all) == 3
+        assert len(scope.d_flow) == 3
         assert len(scope.d_anti) == 0
-        v = scope.d_flow.pop()
-        assert v.function is f
+        assert any(v.function is f for v in scope.d_flow)
+        assert any(v.function is mocksym for v in scope.d_flow)
 
     def test_indirect_access(self):
         grid = Grid(shape=(4, 4))

--- a/tests/test_mpi.py
+++ b/tests/test_mpi.py
@@ -2,7 +2,7 @@ import numpy as np
 import pytest
 from cached_property import cached_property
 
-from conftest import skipif, _R, assert_blocking
+from conftest import skipif, _R, assert_blocking, assert_structure
 from devito import (Grid, Constant, Function, TimeFunction, SparseFunction,
                     SparseTimeFunction, Dimension, ConditionalDimension, SubDimension,
                     SubDomain, Eq, Ne, Inc, NODE, Operator, norm, inner, configuration,
@@ -2243,6 +2243,37 @@ class TestOperatorAdvanced(object):
         op.apply(time_M=0, u=u3)
         assert np.all(u3.data[0, 3:-3, 3:-3] == 1.)
 
+    @pytest.mark.parallel(mode=4)
+    def test_fission_due_to_antidep(self):
+        grid = Grid(shape=(16, 16, 64), dtype=np.float64)
+
+        u = TimeFunction(name='u', grid=grid, space_order=4)
+        u1 = TimeFunction(name='u1', grid=grid, space_order=4)
+        v = TimeFunction(name='v', grid=grid, space_order=4)
+        v1 = TimeFunction(name='v1', grid=grid, space_order=4)
+
+        eqns = [Eq(u.forward, v.laplace),
+                Eq(v.forward, u.forward.dz2)]
+
+        op0 = Operator(eqns, opt=('noop', {'openmp': True}))
+        op1 = Operator(eqns, opt=('advanced', {'openmp': True}))
+
+        # First, check the generated code
+        assert_structure(op1, ['t',
+                               't,x0_blk0,y0_blk0,x,y,z',
+                               't,x0_blk0,y0_blk0,x,y,z'],
+                         't,x0_blk0,y0_blk0,x,y,z,z')
+
+        def init(f, v=1):
+            f.data[:] = np.indices(grid.shape).sum(axis=0) % (.004*v) + .01
+
+        init(u1)
+        init(v1, 2)
+        op1(u=u1, v=v1, time_M=5, h_z=20.)
+
+        assert np.isclose(norm(u1), 12445251.87, rtol=1e-7)
+        assert np.isclose(norm(v1), 147063.38, rtol=1e-7)
+
 
 def gen_serial_norms(shape, so):
     """
@@ -2358,15 +2389,10 @@ class TestIsotropicAcoustic(object):
 
 
 if __name__ == "__main__":
-    configuration['mpi'] = 'dual'
+    configuration['mpi'] = 'basic'
     # TestDecomposition().test_reshape_left_right()
-    TestOperatorSimple().test_trivial_eq_2d()
-    # TestOperatorSimple().test_num_comms('f[t,x-1,y] + f[t,x+1,y]', {'rc', 'lc'})
+    # TestOperatorSimple().test_trivial_eq_2d()
     # TestFunction().test_halo_exchange_bilateral()
-    # TestSparseFunction().test_ownership(((1., 1.), (1., 3.), (3., 1.), (3., 3.)))
-    # TestSparseFunction().test_local_indices([(0.5, 0.5), (1.5, 2.5), (1.5, 1.5), (2.5, 1.5)], [[0.], [1.], [2.], [3.]])  # noqa
     # TestSparseFunction().test_scatter_gather()
-    # TestOperatorAdvanced().test_nontrivial_operator()
-    # TestOperatorAdvanced().test_interpolation_dup()
-    # TestOperatorAdvanced().test_injection_wodup()
+    TestOperatorAdvanced().test_fission_due_to_antidep()
     # TestIsotropicAcoustic().test_adjoint_F_no_omp()

--- a/tests/test_mpi.py
+++ b/tests/test_mpi.py
@@ -573,7 +573,8 @@ class TestOperatorSimple(object):
             assert np.all(f.data_ro_domain[-1, :-time_M] == 31.)
 
     @pytest.mark.parallel(mode=[(4, 'basic'), (4, 'diag'), (4, 'overlap'),
-                                (4, 'overlap2'), (4, 'diag2'), (4, 'full')])
+                                (4, 'overlap2'), (4, 'diag2'), (4, 'full'),
+                                (4, 'dual')])
     def test_trivial_eq_2d(self):
         grid = Grid(shape=(8, 8,))
         x, y = grid.dimensions
@@ -2357,9 +2358,9 @@ class TestIsotropicAcoustic(object):
 
 
 if __name__ == "__main__":
-    configuration['mpi'] = True
+    configuration['mpi'] = 'dual'
     # TestDecomposition().test_reshape_left_right()
-    # TestOperatorSimple().test_trivial_eq_2d()
+    TestOperatorSimple().test_trivial_eq_2d()
     # TestOperatorSimple().test_num_comms('f[t,x-1,y] + f[t,x+1,y]', {'rc', 'lc'})
     # TestFunction().test_halo_exchange_bilateral()
     # TestSparseFunction().test_ownership(((1., 1.), (1., 3.), (3., 1.), (3., 3.)))
@@ -2368,4 +2369,4 @@ if __name__ == "__main__":
     # TestOperatorAdvanced().test_nontrivial_operator()
     # TestOperatorAdvanced().test_interpolation_dup()
     # TestOperatorAdvanced().test_injection_wodup()
-    TestIsotropicAcoustic().test_adjoint_F_no_omp()
+    # TestIsotropicAcoustic().test_adjoint_F_no_omp()

--- a/tests/test_mpi.py
+++ b/tests/test_mpi.py
@@ -2255,7 +2255,6 @@ class TestOperatorAdvanced(object):
         eqns = [Eq(u.forward, v.laplace),
                 Eq(v.forward, u.forward.dz2)]
 
-        op0 = Operator(eqns, opt=('noop', {'openmp': True}))
         op1 = Operator(eqns, opt=('advanced', {'openmp': True}))
 
         # First, check the generated code

--- a/tests/test_mpi.py
+++ b/tests/test_mpi.py
@@ -573,8 +573,7 @@ class TestOperatorSimple(object):
             assert np.all(f.data_ro_domain[-1, :-time_M] == 31.)
 
     @pytest.mark.parallel(mode=[(4, 'basic'), (4, 'diag'), (4, 'overlap'),
-                                (4, 'overlap2'), (4, 'diag2'), (4, 'full'),
-                                (4, 'dual')])
+                                (4, 'overlap2'), (4, 'diag2'), (4, 'full')])
     def test_trivial_eq_2d(self):
         grid = Grid(shape=(8, 8,))
         x, y = grid.dimensions


### PR DESCRIPTION
This PR performs a massive re-engineering of how halo exchanges are detected, constructed, and lowered inside Devito

Why: in master, halo exchanges are detected in the `stree` layer, that is, after *all* clusters-level passes have been performed. The issue is that some of these passes "clutter" the equations/clusters (after all, we're lowering) by e.g. introducing temporaries and changing the index access functions. This has the effect of enormously complicating data dependence analysis. A complexity exploded when I added CUDA/HIP shared memory.

What: change of paradigm. Now detecting halo exchanges is one of the first things the compiler does, and it does that at the `clusters` level. A halo exchange is here represented simply as yet another Cluster. It could not have been metadata attached to Cluster because Clusters evolve during lowering, which would take us back to the problem we're trying to solve here. A "floating" Cluster is the way to go, in my opinion. I failed to see this mechanism for several years, until something flipped in my mind when I was at Rice. 

How: significant code changes, but in the end, many are simplifications

This PR is not finished yet, there are a couple of small TODOs to deal with, but I'd like people to start reviewing because we'll have to merge it soon (there has been a demand for CUDA/HIP + MPI numbers for weeks...)