### PR TITLE
mpi: Instrument compute0 core after specialising as ComputeCall

### DIFF
--- a/devito/mpi/routines.py
+++ b/devito/mpi/routines.py
@@ -12,7 +12,7 @@ from devito.ir.equations import DummyEq
 from devito.ir.iet import (Call, Callable, Conditional, ElementalFunction,
                            Expression, ExpressionBundle, AugmentedExpression,
                            Iteration, List, Prodder, Return, make_efunc, FindNodes,
-                           Transformer, derive_parameters, ElementalCall)
+                           Transformer, ElementalCall)
 from devito.mpi import MPI
 from devito.symbolics import (Byref, CondNe, FieldFromPointer, FieldFromComposite,
                               IndexedPointer, Macro, cast_mapper, subs_op_args)
@@ -572,6 +572,14 @@ class DiagHaloExchangeBuilder(BasicHaloExchangeBuilder):
         return HaloUpdate('haloupdate%s' % key, iet, parameters)
 
 
+class ComputeCall(ElementalCall):
+    pass
+
+
+class ComputeFunction(ElementalFunction):
+    _Call_cls = ComputeCall
+
+
 class OverlapHaloExchangeBuilder(DiagHaloExchangeBuilder):
 
     """
@@ -647,7 +655,8 @@ class OverlapHaloExchangeBuilder(DiagHaloExchangeBuilder):
         if hs.body.is_Call:
             return None
         else:
-            return make_compute_func('compute%d' % key, hs.body, hs.arguments)
+            return make_efunc('compute%d' % key, hs.body, hs.arguments,
+                              efunc_type=ComputeFunction)
 
     def _call_compute(self, hs, compute, *args):
         if compute is None:
@@ -952,7 +961,8 @@ class FullHaloExchangeBuilder(Overlap2HaloExchangeBuilder):
             mapper = {i: List(body=[callpoke, i]) for i in
                       FindNodes(ExpressionBundle).visit(hs.body)}
             iet = Transformer(mapper).visit(hs.body)
-            return make_compute_func('compute%d' % key, iet, hs.arguments)
+            return make_efunc('compute%d' % key, iet, hs.arguments,
+                              efunc_type=ComputeFunction)
 
     def _make_poke(self, hs, key, msgs):
         lflag = Symbol(name='lflag')
@@ -1025,23 +1035,6 @@ class HaloUpdate(MPICallable):
         super(HaloUpdate, self).__init__(name, body, parameters)
 
 
-class ComputeFunction(ElementalFunction):
-
-    def make_call(self, dynamic_args_mapper=None, incr=False, retobj=None,
-                  is_indirect=False):
-        return ComputeCall(self.name, list(self.parameters), dict(self._mapper),
-                           dynamic_args_mapper, incr, retobj, is_indirect)
-
-
-def make_compute_func(name, iet, dynamic_parameters=None, retval='void', prefix='static'):
-    """
-    Shortcut to create a ComputeFunction.
-    """
-    return ComputeFunction(name, iet, retval=retval,
-                           parameters=derive_parameters(iet), prefix=prefix,
-                           dynamic_parameters=dynamic_parameters)
-
-
 class Remainder(ElementalFunction):
     pass
 
@@ -1083,10 +1076,6 @@ class HaloUpdateCall(MPICall):
 
 
 class HaloWaitCall(MPICall):
-    pass
-
-
-class ComputeCall(ElementalCall):
     pass
 
 

--- a/devito/mpi/routines.py
+++ b/devito/mpi/routines.py
@@ -12,7 +12,7 @@ from devito.ir.equations import DummyEq
 from devito.ir.iet import (Call, Callable, Conditional, ElementalFunction,
                            Expression, ExpressionBundle, AugmentedExpression,
                            Iteration, List, Prodder, Return, make_efunc, FindNodes,
-                           Transformer)
+                           Transformer, derive_parameters, ElementalCall)
 from devito.mpi import MPI
 from devito.symbolics import (Byref, CondNe, FieldFromPointer, FieldFromComposite,
                               IndexedPointer, Macro, cast_mapper, subs_op_args)
@@ -647,7 +647,7 @@ class OverlapHaloExchangeBuilder(DiagHaloExchangeBuilder):
         if hs.body.is_Call:
             return None
         else:
-            return make_efunc('compute%d' % key, hs.body, hs.arguments)
+            return make_compute_func('compute%d' % key, hs.body, hs.arguments)
 
     def _call_compute(self, hs, compute, *args):
         if compute is None:
@@ -952,7 +952,7 @@ class FullHaloExchangeBuilder(Overlap2HaloExchangeBuilder):
             mapper = {i: List(body=[callpoke, i]) for i in
                       FindNodes(ExpressionBundle).visit(hs.body)}
             iet = Transformer(mapper).visit(hs.body)
-            return make_efunc('compute%d' % key, iet, hs.arguments)
+            return make_compute_func('compute%d' % key, iet, hs.arguments)
 
     def _make_poke(self, hs, key, msgs):
         lflag = Symbol(name='lflag')
@@ -1025,6 +1025,23 @@ class HaloUpdate(MPICallable):
         super(HaloUpdate, self).__init__(name, body, parameters)
 
 
+class ComputeFunction(ElementalFunction):
+
+    def make_call(self, dynamic_args_mapper=None, incr=False, retobj=None,
+                  is_indirect=False):
+        return ComputeCall(self.name, list(self.parameters), dict(self._mapper),
+                           dynamic_args_mapper, incr, retobj, is_indirect)
+
+
+def make_compute_func(name, iet, dynamic_parameters=None, retval='void', prefix='static'):
+    """
+    Shortcut to create a ComputeFunction.
+    """
+    return ComputeFunction(name, iet, retval=retval,
+                           parameters=derive_parameters(iet), prefix=prefix,
+                           dynamic_parameters=dynamic_parameters)
+
+
 class Remainder(ElementalFunction):
     pass
 
@@ -1066,6 +1083,10 @@ class HaloUpdateCall(MPICall):
 
 
 class HaloWaitCall(MPICall):
+    pass
+
+
+class ComputeCall(ElementalCall):
     pass
 
 

--- a/devito/operator/profiling.py
+++ b/devito/operator/profiling.py
@@ -16,7 +16,7 @@ from devito.ir.iet import (BusyWait, ExpressionBundle, List, TimedList, Section,
 from devito.ir.support import IntervalGroup
 from devito.logger import warning, error
 from devito.mpi import MPI
-from devito.mpi.routines import MPICall, MPIList, RemainderCall
+from devito.mpi.routines import MPICall, MPIList, RemainderCall, ComputeCall
 from devito.parameters import configuration
 from devito.symbolics import subs_op_args
 from devito.tools import DefaultOrderedDict, flatten
@@ -332,7 +332,7 @@ class AdvancedProfilerVerbose2(AdvancedProfilerVerbose):
 
     @property
     def trackable_subsections(self):
-        return (MPICall, BusyWait)
+        return (MPICall, BusyWait, ComputeCall)
 
 
 class AdvisorProfiler(AdvancedProfiler):

--- a/devito/passes/iet/instrument.py
+++ b/devito/passes/iet/instrument.py
@@ -1,7 +1,8 @@
 from devito.ir.iet import (BusyWait, FindNodes, FindSymbols, MapNodes, Section,
                            TimedList, Transformer)
 from devito.mpi.routines import (HaloUpdateCall, HaloWaitCall, MPICall, MPIList,
-                                 HaloUpdateList, HaloWaitList, RemainderCall)
+                                 HaloUpdateList, HaloWaitList, RemainderCall,
+                                 ComputeCall)
 from devito.passes.iet.engine import iet_pass
 from devito.types import Timer
 
@@ -36,6 +37,7 @@ def track_subsections(iet, **kwargs):
         HaloUpdateCall: 'haloupdate',
         HaloWaitCall: 'halowait',
         RemainderCall: 'remainder',
+        ComputeCall: 'compute',
         HaloUpdateList: 'haloupdate',
         HaloWaitList: 'halowait',
         BusyWait: 'busywait'
@@ -43,7 +45,7 @@ def track_subsections(iet, **kwargs):
 
     mapper = {}
 
-    for NodeType in [MPIList, MPICall, BusyWait]:
+    for NodeType in [MPIList, MPICall, BusyWait, ComputeCall]:
         for k, v in MapNodes(Section, NodeType).visit(iet).items():
             for i in v:
                 if i in mapper or not any(issubclass(i.__class__, n)

--- a/tests/test_mpi.py
+++ b/tests/test_mpi.py
@@ -1420,6 +1420,23 @@ class TestCodeGeneration(object):
         assert len(calls) == 2
         assert calls[0].ncomps == 7
 
+    @switchconfig(profiling='advanced2')
+    @pytest.mark.parallel(mode=[
+        (1, 'full'),
+    ])
+    def test_profiled_regions(self):
+        grid = Grid(shape=(10, 10, 10))
+
+        f = TimeFunction(name='f', grid=grid, space_order=2)
+        g = TimeFunction(name='g', grid=grid, space_order=2)
+
+        eqns = [Eq(f.forward, f.dx2 + 1.),
+                Eq(g.forward, g.dx2 + 1.)]
+
+        op = Operator(eqns)
+        assert op._profiler.all_sections == ['section0', 'haloupdate0', 'halowait0',
+                                             'remainder0', 'compute0']
+
     @pytest.mark.parallel(mode=1)
     def test_enforce_haloupdate_if_unwritten_function(self):
         grid = Grid(shape=(16, 16))

--- a/tests/test_mpi.py
+++ b/tests/test_mpi.py
@@ -11,9 +11,10 @@ from devito.data import LEFT, RIGHT
 from devito.ir.iet import (Call, Conditional, Iteration, FindNodes, FindSymbols,
                            retrieve_iteration_tree)
 from devito.mpi import MPI
-from devito.mpi.routines import HaloUpdateCall, HaloUpdateList, MPICall
+from devito.mpi.routines import HaloUpdateCall, HaloUpdateList, MPICall, ComputeCall
 from devito.mpi.distributed import CustomTopology
 from devito.tools import Bunch
+
 from examples.seismic.acoustic import acoustic_setup
 
 pytestmark = skipif(['nompi'], whole_module=True)
@@ -1400,6 +1401,7 @@ class TestCodeGeneration(object):
             assert len(op._func_table) == 7
             assert len(calls) == 4
             assert 'haloupdate1' not in op._func_table
+            assert len(FindNodes(ComputeCall).visit(op)) == 1
 
     @pytest.mark.parallel(mode=[(1, 'diag2')])
     def test_many_functions(self):


### PR DESCRIPTION
This PR aims to make compute0 "more special" for instrumenting

and then adds a timer for the compute0 core area in FULL mpi mode  (for advanced2 profiling)

e.g now we get:

```
Global performance: [OI=6.55, 15.50 GFlops/s, 0.19 GPts/s]
Local performance:
  * section0[rank0]<21,50,50,8,8,40> ran in 0.72 s [OI=6.55, 15.56 GFlops/s, 0.19 GPts/s]
    + haloupdate0 ran in 0.00 s [0.01%]
    + halowait0 ran in 0.00 s [0.01%]
    + remainder0 ran in 0.55 s [76.68%]
    + compute0 ran in 0.17 s [23.32%]
```


Generated code-diff:

```bash
*** 42,48 ****
    double haloupdate0;
    double halowait0;
    double remainder0;
-   double compute0;
  } ;
  
  struct region0
--- 42,47 ----
***************
*** 81,89 ****
      START_TIMER(haloupdate0)
      haloupdate0(u_vec,comm,msg0,6,t0,nthreads);
      STOP_TIMER(haloupdate0,timers)
-     START_TIMER(compute0)
      compute0(a,msg0,u_vec,dt,r0,r1,r2,r3,t0,t1,x0_blk0_size,x_M - 16,x_m + 16,y0_blk0_size,y_M - 16,y_m + 16,z_M - 16,z_m + 16,nthreads);
-     STOP_TIMER(compute0,timers)
      START_TIMER(halowait0)
      halowait0(u_vec,t0,msg0,6,nthreads);
      STOP_TIMER(halowait0,timers)
--- 80,86 ----

```