### PR TITLE
compiler: Add guards to prevent OOB when streaming buffers with ConditionalDimension

### DIFF
--- a/devito/passes/clusters/buffering.py
+++ b/devito/passes/clusters/buffering.py
@@ -179,8 +179,7 @@ class Buffering(Queue):
                 lhs = b.indexed[dims]._subs(dim, b.firstidx.b)
                 rhs = b.function[dims]._subs(dim, b.firstidx.f)
 
-                if dim.is_Conditional:
-                    guards[b.xd] = GuardBound(0, b.firstidx.f)
+                guards[b.xd] = GuardBound(0, b.firstidx.f)
 
             elif b.is_write and init_onwrite(b.function):
                 dims = b.buffer.dimensions
@@ -229,11 +228,8 @@ class Buffering(Queue):
 
                 expr = lower_exprs(Eq(lhs, rhs))
                 ispace = b.readfrom
+                guards = c.guards.andg(b.xd, GuardBound(0, b.firstidx.f))
                 properties = c.properties.sequentialize(d)
-
-                guards = c.guards
-                if b.dim.is_Conditional:
-                    guards = guards.andg(b.xd, GuardBound(0, b.firstidx.f))
 
                 processed.append(
                     c.rebuild(exprs=expr, ispace=ispace,
@@ -266,11 +262,8 @@ class Buffering(Queue):
 
                 expr = lower_exprs(uxreplace(Eq(lhs, rhs), b.subdims_mapper))
                 ispace = b.written
+                guards = c.guards.andg(b.xd, GuardBound(0, b.firstidx.f))
                 properties = c.properties.sequentialize(d)
-
-                guards = c.guards
-                if b.dim.is_Conditional:
-                    guards = guards.andg(b.xd, GuardBound(0, b.firstidx.f))
 
                 processed.append(
                     c.rebuild(exprs=expr, ispace=ispace,

--- a/devito/passes/clusters/buffering.py
+++ b/devito/passes/clusters/buffering.py
@@ -167,6 +167,8 @@ class Buffering(Queue):
             b = Buffer(f, dim, d, accessv, cache, self.options, self.sregistry)
             buffers.append(b)
 
+            guards = {}
+
             if b.is_read or not b.has_uniform_subdims:
                 # Special case: avoid initialization if not strictly necessary
                 # See docstring for more info about what this implies
@@ -176,6 +178,9 @@ class Buffering(Queue):
                 dims = b.function.dimensions
                 lhs = b.indexed[dims]._subs(dim, b.firstidx.b)
                 rhs = b.function[dims]._subs(dim, b.firstidx.f)
+
+                if dim.is_Conditional:
+                    guards[b.xd] = GuardBound(0, b.firstidx.f)
 
             elif b.is_write and init_onwrite(b.function):
                 dims = b.buffer.dimensions
@@ -191,7 +196,7 @@ class Buffering(Queue):
 
             expr = lower_exprs(Eq(lhs, rhs))
             ispace = b.writeto
-            guards = {pd: GuardBound(dim.root.symbolic_min, dim.root.symbolic_max)}
+            guards[pd] = GuardBound(dim.root.symbolic_min, dim.root.symbolic_max)
             properties = {d: {AFFINE, PARALLEL} for d in ispace.itdimensions}
 
             init.append(Cluster(expr, ispace, guards=guards, properties=properties))
@@ -226,8 +231,12 @@ class Buffering(Queue):
                 ispace = b.readfrom
                 properties = c.properties.sequentialize(d)
 
+                guards = c.guards
+                if b.dim.is_Conditional:
+                    guards.andg(b.xd, GuardBound(0, b.firstidx.f))
+
                 processed.append(
-                    c.rebuild(exprs=expr, ispace=ispace, properties=properties)
+                    c.rebuild(exprs=expr, ispace=ispace, guards=guards, properties=properties)
                 )
 
             # Substitute buffered Functions with the newly created buffers
@@ -258,8 +267,12 @@ class Buffering(Queue):
                 ispace = b.written
                 properties = c.properties.sequentialize(d)
 
+                guards = c.guards
+                if b.dim.is_Conditional:
+                    guards.andg(b.xd, GuardBound(0, b.firstidx.f))
+
                 processed.append(
-                    c.rebuild(exprs=expr, ispace=ispace, properties=properties)
+                    c.rebuild(exprs=expr, ispace=ispace, guards=guards, properties=properties)
                 )
 
         # Lift {write,read}-only buffers into separate IterationSpaces

--- a/devito/passes/clusters/buffering.py
+++ b/devito/passes/clusters/buffering.py
@@ -236,7 +236,8 @@ class Buffering(Queue):
                     guards = guards.andg(b.xd, GuardBound(0, b.firstidx.f))
 
                 processed.append(
-                    c.rebuild(exprs=expr, ispace=ispace, guards=guards, properties=properties)
+                    c.rebuild(exprs=expr, ispace=ispace,
+                              guards=guards, properties=properties)
                 )
 
             # Substitute buffered Functions with the newly created buffers
@@ -272,7 +273,8 @@ class Buffering(Queue):
                     guards = guards.andg(b.xd, GuardBound(0, b.firstidx.f))
 
                 processed.append(
-                    c.rebuild(exprs=expr, ispace=ispace, guards=guards, properties=properties)
+                    c.rebuild(exprs=expr, ispace=ispace,
+                              guards=guards, properties=properties)
                 )
 
         # Lift {write,read}-only buffers into separate IterationSpaces

--- a/devito/passes/clusters/buffering.py
+++ b/devito/passes/clusters/buffering.py
@@ -233,7 +233,7 @@ class Buffering(Queue):
 
                 guards = c.guards
                 if b.dim.is_Conditional:
-                    guards.andg(b.xd, GuardBound(0, b.firstidx.f))
+                    guards = guards.andg(b.xd, GuardBound(0, b.firstidx.f))
 
                 processed.append(
                     c.rebuild(exprs=expr, ispace=ispace, guards=guards, properties=properties)
@@ -269,7 +269,7 @@ class Buffering(Queue):
 
                 guards = c.guards
                 if b.dim.is_Conditional:
-                    guards.andg(b.xd, GuardBound(0, b.firstidx.f))
+                    guards = guards.andg(b.xd, GuardBound(0, b.firstidx.f))
 
                 processed.append(
                     c.rebuild(exprs=expr, ispace=ispace, guards=guards, properties=properties)

--- a/tests/test_buffering.py
+++ b/tests/test_buffering.py
@@ -474,7 +474,7 @@ def test_conddim_backwards():
     op1 = Operator(eqns, opt='buffering')
 
     # Check generated code
-    assert len(retrieve_iteration_tree(op1)) == 3
+    assert len(retrieve_iteration_tree(op1)) == 4
     buffers = [i for i in FindSymbols().visit(op1) if i.is_Array]
     assert len(buffers) == 1
 
@@ -507,7 +507,7 @@ def test_conddim_backwards_multi_slots():
     op1 = Operator(eqns, opt='buffering')
 
     # Check generated code
-    assert len(retrieve_iteration_tree(op1)) == 3
+    assert len(retrieve_iteration_tree(op1)) == 4
     buffers = [i for i in FindSymbols().visit(op1) if i.is_Array]
     assert len(buffers) == 1
 
@@ -544,7 +544,7 @@ def test_conddim_backwards_unstructured():
     op1 = Operator(eqns, opt='buffering')
 
     # Check generated code
-    assert len(retrieve_iteration_tree(op1)) == 3
+    assert len(retrieve_iteration_tree(op1)) == 4
     buffers = [i for i in FindSymbols().visit(op1) if i.is_Array]
     assert len(buffers) == 1
 
@@ -589,7 +589,7 @@ def test_conddim_w_shifting():
     op1 = Operator(eqns, opt='buffering')
 
     # Check generated code
-    assert len(retrieve_iteration_tree(op1)) == 3
+    assert len(retrieve_iteration_tree(op1)) == 4
     buffers = [i for i in FindSymbols().visit(op1) if i.is_Array]
     assert len(buffers) == 1
 

--- a/tests/test_buffering.py
+++ b/tests/test_buffering.py
@@ -21,7 +21,7 @@ def test_read_write():
     op1 = Operator(eqn, opt='buffering')
 
     # Check generated code
-    assert len(retrieve_iteration_tree(op1)) == 2
+    assert len(retrieve_iteration_tree(op1)) == 3
     buffers = [i for i in FindSymbols().visit(op1) if i.is_Array]
     assert len(buffers) == 1
     assert buffers.pop().symbolic_shape[0] == 2
@@ -77,7 +77,7 @@ def test_read_only():
     op1 = Operator(eqns, opt='buffering')
 
     # Check generated code
-    assert len(retrieve_iteration_tree(op1)) == 3
+    assert len(retrieve_iteration_tree(op1)) == 4
     buffers = [i for i in FindSymbols().visit(op1) if i.is_Array]
     assert len(buffers) == 1
 
@@ -126,7 +126,7 @@ def test_read_only_backwards():
     op1 = Operator(eqns, opt='buffering')
 
     # Check generated code
-    assert len(retrieve_iteration_tree(op1)) == 3
+    assert len(retrieve_iteration_tree(op1)) == 4
     buffers = [i for i in FindSymbols().visit(op1) if i.is_Array]
     assert len(buffers) == 1
 
@@ -157,7 +157,7 @@ def test_read_only_backwards_unstructured():
     op1 = Operator(eqns, opt='buffering')
 
     # Check generated code
-    assert len(retrieve_iteration_tree(op1)) == 2
+    assert len(retrieve_iteration_tree(op1)) == 3
     buffers = [i for i in FindSymbols().visit(op1) if i.is_Array]
     assert len(buffers) == 1
 
@@ -181,7 +181,7 @@ def test_async_degree(async_degree):
     op1 = Operator(eqn, opt=('buffering', {'buf-async-degree': async_degree}))
 
     # Check generated code
-    assert len(retrieve_iteration_tree(op1)) == 2
+    assert len(retrieve_iteration_tree(op1)) == 3
     buffers = [i for i in FindSymbols().visit(op1) if i.is_Array]
     assert len(buffers) == 1
     assert buffers.pop().symbolic_shape[0] == async_degree
@@ -209,8 +209,8 @@ def test_two_homogeneous_buffers():
     op2 = Operator(eqns, opt=('buffering', 'fuse'))
 
     # Check generated code
-    assert len(retrieve_iteration_tree(op1)) == 2
-    assert len(retrieve_iteration_tree(op2)) == 2
+    assert len(retrieve_iteration_tree(op1)) == 3
+    assert len(retrieve_iteration_tree(op2)) == 3
     buffers = [i for i in FindSymbols().visit(op1.body) if i.is_Array]
     assert len(buffers) == 2
 
@@ -241,7 +241,7 @@ def test_two_heterogeneous_buffers():
     op1 = Operator(eqns, opt='buffering')
 
     # Check generated code
-    assert len(retrieve_iteration_tree(op1)) == 3
+    assert len(retrieve_iteration_tree(op1)) == 5
     buffers = [i for i in FindSymbols().visit(op1.body) if i.is_Array]
     assert len(buffers) == 2
 
@@ -272,7 +272,7 @@ def test_over_injection():
 
     # Check generated code
     assert len(retrieve_iteration_tree(op1)) ==\
-        5 + bool(configuration['language'] != 'C')
+        6 + bool(configuration['language'] != 'C')
     buffers = [i for i in FindSymbols().visit(op1) if i.is_Array]
     assert len(buffers) == 1
 
@@ -442,7 +442,7 @@ def test_subdims():
     op1 = Operator(eqn, opt='buffering')
 
     # Check generated code
-    assert len(retrieve_iteration_tree(op1)) == 2
+    assert len(retrieve_iteration_tree(op1)) == 3
     assert len([i for i in FindSymbols().visit(op1) if i.is_Array]) == 1
 
     op0.apply(time_M=nt-2)
@@ -628,7 +628,7 @@ def test_multi_access():
     op1 = Operator(eqns, opt='buffering')
 
     # Check generated code
-    assert len(retrieve_iteration_tree(op1)) == 2
+    assert len(retrieve_iteration_tree(op1)) == 3
     buffers = [i for i in FindSymbols().visit(op1) if i.is_Array]
     assert len(buffers) == 1
 
@@ -652,10 +652,10 @@ def test_issue_1901():
     op = Operator(eq, opt='buffering')
 
     trees = retrieve_iteration_tree(op)
-    assert len(trees) == 2
-    assert trees[1].root.dim is time
-    assert not trees[1].root.is_Parallel
-    assert trees[1].root.is_Sequential  # Obv
+    assert len(trees) == 3
+    assert trees[2].root.dim is time
+    assert not trees[2].root.is_Parallel
+    assert trees[2].root.is_Sequential  # Obv
 
 
 def test_everything():


### PR DESCRIPTION
Using the time derivative of a streamed buffer with a ConditionalDimension results in OOB within `init_to_host`. This was not captured in existing tests.

A new test has been added `test_gpu_common.py::test_streaming_multi_input_conddim_foward` that fails with this OOB; and a new guard is now introduced in `Buffering` to prevent it.