### PR TITLE
bench: Add instrumentation for compute0 Elemental call

### DIFF
--- a/devito/passes/iet/instrument.py
+++ b/devito/passes/iet/instrument.py
@@ -1,5 +1,5 @@
 from devito.ir.iet import (BusyWait, FindNodes, FindSymbols, MapNodes, Section,
-                           TimedList, Transformer)
+                           TimedList, Transformer, ElementalCall)
 from devito.mpi.routines import (HaloUpdateCall, HaloWaitCall, MPICall, MPIList,
                                  HaloUpdateList, HaloWaitList, RemainderCall)
 from devito.passes.iet.engine import iet_pass
@@ -16,7 +16,6 @@ def instrument(graph, **kwargs):
     if profiler is None:
         return
     timer = Timer(profiler.name, list(profiler.all_sections))
-
     instrument_sections(graph, timer=timer, **kwargs)
     sync_sections(graph, **kwargs)
 
@@ -36,6 +35,7 @@ def track_subsections(iet, **kwargs):
         HaloUpdateCall: 'haloupdate',
         HaloWaitCall: 'halowait',
         RemainderCall: 'remainder',
+        ElementalCall: 'compute',
         HaloUpdateList: 'haloupdate',
         HaloWaitList: 'halowait',
         BusyWait: 'busywait'
@@ -43,7 +43,7 @@ def track_subsections(iet, **kwargs):
 
     mapper = {}
 
-    for NodeType in [MPIList, MPICall, BusyWait]:
+    for NodeType in [MPIList, MPICall, BusyWait, ElementalCall]:
         for k, v in MapNodes(Section, NodeType).visit(iet).items():
             for i in v:
                 if i in mapper or not any(issubclass(i.__class__, n)


### PR DESCRIPTION
Adds a timer for the compute0 core area in FULL mpi mode  (for advanced2 profiling)
e.g, now you get:

```
Global performance: [OI=6.55, 15.50 GFlops/s, 0.19 GPts/s]
Local performance:
  * section0[rank0]<21,50,50,8,8,40> ran in 0.72 s [OI=6.55, 15.56 GFlops/s, 0.19 GPts/s]
    + haloupdate0 ran in 0.00 s [0.01%]
    + halowait0 ran in 0.00 s [0.01%]
    + remainder0 ran in 0.55 s [76.68%]
    + compute0 ran in 0.17 s [23.32%]
```


Generated code-diff:

```bash
*** 42,48 ****
    double haloupdate0;
    double halowait0;
    double remainder0;
-   double compute0;
  } ;
  
  struct region0
--- 42,47 ----
***************
*** 81,89 ****
      START_TIMER(haloupdate0)
      haloupdate0(u_vec,comm,msg0,6,t0,nthreads);
      STOP_TIMER(haloupdate0,timers)
-     START_TIMER(compute0)
      compute0(a,msg0,u_vec,dt,r0,r1,r2,r3,t0,t1,x0_blk0_size,x_M - 16,x_m + 16,y0_blk0_size,y_M - 16,y_m + 16,z_M - 16,z_m + 16,nthreads);
-     STOP_TIMER(compute0,timers)
      START_TIMER(halowait0)
      halowait0(u_vec,t0,msg0,6,nthreads);
      STOP_TIMER(halowait0,timers)
--- 80,86 ----

```