### PR TITLE
compiler: Prevent topofusion of homogeneous sync Clusters

### DIFF
--- a/devito/passes/clusters/misc.py
+++ b/devito/passes/clusters/misc.py
@@ -93,6 +93,7 @@ class Fusion(Queue):
     """
 
     _q_guards_in_key = True
+    _q_syncs_in_key = True
 
     def __init__(self, toposort, options=None):
         options = options or {}


### PR DESCRIPTION
This affects only PRO.

While CI runs, I'll think about whether there's a way of testing this in OSS as well (in PRO it's tested, it's trivial)