### PR TITLE
compiler: Change tile use in DeviceAcczier to allow multiple tile sizes

### DIFF
--- a/devito/passes/iet/languages/openacc.py
+++ b/devito/passes/iet/languages/openacc.py
@@ -180,13 +180,8 @@ class DeviceAccizer(PragmaDeviceAwareTransformer):
         if self._is_offloadable(root) and \
            all(i.is_Affine for i in [root] + collapsable) and \
            self.par_tile:
-            # TODO: still unable to exploit multiple par-tiles (one per nest)
-            # This will require unconditionally applying blocking, and then infer
-            # the tile clause shape from the BlockDimensions' step
-            par_tile_length = len(self.par_tile)
-            idx = index if index < par_tile_length else par_tile_length - 1
+            idx = min(index, len(self.par_tile) - 1)
             tile = self.par_tile[idx]
-
             assert isinstance(tile, tuple)
             nremainder = (ncollapsable + 1) - len(tile)
             if nremainder >= 0:

--- a/devito/passes/iet/languages/openacc.py
+++ b/devito/passes/iet/languages/openacc.py
@@ -171,7 +171,7 @@ class DeviceAccizer(PragmaDeviceAwareTransformer):
 
     lang = AccBB
 
-    def _make_partree(self, candidates, nthreads=None):
+    def _make_partree(self, candidates, nthreads=None, index=0):
         assert candidates
 
         root, collapsable = self._select_candidates(candidates)
@@ -183,7 +183,10 @@ class DeviceAccizer(PragmaDeviceAwareTransformer):
             # TODO: still unable to exploit multiple par-tiles (one per nest)
             # This will require unconditionally applying blocking, and then infer
             # the tile clause shape from the BlockDimensions' step
-            tile = self.par_tile[0]
+            par_tile_length = len(self.par_tile)
+            idx = index if index < par_tile_length else par_tile_length - 1
+            tile = self.par_tile[idx]
+
             assert isinstance(tile, tuple)
             nremainder = (ncollapsable + 1) - len(tile)
             if nremainder >= 0:

--- a/devito/passes/iet/parpragma.py
+++ b/devito/passes/iet/parpragma.py
@@ -395,7 +395,7 @@ class PragmaShmTransformer(PragmaSimdTransformer):
                 continue
 
             # Outer parallelism
-            root, partree = self._make_partree(candidates, None, i)
+            root, partree = self._make_partree(candidates, index=i)
             if partree is None or root in mapper:
                 continue
 

--- a/devito/passes/iet/parpragma.py
+++ b/devito/passes/iet/parpragma.py
@@ -388,7 +388,7 @@ class PragmaShmTransformer(PragmaSimdTransformer):
     def _make_parallel(self, iet):
         mapper = {}
         parrays = {}
-        for i, tree in enumerate(retrieve_iteration_tree(iet, mode='superset')) :
+        for i, tree in enumerate(retrieve_iteration_tree(iet, mode='superset')):
             # Get the parallelizable Iterations in `tree`
             candidates = filter_iterations(tree, key=self.key)
             if not candidates:

--- a/devito/passes/iet/parpragma.py
+++ b/devito/passes/iet/parpragma.py
@@ -388,14 +388,14 @@ class PragmaShmTransformer(PragmaSimdTransformer):
     def _make_parallel(self, iet):
         mapper = {}
         parrays = {}
-        for tree in retrieve_iteration_tree(iet, mode='superset'):
+        for i, tree in enumerate(retrieve_iteration_tree(iet, mode='superset')) :
             # Get the parallelizable Iterations in `tree`
             candidates = filter_iterations(tree, key=self.key)
             if not candidates:
                 continue
 
             # Outer parallelism
-            root, partree = self._make_partree(candidates)
+            root, partree = self._make_partree(candidates, None, i)
             if partree is None or root in mapper:
                 continue
 

--- a/devito/passes/iet/parpragma.py
+++ b/devito/passes/iet/parpragma.py
@@ -270,7 +270,7 @@ class PragmaShmTransformer(PragmaSimdTransformer):
         partree = Transformer(mapper).visit(partree)
         return partree
 
-    def _make_partree(self, candidates, nthreads=None):
+    def _make_partree(self, candidates, nthreads=None, index=None):
         assert candidates
 
         # Get the collapsable Iterations
@@ -492,7 +492,7 @@ class PragmaDeviceAwareTransformer(DeviceAwareMixin, PragmaShmTransformer):
         else:
             return super()._make_threaded_prodders(partree)
 
-    def _make_partree(self, candidates, nthreads=None):
+    def _make_partree(self, candidates, nthreads=None, index=None):
         """
         Parallelize the `candidates` Iterations. In particular:
 

--- a/tests/test_dle.py
+++ b/tests/test_dle.py
@@ -318,6 +318,60 @@ class TestBlockingParTile(object):
             assert iters[0].step == par_tile[1]
             assert iters[1].step == par_tile[0]
 
+    
+    @pytest.mark.parametrize('par_tile,expected', [
+        ((32, 4, 4), ((4, 4, 32), (4, 4, 32))),
+        (((16, 4, 4), (16, 16, 16)), ((4, 4, 16), (16, 16, 16))),
+        (((32, 4, 4), 1), ((4, 4, 32), (4, 4, 32))),
+        (((32, 4, 4), 1, 'tag0'), ((4, 4, 32), (4, 4, 32))),
+        ((((32, 4, 8), 1, 'tag0'), ((32, 8, 4), 2)), ((8, 4, 32), (4, 8, 32))),
+    ])
+    def test_openacc_structure(self, par_tile, expected):
+        grid = Grid(shape=(8, 8, 8))
+
+        u = TimeFunction(name="u", grid=grid, space_order=4)
+        v = TimeFunction(name="v", grid=grid, space_order=4)
+
+        eqns = [Eq(u.forward, u.dx),
+                Eq(v.forward, u.forward.dx)]
+
+        op = Operator(eqns, platform='nvidiaX', language='openacc', opt=('advanced', {'par-tile': par_tile,
+                                              'blocklevels': 1, 'blockinner': True}))
+
+        bns, _ = assert_blocking(op, {'x0_blk0', 'x1_blk0'})
+        assert len(bns) == len(expected)
+        for root, v in zip(bns.values(), expected):
+            iters = FindNodes(Iteration).visit(root)
+            iters = [i for i in iters if i.dim.is_Block and i.dim._depth == 1]
+            assert len(iters) == len(v)
+            assert all(i.step == j for i, j in zip(iters, v))
+
+
+    def test_openacc_multi_tile_structure(self):
+        grid = Grid(shape=(8, 8, 8))
+
+        u = TimeFunction(name="u", grid=grid, space_order=4)
+        v = TimeFunction(name="v", grid=grid, space_order=4)
+
+        eqns = [Eq(u.forward, u.dx),
+                Eq(v.forward, u.forward.dx)]
+        
+        par_tile=((32, 4, 4), (16, 4, 4))
+        expected=((4, 4, 32), (4, 4, 16))
+
+        op = Operator(eqns, platform='nvidiaX', language='openacc', opt=('advanced', {'par-tile': par_tile,
+                                              'blocklevels': 1, 'blockinner': True}))
+
+        bns, _ = assert_blocking(op, {'x0_blk0', 'x1_blk0'})
+        assert len(bns) == len(expected)
+        assert bns['x0_blk0'].pragmas[0].value == 'acc parallel loop tile(32,4,4) present(u)'
+        assert bns['x1_blk0'].pragmas[0].value == 'acc parallel loop tile(16,4,4) present(u,v)'
+        for root, v in zip(bns.values(), expected):
+            iters = FindNodes(Iteration).visit(root)
+            iters = [i for i in iters if i.dim.is_Block and i.dim._depth == 1]
+            assert len(iters) == len(v)
+            assert all(i.step == j for i, j in zip(iters, v))
+
 
 @pytest.mark.parametrize("shape", [(10,), (10, 45), (20, 33), (10, 31, 45), (45, 31, 45)])
 @pytest.mark.parametrize("time_order", [2])

--- a/tests/test_gpu_openacc.py
+++ b/tests/test_gpu_openacc.py
@@ -3,10 +3,10 @@ import numpy as np
 
 from devito import (Grid, Function, TimeFunction, SparseTimeFunction, Eq, Operator,
                     norm, solve)
-from conftest import skipif, opts_device_tiling
+from conftest import skipif, assert_blocking, opts_device_tiling
 from devito.data import LEFT
 from devito.exceptions import InvalidOperator
-from devito.ir.iet import retrieve_iteration_tree
+from devito.ir.iet import retrieve_iteration_tree, FindNodes, Iteration
 from examples.seismic import TimeAxis, RickerSource, Receiver
 
 pytestmark = skipif(['nodevice'], whole_module=True)
@@ -111,7 +111,7 @@ class TestCodeGeneration(object):
         # Only the AFFINE Iterations are tiled
         assert trees[3][1].pragmas[0].value ==\
             'acc parallel loop collapse(1) present(src,src_coords,u)'
-        
+           
     @pytest.mark.parametrize('par_tile', [((32, 4, 4), (8, 8)), ((32, 4), (8, 8)), ((32, 4, 4), (8, 8, 8))])
     def test_multiple_tile_sizes(self, par_tile):
         grid = Grid(shape=(3, 3, 3))
@@ -135,6 +135,31 @@ class TestCodeGeneration(object):
             'acc parallel loop tile(32,4,4) present(u)'
         assert trees[1][1].pragmas[0].value ==\
             'acc parallel loop tile(8,8) present(u)'
+
+    def test_multi_tile_blocking_structure(self):
+        grid = Grid(shape=(8, 8, 8))
+
+        u = TimeFunction(name="u", grid=grid, space_order=4)
+        v = TimeFunction(name="v", grid=grid, space_order=4)
+
+        eqns = [Eq(u.forward, u.dx),
+                Eq(v.forward, u.forward.dx)]
+        
+        par_tile=((32, 4, 4), (16, 4, 4))
+        expected=((4, 4, 32), (4, 4, 16))
+
+        op = Operator(eqns, platform='nvidiaX', language='openacc', opt=('advanced', {'par-tile': par_tile,
+                                              'blocklevels': 1, 'blockinner': True}))
+
+        bns, _ = assert_blocking(op, {'x0_blk0', 'x1_blk0'})
+        assert len(bns) == len(expected)
+        assert bns['x0_blk0'].pragmas[0].value == 'acc parallel loop tile(32,4,4) present(u)'
+        assert bns['x1_blk0'].pragmas[0].value == 'acc parallel loop tile(16,4,4) present(u,v)'
+        for root, v in zip(bns.values(), expected):
+            iters = FindNodes(Iteration).visit(root)
+            iters = [i for i in iters if i.dim.is_Block and i.dim._depth == 1]
+            assert len(iters) == len(v)
+            assert all(i.step == j for i, j in zip(iters, v))
 
 
 class TestOperator(object):

--- a/tests/test_gpu_openacc.py
+++ b/tests/test_gpu_openacc.py
@@ -111,6 +111,30 @@ class TestCodeGeneration(object):
         # Only the AFFINE Iterations are tiled
         assert trees[3][1].pragmas[0].value ==\
             'acc parallel loop collapse(1) present(src,src_coords,u)'
+        
+    @pytest.mark.parametrize('par_tile', [((32, 4, 4), (8, 8)), ((32, 4), (8, 8)), ((32, 4, 4), (8, 8, 8))])
+    def test_multiple_tile_sizes(self, par_tile):
+        grid = Grid(shape=(3, 3, 3))
+        t = grid.stepping_dim
+        x, y, z = grid.dimensions
+
+        u = TimeFunction(name='u', grid=grid)
+        src = SparseTimeFunction(name="src", grid=grid, nt=3, npoint=1)
+
+        eqns = [Eq(u.forward, u + 1,),
+                Eq(u[t+1, 0, y, z], u[t, 0, y, z] + 1.)]
+        eqns += src.inject(field=u.forward, expr=src)
+
+        op = Operator(eqns, platform='nvidiaX', language='openacc',
+                      opt=('advanced', {'par-tile': par_tile}))
+
+        trees = retrieve_iteration_tree(op)
+        assert len(trees) == 4
+
+        assert trees[0][1].pragmas[0].value ==\
+            'acc parallel loop tile(32,4,4) present(u)'
+        assert trees[1][1].pragmas[0].value ==\
+            'acc parallel loop tile(8,8) present(u)'
 
 
 class TestOperator(object):


### PR DESCRIPTION
A proposal to allow the use of multiple tile sizes in the same operator, through the _part-tile_ flag.
Passing multiple tuples to the _part-tile_ flag is already supported, but only the first tuple is applied in the __make_partree_ method of _DeviceAcczier_ class.

The changes consist of supplying the nesting index in the _make_parallel_ method of _PragmaShmTransformer_ to the __make_partree_ method and using the tile size with the respective index.

Cases with different tile and nesting sizes are handled. Given `n` tile sizes for an operator with `m` nests:

If `n = m`: The i-th tile size is assigned to the i-th nesting.
If `n > m`: The first `m` tile sizes are assigned to the `m` nests (i-th tile size -> i-th nesting), and the remaining `n-m` is not used.
If `n < m`: The `n` tile sizes are assigned to the first `n` nestings, and the remaining `m-n` nestings replicate the last tile size.