### PR TITLE
mpi: Enhance flexibility for custom topologies

### DIFF
--- a/devito/mpi/distributed.py
+++ b/devito/mpi/distributed.py
@@ -588,18 +588,15 @@ class CustomTopology(tuple):
                        dimension
 
     Example:
-    Assuming N=8 and requested topology is `('*', '*', 1)`,
-    since there is no integer K, so that K*K=8, we resort to the closest to
+    Assuming N=6 and requested topology is `('*', '*', 1)`,
+    since there is no integer K, so that K*K=6, we resort to the closest to
     the nstars root (square, cubic) that satisfies that the decomposed domains
     are correctly distributed to the number of processes.
 
-    For N=8
+    For N=6
     * ('*', '*', 1) gives: (3, 2, 1)
     * ('*', 1, '*') gives: (3, 1, 2)
     * (1, '*', '*') gives: (1, 3, 2)
-    * ('*','*','*') gives: (2, 3, 1), cubic root of 8 is an integer and thus we
-    start with equal priority.
-    TOFIX: better is (3, 2, 1)
 
     Raises
     ------

--- a/examples/seismic/test_seismic_utils.py
+++ b/examples/seismic/test_seismic_utils.py
@@ -12,7 +12,6 @@ def not_bcs(bc):
 @pytest.mark.parametrize('nbl, bcs', [
     (20, ("mask", 1)), (0, ("mask", 1)),
     (20, ("damp", 0)), (0, ("damp", 0))
-
 ])
 def test_damp(nbl, bcs):
     shape = (21, 21)

--- a/tests/test_mpi.py
+++ b/tests/test_mpi.py
@@ -180,6 +180,23 @@ class TestDistributor(object):
         assert f2.shape == expected[distributor.myrank]
         assert f2.size_global == f.size_global
 
+    @pytest.mark.parametrize('topology, dist_topology, expected', [
+        (('*', 1, 1), (4, 1, 1), [(4, 15, 15), (4, 15, 15), (4, 15, 15), (3, 15, 15)]),
+        ((1, '*', 1), (1, 4, 1), [(15, 4, 15), (15, 4, 15), (15, 4, 15), (15, 3, 15)]),
+        ((1, 1, '*'), (1, 1, 4), [(15, 15, 4), (15, 15, 4), (15, 15, 4), (15, 15, 3)]),
+        (('*', 1, '*'), (2, 1, 2), [(8, 15, 8), (8, 15, 7), (7, 15, 8), (7, 15, 7)]),
+    ])
+    @pytest.mark.parallel(mode=[4])
+    def test_custom_topology_3d(self, topology, dist_topology, expected):
+        shape = (15, 15, 15)
+
+        # Decompose using a `topology` with stars
+        grid = Grid(shape=shape, topology=topology)
+        f = Function(name='f', grid=grid)
+        distributor = grid.distributor
+        assert distributor.topology == dist_topology
+        assert f.shape == expected[distributor.myrank]
+
 
 class TestFunction(object):
 

--- a/tests/test_mpi.py
+++ b/tests/test_mpi.py
@@ -197,6 +197,27 @@ class TestDistributor(object):
         assert distributor.topology == dist_topology
         assert f.shape == expected[distributor.myrank]
 
+    @pytest.mark.parametrize('topology, dist_topology, expected', [
+        (('*', 1, '*'), (3, 1, 2),
+         [(5, 15, 8), (5, 15, 7), (5, 15, 8), (5, 15, 7), (5, 15, 8), (5, 15, 7)]),
+        (('*', '*', 1), (3, 2, 1),
+         [(5, 8, 15), (5, 7, 15), (5, 8, 15), (5, 7, 15), (5, 8, 15), (5, 7, 15)]),
+        ((1, '*', '*'), (1, 3, 2),
+         [(15, 5, 8), (15, 5, 7), (15, 5, 8), (15, 5, 7), (15, 5, 8), (15, 5, 7)]),
+        (('*', '*', '*'), (2, 3, 1),
+         [(8, 5, 15), (8, 5, 15), (8, 5, 15), (7, 5, 15), (7, 5, 15), (7, 5, 15)])
+    ])
+    @pytest.mark.parallel(mode=[6])
+    def test_custom_topology_3d_v2(self, topology, dist_topology, expected):
+        shape = (15, 15, 15)
+
+        # Decompose using a `topology` with stars
+        grid = Grid(shape=shape, topology=topology)
+        f = Function(name='f', grid=grid)
+        distributor = grid.distributor
+        assert distributor.topology == dist_topology
+        assert f.shape == expected[distributor.myrank]
+
 
 class TestFunction(object):
 

--- a/tests/test_mpi.py
+++ b/tests/test_mpi.py
@@ -12,9 +12,18 @@ from devito.ir.iet import (Call, Conditional, Iteration, FindNodes, FindSymbols,
                            retrieve_iteration_tree)
 from devito.mpi import MPI
 from devito.mpi.routines import HaloUpdateCall, MPICall
+from devito.mpi.distributed import CustomTopology, Distributor
 from examples.seismic.acoustic import acoustic_setup
 
 pytestmark = skipif(['nompi'], whole_module=True)
+
+class Dummy_input_comm():
+    """
+    Helper class to assist with modelling a communicator with
+    a specific size
+    """
+    def __init__(self, size):
+        self.size = size
 
 
 class TestDistributor(object):
@@ -217,6 +226,20 @@ class TestDistributor(object):
         distributor = grid.distributor
         assert distributor.topology == dist_topology
         assert f.shape == expected[distributor.myrank]
+
+    @pytest.mark.parametrize('comm_size, topology, dist_topology', [
+        (6, ('*', 1, '*'), (3, 1, 2)),
+        (6, ('*', '*', 1), (3, 2, 1)),
+        (6, (1, '*', '*'), (1, 3, 2)),
+        (6, ('*', '*', '*'), (2, 3, 1)),
+        (8, ('*', 1, '*'), (4, 1, 2)),
+        (8, ('*', '*', 1), (4, 2, 1)),
+        (8, (1, '*', '*'), (1, 4, 2)),
+    ])
+    def test_custom_topology_3d_dummy(self, comm_size, topology, dist_topology):
+        dummy_comm = Dummy_input_comm(comm_size)
+        custom_topology = CustomTopology(topology, dummy_comm)
+        assert custom_topology == dist_topology
 
 
 class TestFunction(object):

--- a/tests/test_mpi.py
+++ b/tests/test_mpi.py
@@ -12,16 +12,14 @@ from devito.ir.iet import (Call, Conditional, Iteration, FindNodes, FindSymbols,
                            retrieve_iteration_tree)
 from devito.mpi import MPI
 from devito.mpi.routines import HaloUpdateCall, MPICall
-from devito.mpi.distributed import CustomTopology, Distributor
+from devito.mpi.distributed import CustomTopology
 from examples.seismic.acoustic import acoustic_setup
 
 pytestmark = skipif(['nompi'], whole_module=True)
 
-class Dummy_input_comm():
-    """
-    Helper class to assist with modelling a communicator with
-    a specific size
-    """
+
+class DummyInputComm():
+    "Helper class for modelling a communicator with a specific size"
     def __init__(self, size):
         self.size = size
 
@@ -189,55 +187,35 @@ class TestDistributor(object):
         assert f2.shape == expected[distributor.myrank]
         assert f2.size_global == f.size_global
 
-    @pytest.mark.parametrize('topology, dist_topology, expected', [
-        (('*', 1, 1), (4, 1, 1), [(4, 15, 15), (4, 15, 15), (4, 15, 15), (3, 15, 15)]),
-        ((1, '*', 1), (1, 4, 1), [(15, 4, 15), (15, 4, 15), (15, 4, 15), (15, 3, 15)]),
-        ((1, 1, '*'), (1, 1, 4), [(15, 15, 4), (15, 15, 4), (15, 15, 4), (15, 15, 3)]),
-        (('*', 1, '*'), (2, 1, 2), [(8, 15, 8), (8, 15, 7), (7, 15, 8), (7, 15, 7)]),
-    ])
-    @pytest.mark.parallel(mode=[4])
-    def test_custom_topology_3d(self, topology, dist_topology, expected):
-        shape = (15, 15, 15)
-
-        # Decompose using a `topology` with stars
-        grid = Grid(shape=shape, topology=topology)
-        f = Function(name='f', grid=grid)
-        distributor = grid.distributor
-        assert distributor.topology == dist_topology
-        assert f.shape == expected[distributor.myrank]
-
-    @pytest.mark.parametrize('topology, dist_topology, expected', [
-        (('*', 1, '*'), (3, 1, 2),
-         [(5, 15, 8), (5, 15, 7), (5, 15, 8), (5, 15, 7), (5, 15, 8), (5, 15, 7)]),
-        (('*', '*', 1), (3, 2, 1),
-         [(5, 8, 15), (5, 7, 15), (5, 8, 15), (5, 7, 15), (5, 8, 15), (5, 7, 15)]),
-        ((1, '*', '*'), (1, 3, 2),
-         [(15, 5, 8), (15, 5, 7), (15, 5, 8), (15, 5, 7), (15, 5, 8), (15, 5, 7)]),
-        (('*', '*', '*'), (2, 3, 1),
-         [(8, 5, 15), (8, 5, 15), (8, 5, 15), (7, 5, 15), (7, 5, 15), (7, 5, 15)])
-    ])
-    @pytest.mark.parallel(mode=[6])
-    def test_custom_topology_3d_v2(self, topology, dist_topology, expected):
-        shape = (15, 15, 15)
-
-        # Decompose using a `topology` with stars
-        grid = Grid(shape=shape, topology=topology)
-        f = Function(name='f', grid=grid)
-        distributor = grid.distributor
-        assert distributor.topology == dist_topology
-        assert f.shape == expected[distributor.myrank]
-
     @pytest.mark.parametrize('comm_size, topology, dist_topology', [
+        (1, (1, '*', '*'), (1, 1, 1)),
+        (2, (1, '*', '*'), (1, 2, 1)),
+        (3, (1, '*', '*'), (1, 3, 1)),
+        (3, ('*', 1, '*'), (3, 1, 1)),
+        (3, ('*', '*', 1), (3, 1, 1)),
         (6, ('*', 1, '*'), (3, 1, 2)),
         (6, ('*', '*', 1), (3, 2, 1)),
         (6, (1, '*', '*'), (1, 3, 2)),
-        (6, ('*', '*', '*'), (2, 3, 1)),
+        (6, ('*', '*', '*'), (2, 3, 1)),  # TOFIX as (3, 2, 1)
         (8, ('*', 1, '*'), (4, 1, 2)),
         (8, ('*', '*', 1), (4, 2, 1)),
         (8, (1, '*', '*'), (1, 4, 2)),
+        (8, ('*', '*', '*'), (2, 2, 2)),
+        (9, ('*', '*', '*'), (3, 3, 1)),
+        (11, (1, '*', '*'), (1, 11, 1)),
+        (16, ('*', '*', 1), (4, 4, 1)),
+        (16, ('*', 1, '*'), (4, 1, 4)),
+        (32, ('*', '*', 1), (8, 4, 1)),
+        (64, ('*', '*', '*'), (4, 4, 4)),
+        (64, ('*', '*', 1), (8, 8, 1)),
+        (128, ('*', '*', 1), (16, 8, 1)),
+        (256, (1, '*', '*'), (1, 16, 16)),
+        (256, ('*', 1, '*'), (16, 1, 16)),
+        (256, ('*', '*', 1), (16, 16, 1)),
+        (256, ('*', '*', '*'), (8, 8, 4)),
     ])
     def test_custom_topology_3d_dummy(self, comm_size, topology, dist_topology):
-        dummy_comm = Dummy_input_comm(comm_size)
+        dummy_comm = DummyInputComm(comm_size)
         custom_topology = CustomTopology(topology, dummy_comm)
         assert custom_topology == dist_topology
 


### PR DESCRIPTION
This PR enhances the available custom topology MPI decompositions

The requirements for the number of stars to evenly divide the number of MPI procs is dropped:
    N must evenly divide the number of `'*'`, otherwise a ValueError exception
    is raised.

You can see some topology to decomposition combos in the added tests: (e.g.)

```
    @pytest.mark.parametrize('comm_size, topology, dist_topology', [
        (1, (1, '*', '*'), (1, 1, 1)),
        (2, (1, '*', '*'), (1, 2, 1)),
        (3, (1, '*', '*'), (1, 3, 1)),
        (3, ('*', 1, '*'), (3, 1, 1)),
        (3, ('*', '*', 1), (3, 1, 1)),
        (6, ('*', 1, '*'), (3, 1, 2)),
        (6, ('*', '*', 1), (3, 2, 1)),
        (6, (1, '*', '*'), (1, 3, 2)),
        (6, ('*', '*', '*'), (2, 3, 1)),
        (8, ('*', 1, '*'), (4, 1, 2)),
        (8, ('*', '*', 1), (4, 2, 1)),
        (8, (1, '*', '*'), (1, 4, 2)),
        (8, ('*', '*', '*'), (2, 2, 2)),
        (9, ('*', '*', '*'), (3, 3, 1)),
        (11, (1, '*', '*'), (1, 11, 1)),
    ])
```