### PR TITLE
docker: revamp base deployment

### DIFF
--- a/.github/workflows/docker-bases.yml
+++ b/.github/workflows/docker-bases.yml
@@ -101,16 +101,6 @@ jobs:
           build-args: 'arch=icx'
           tags: 'devitocodes/bases:cpu-icx'
 
-      - name: ICC image
-        uses: docker/build-push-action@v3
-        with:
-          context: .
-          file: './docker/Dockerfile.cpu'
-          push: true
-          target: 'icc'
-          build-args: 'arch=icc'
-          tags: 'devitocodes/bases:cpu-icc'
-
 #######################################################
 ################### Nvidia nvhpc ######################
 #######################################################
@@ -250,7 +240,7 @@ jobs:
           context: .
           file: './docker/Dockerfile.amd'
           push: true
-          target: 'aomp'
+          target: 'amdclang'
           tags: devitocodes/bases:amd
 
       - name: AMD HIP image

--- a/.github/workflows/docker-bases.yml
+++ b/.github/workflows/docker-bases.yml
@@ -15,68 +15,14 @@ on:
     - cron: "0 13 * * 1"
 
 jobs:
-  deploy-docker-bases:
+#######################################################
+################### CPU ###############################
+#######################################################
+  deploy-cpu-bases:
     name: ${{ matrix.tag }}
     runs-on: ${{ matrix.runner }}
     env:
       DOCKER_BUILDKIT: "1"
-
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - tag: 'devitocodes/bases:nvidia-nvc'
-            arch: 'arch=nvc'
-            version: 'ver=nvhpc-22-7'
-            dockerfile: './docker/Dockerfile.nvidia'
-            runner: ["self-hosted", "nvidiagpu"]
-
-          - tag: 'devitocodes/bases:nvidia-nvcc'
-            arch: 'arch=nvcc'
-            version: 'ver=nvhpc-22-7'
-            dockerfile: './docker/Dockerfile.nvidia'
-            runner: ["self-hosted", "nvidiagpu"]
-
-          - tag: 'devitocodes/bases:nvidia-clang'
-            arch: 'arch=clang'
-            # clang is only officialy supporting cuda<11.5. The latest nvidia sdk with cuda 11.5 is 21.11 (last of 2021)
-            # We cannot use newer ones such as 22-1 because the package manager automatically installs the latest 2022
-            # that re-install the latest (11.7) version on top of it.
-            # For more info check https://llvm.org/docs/CompileCudaWithLLVM.html and the Prerequisites 
-            version: 'ver=nvhpc-21-11'
-            dockerfile: './docker/Dockerfile.nvidia'
-            runner: ["self-hosted", "nvidiagpu"]
-
-          - tag: 'devitocodes/bases:amd'
-            arch: ''
-            version: ''
-            dockerfile: './docker/Dockerfile.amd'
-            runner: ["self-hosted", "amdgpu"]
-
-          - tag: 'devitocodes/bases:amd-hip'
-            arch: 'arch=hip'
-            version: ''
-            dockerfile: './docker/Dockerfile.amd'
-            runner: ["self-hosted", "amdgpu"]
-          
-          # These ones are tiny runs on default
-          - tag: 'devitocodes/bases:cpu-gcc'
-            arch: 'arch=gcc'
-            version: ''
-            dockerfile: './docker/Dockerfile.cpu'
-            runner: ubuntu-latest 
-          
-          - tag: 'devitocodes/bases:cpu-icc, devitocodes/bases:cpu-icx'
-            arch: 'arch=icc'
-            version: ''
-            dockerfile: './docker/Dockerfile.cpu'
-            runner: ubuntu-latest 
-
-          - tag: 'devitocodes/bases:cpu-nvc'
-            arch: 'arch=nvc-host'
-            version: ''
-            dockerfile: './docker/Dockerfile.nvidia'
-            runner: ["self-hosted", "nvidiagpu"]
 
     steps:
       - name: Checkout devito
@@ -104,9 +50,184 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           context: .
-          file: ${{ matrix.dockerfile }}
+          file: './docker/Dockerfile.cpu'
           push: true
           build-args: |
-            ${{ matrix.arch }}
-            ${{ matrix.version }}
-          tags: ${{ matrix.tag }}
+            'arch=gcc'
+          tags: 'devitocodes/bases:cpu-gcc'
+
+      - name: Docker image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          file: './docker/Dockerfile.cpu'
+          push: true
+          build-args: |
+            'arch=icx'
+          tags: 'devitocodes/bases:cpu-icx'
+
+      - name: Docker image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          file: './docker/Dockerfile.cpu'
+          push: true
+          build-args: |
+            'arch=icc'
+          tags: 'devitocodes/bases:cpu-icc'
+
+#######################################################
+################### Nvidia nvhpc ######################
+#######################################################
+  deploy-nvidia-bases:
+    name: "nvidia-bases"
+    runs-on: ["self-hosted", "nvidiagpu"]
+    env:
+      DOCKER_BUILDKIT: "1"
+
+    steps:
+      - name: Checkout devito
+        uses: actions/checkout@v3
+
+      - name: Check event name
+        run: echo ${{ github.event_name }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: cleanup
+        run: docker system prune -a -f
+
+      - name: Docker image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          file: './docker/Dockerfile.nvidia'
+          push: true
+          build-args: |
+            'arch=nvc'
+          tags: 'devitocodes/bases:nvidia-nvc'
+
+      - name: Docker image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          file: './docker/Dockerfile.nvidia'
+          push: true
+          build-args: |
+            'arch=nvcc'
+          tags: 'devitocodes/bases:nvidia-nvcc'
+
+      - name: Docker image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          file: './docker/Dockerfile.nvidia'
+          push: true
+          build-args: |
+            'arch=nvc-host'
+          tags: 'devitocodes/bases:cpu-nvc'
+
+#######################################################
+################### Nvidia clang ######################
+# # clang is only officialy supporting cuda<11.5. The latest nvidia sdk with cuda 11.5 is 21.11 (last of 2021)
+# # We cannot use newer ones such as 22-1 because the package manager automatically installs the latest 2022
+# # that re-install the latest (11.7) version on top of it.
+# # For more info check https://llvm.org/docs/CompileCudaWithLLVM.html and the Prerequisites 
+#######################################################
+  deploy-nvidia-clang-base:
+    name: "nvidia-clang-base"
+    runs-on: ["self-hosted", "nvidiagpu"]
+    env:
+      DOCKER_BUILDKIT: "1"
+
+    steps:
+      - name: Checkout devito
+        uses: actions/checkout@v3
+
+      - name: Check event name
+        run: echo ${{ github.event_name }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: cleanup
+        run: docker system prune -a -f
+
+      - name: Docker image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          file: './docker/Dockerfile.nvidia'
+          push: true
+          build-args: |
+            'arch=clang'
+            'ver=nvhpc-21-11'
+          tags: 'devitocodes/bases:nvidia-clang'
+
+#######################################################
+##################### AMD #############################
+#######################################################
+  deploy-amd-bases:
+    name: "amd-base"
+    runs-on: ["self-hosted", "amdgpu"]
+    env:
+      DOCKER_BUILDKIT: "1"
+
+    steps:
+      - name: Checkout devito
+        uses: actions/checkout@v3
+
+      - name: Check event name
+        run: echo ${{ github.event_name }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: cleanup
+        run: docker system prune -a -f
+
+      - name: Docker image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          file: './docker/Dockerfile.amd'
+          push: true
+          tags: devitocodes/bases:amd
+
+      - name: Docker image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          file: './docker/Dockerfile.amd'
+          push: true
+          build-args: |
+            arch=hip
+          tags: devitocodes/bases:amd-hip

--- a/.github/workflows/docker-bases.yml
+++ b/.github/workflows/docker-bases.yml
@@ -1,5 +1,9 @@
 name: Build base compilers docker images
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   push:
     paths:
@@ -16,11 +20,11 @@ on:
 
 jobs:
 #######################################################
-################### CPU ###############################
+############## Basic gcc CPU ##########################
 #######################################################
   deploy-cpu-bases:
-    name: ${{ matrix.tag }}
-    runs-on: ${{ matrix.runner }}
+    name: "cpu-base"
+    runs-on: ubuntu-latest
     env:
       DOCKER_BUILDKIT: "1"
 
@@ -46,34 +50,65 @@ jobs:
       - name: cleanup
         run: docker system prune -a -f
 
-      - name: Docker image
+      - name: GCC image
         uses: docker/build-push-action@v3
         with:
           context: .
           file: './docker/Dockerfile.cpu'
           push: true
-          build-args: |
-            'arch=gcc'
+          target: 'gcc'
+          build-args: 'arch=gcc'
           tags: 'devitocodes/bases:cpu-gcc'
 
-      - name: Docker image
+#######################################################
+############## Intel OneApi CPU #######################
+#######################################################
+  deploy-oneapi-bases:
+    name: "oneapi-base"
+    runs-on: ubuntu-latest
+    env:
+      DOCKER_BUILDKIT: "1"
+
+    steps:
+      - name: Checkout devito
+        uses: actions/checkout@v3
+
+      - name: Check event name
+        run: echo ${{ github.event_name }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: cleanup
+        run: docker system prune -a -f
+
+      - name: ICX image
         uses: docker/build-push-action@v3
         with:
           context: .
           file: './docker/Dockerfile.cpu'
           push: true
-          build-args: |
-            'arch=icx'
+          target: 'icx'
+          build-args: 'arch=icx'
           tags: 'devitocodes/bases:cpu-icx'
 
-      - name: Docker image
+      - name: ICC image
         uses: docker/build-push-action@v3
         with:
           context: .
           file: './docker/Dockerfile.cpu'
           push: true
-          build-args: |
-            'arch=icc'
+          target: 'icc'
+          build-args: 'arch=icc'
           tags: 'devitocodes/bases:cpu-icc'
 
 #######################################################
@@ -107,42 +142,38 @@ jobs:
       - name: cleanup
         run: docker system prune -a -f
 
-      - name: Docker image
+      - name: NVC image
         uses: docker/build-push-action@v3
         with:
           context: .
           file: './docker/Dockerfile.nvidia'
           push: true
-          build-args: |
-            'arch=nvc'
+          target: 'nvc'
+          build-args: 'arch=nvc'
           tags: 'devitocodes/bases:nvidia-nvc'
 
-      - name: Docker image
+      - name: NVCC image
         uses: docker/build-push-action@v3
         with:
           context: .
           file: './docker/Dockerfile.nvidia'
           push: true
-          build-args: |
-            'arch=nvcc'
+          target: 'nvcc'
+          build-args: 'arch=nvcc'
           tags: 'devitocodes/bases:nvidia-nvcc'
 
-      - name: Docker image
+      - name: NVC host image
         uses: docker/build-push-action@v3
         with:
           context: .
           file: './docker/Dockerfile.nvidia'
           push: true
-          build-args: |
-            'arch=nvc-host'
+          target: 'nvc-host'
+          build-args: 'arch=nvc-host'
           tags: 'devitocodes/bases:cpu-nvc'
 
 #######################################################
 ################### Nvidia clang ######################
-# # clang is only officialy supporting cuda<11.5. The latest nvidia sdk with cuda 11.5 is 21.11 (last of 2021)
-# # We cannot use newer ones such as 22-1 because the package manager automatically installs the latest 2022
-# # that re-install the latest (11.7) version on top of it.
-# # For more info check https://llvm.org/docs/CompileCudaWithLLVM.html and the Prerequisites 
 #######################################################
   deploy-nvidia-clang-base:
     name: "nvidia-clang-base"
@@ -172,15 +203,14 @@ jobs:
       - name: cleanup
         run: docker system prune -a -f
 
-      - name: Docker image
+      - name: Nvidia clang image
         uses: docker/build-push-action@v3
         with:
           context: .
           file: './docker/Dockerfile.nvidia'
           push: true
-          build-args: |
-            'arch=clang'
-            'ver=nvhpc-21-11'
+          target: 'clang'
+          build-args: 'arch=clang'
           tags: 'devitocodes/bases:nvidia-clang'
 
 #######################################################
@@ -214,20 +244,22 @@ jobs:
       - name: cleanup
         run: docker system prune -a -f
 
-      - name: Docker image
+      - name: AMD image
         uses: docker/build-push-action@v3
         with:
           context: .
           file: './docker/Dockerfile.amd'
           push: true
+          target: 'aomp'
           tags: devitocodes/bases:amd
 
-      - name: Docker image
+      - name: AMD HIP image
         uses: docker/build-push-action@v3
         with:
           context: .
           file: './docker/Dockerfile.amd'
           push: true
+          target: 'hip'
           build-args: |
             arch=hip
           tags: devitocodes/bases:amd-hip

--- a/.github/workflows/docker-devito.yml
+++ b/.github/workflows/docker-devito.yml
@@ -33,7 +33,7 @@ jobs:
           # Runtime gpu flags from https://hub.docker.com/r/rocm/tensorflow/
           - base: 'bases:amd'
             tag: 'amd'
-            flag: '--network=host --device=/dev/kfd --device=/dev/dri --ipc=host --group-add video --group-add 109 --cap-add=SYS_PTRACE --security-opt seccomp=unconfined'
+            flag: '--network=host --device=/dev/kfd --device=/dev/dri --ipc=host --group-add video --group-add $(getent group render | cut -d: -f3) --cap-add=SYS_PTRACE --security-opt seccomp=unconfined'
             test: 'tests/test_gpu_openmp.py'
             runner: ["self-hosted", "amdgpu"]
 

--- a/.github/workflows/docker-devito.yml
+++ b/.github/workflows/docker-devito.yml
@@ -18,38 +18,38 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - base: 'bases:nvidia-nvc'
+          - base: 'test-bases:nvidia-nvc'
             tag: 'nvidia-nvc'
             flag: '--gpus all'
             test: 'tests/test_gpu_openacc.py tests/test_gpu_common.py'
             runner: ["self-hosted", "nvidiagpu"]
 
-          - base: 'bases:nvidia-clang'
+          - base: 'test-bases:nvidia-clang'
             tag: 'nvidia-clang'
             flag: '--gpus all'
             test: 'tests/test_gpu_openmp.py tests/test_gpu_common.py'
             runner: ["self-hosted", "nvidiagpu"]
 
           # Runtime gpu flags from https://hub.docker.com/r/rocm/tensorflow/
-          - base: 'bases:amd'
+          - base: 'test-bases:amd'
             tag: 'amd'
             flag: '--network=host --device=/dev/kfd --device=/dev/dri --ipc=host --group-add video --group-add 109 --cap-add=SYS_PTRACE --security-opt seccomp=unconfined'
             test: 'tests/test_gpu_openmp.py'
             runner: ["self-hosted", "amdgpu"]
 
-          - base: 'bases:cpu-gcc'
+          - base: 'test-bases:cpu-gcc'
             tag: "gcc"
             flag: ''
             test: 'tests/test_operator.py'
             runner: ubuntu-latest
 
-          - base: 'bases:cpu-icc'
+          - base: 'test-bases:cpu-icc'
             tag: "icc"
             flag: ''
             test: 'tests/test_operator.py'
             runner: ubuntu-latest
 
-          - base: 'bases:cpu-icx'
+          - base: 'test-bases:cpu-icx'
             tag: "icx"
             flag: ''
             test: 'tests/test_operator.py'
@@ -90,16 +90,16 @@ jobs:
           tags: |
             type=raw,value=${{ matrix.tag }}-dev
             type=raw,value=${{ matrix.tag }}-latest,enable=${{ github.event_name == 'release' }}
-            type=raw,value=latest,enable=${{ matrix.base == 'bases:cpu-gcc' }}
+            type=raw,value=latest,enable=${{ matrix.base == 'test-bases:cpu-gcc' }}
             type=semver,pattern={{raw}},prefix=${{ matrix.tag }}-,enable=${{ github.event_name == 'release' }}
             # Legacy "gpu" tag
-            type=raw,value=gpu-dev,enable=${{ matrix.base == 'bases:nvidia-nvc' }}
-            type=semver,pattern={{raw}},prefix=gpu-,enable=${{ github.event_name == 'release' &&  matrix.base == 'bases:nvidia-nvc' }}
-            type=semver,pattern={{raw}},value=gpu-latest,enable=${{ github.event_name == 'release' &&  matrix.base == 'bases:nvidia-nvc' }}
+            type=raw,value=gpu-dev,enable=${{ matrix.base == 'test-bases:nvidia-nvc' }}
+            type=semver,pattern={{raw}},prefix=gpu-,enable=${{ github.event_name == 'release' &&  matrix.base == 'test-bases:nvidia-nvc' }}
+            type=semver,pattern={{raw}},value=gpu-latest,enable=${{ github.event_name == 'release' &&  matrix.base == 'test-bases:nvidia-nvc' }}
             # Legacy "cpu" tag
-            type=raw,value=cpu-dev,enable=${{ matrix.base == 'bases:cpu-gcc' }}
-            type=semver,pattern={{raw}},prefix=cpu-,enable=${{ github.event_name == 'release' && matrix.base == 'bases:cpu-gcc' }}
-            type=semver,pattern={{raw}},value=cpu-latest,enable=${{ github.event_name == 'release' && matrix.base == 'bases:cpu-gcc' }}
+            type=raw,value=cpu-dev,enable=${{ matrix.base == 'test-bases:cpu-gcc' }}
+            type=semver,pattern={{raw}},prefix=cpu-,enable=${{ github.event_name == 'release' && matrix.base == 'test-bases:cpu-gcc' }}
+            type=semver,pattern={{raw}},value=cpu-latest,enable=${{ github.event_name == 'release' && matrix.base == 'test-bases:cpu-gcc' }}
 
       - name: Check tags
         run: echo "${{ steps.meta.outputs.tags }}"

--- a/.github/workflows/docker-devito.yml
+++ b/.github/workflows/docker-devito.yml
@@ -49,6 +49,12 @@ jobs:
             test: 'tests/test_operator.py'
             runner: ubuntu-latest
 
+          - base: 'bases:cpu-icx'
+            tag: "icx"
+            flag: ''
+            test: 'tests/test_operator.py'
+            runner: ubuntu-latest
+
     steps:
       - name: Checkout devito
         uses: actions/checkout@v3

--- a/.github/workflows/docker-devito.yml
+++ b/.github/workflows/docker-devito.yml
@@ -18,38 +18,38 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - base: 'test-bases:nvidia-nvc'
+          - base: 'bases:nvidia-nvc'
             tag: 'nvidia-nvc'
             flag: '--gpus all'
             test: 'tests/test_gpu_openacc.py tests/test_gpu_common.py'
             runner: ["self-hosted", "nvidiagpu"]
 
-          - base: 'test-bases:nvidia-clang'
+          - base: 'bases:nvidia-clang'
             tag: 'nvidia-clang'
             flag: '--gpus all'
             test: 'tests/test_gpu_openmp.py tests/test_gpu_common.py'
             runner: ["self-hosted", "nvidiagpu"]
 
           # Runtime gpu flags from https://hub.docker.com/r/rocm/tensorflow/
-          - base: 'test-bases:amd'
+          - base: 'bases:amd'
             tag: 'amd'
             flag: '--network=host --device=/dev/kfd --device=/dev/dri --ipc=host --group-add video --group-add 109 --cap-add=SYS_PTRACE --security-opt seccomp=unconfined'
             test: 'tests/test_gpu_openmp.py'
             runner: ["self-hosted", "amdgpu"]
 
-          - base: 'test-bases:cpu-gcc'
+          - base: 'bases:cpu-gcc'
             tag: "gcc"
             flag: ''
             test: 'tests/test_operator.py'
             runner: ubuntu-latest
 
-          - base: 'test-bases:cpu-icc'
+          - base: 'bases:cpu-icc'
             tag: "icc"
             flag: ''
             test: 'tests/test_operator.py'
             runner: ubuntu-latest
 
-          - base: 'test-bases:cpu-icx'
+          - base: 'bases:cpu-icx'
             tag: "icx"
             flag: ''
             test: 'tests/test_operator.py'
@@ -90,16 +90,16 @@ jobs:
           tags: |
             type=raw,value=${{ matrix.tag }}-dev
             type=raw,value=${{ matrix.tag }}-latest,enable=${{ github.event_name == 'release' }}
-            type=raw,value=latest,enable=${{ matrix.base == 'test-bases:cpu-gcc' }}
+            type=raw,value=latest,enable=${{ matrix.base == 'bases:cpu-gcc' }}
             type=semver,pattern={{raw}},prefix=${{ matrix.tag }}-,enable=${{ github.event_name == 'release' }}
             # Legacy "gpu" tag
-            type=raw,value=gpu-dev,enable=${{ matrix.base == 'test-bases:nvidia-nvc' }}
-            type=semver,pattern={{raw}},prefix=gpu-,enable=${{ github.event_name == 'release' &&  matrix.base == 'test-bases:nvidia-nvc' }}
-            type=semver,pattern={{raw}},value=gpu-latest,enable=${{ github.event_name == 'release' &&  matrix.base == 'test-bases:nvidia-nvc' }}
+            type=raw,value=gpu-dev,enable=${{ matrix.base == 'bases:nvidia-nvc' }}
+            type=semver,pattern={{raw}},prefix=gpu-,enable=${{ github.event_name == 'release' &&  matrix.base == 'bases:nvidia-nvc' }}
+            type=semver,pattern={{raw}},value=gpu-latest,enable=${{ github.event_name == 'release' &&  matrix.base == 'bases:nvidia-nvc' }}
             # Legacy "cpu" tag
-            type=raw,value=cpu-dev,enable=${{ matrix.base == 'test-bases:cpu-gcc' }}
-            type=semver,pattern={{raw}},prefix=cpu-,enable=${{ github.event_name == 'release' && matrix.base == 'test-bases:cpu-gcc' }}
-            type=semver,pattern={{raw}},value=cpu-latest,enable=${{ github.event_name == 'release' && matrix.base == 'test-bases:cpu-gcc' }}
+            type=raw,value=cpu-dev,enable=${{ matrix.base == 'bases:cpu-gcc' }}
+            type=semver,pattern={{raw}},prefix=cpu-,enable=${{ github.event_name == 'release' && matrix.base == 'bases:cpu-gcc' }}
+            type=semver,pattern={{raw}},value=cpu-latest,enable=${{ github.event_name == 'release' && matrix.base == 'bases:cpu-gcc' }}
 
       - name: Check tags
         run: echo "${{ steps.meta.outputs.tags }}"

--- a/.github/workflows/docker-devito.yml
+++ b/.github/workflows/docker-devito.yml
@@ -43,12 +43,6 @@ jobs:
             test: 'tests/test_operator.py'
             runner: ubuntu-latest
 
-          - base: 'bases:cpu-icc'
-            tag: "icc"
-            flag: ''
-            test: 'tests/test_operator.py'
-            runner: ubuntu-latest
-
           - base: 'bases:cpu-icx'
             tag: "icx"
             flag: ''

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -46,8 +46,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        pip install -e .[tests]
-        pip install matplotlib pyrevolve
+        pip install -e .[tests,extras]
 
     - name: Tests in examples
       run: py.test --cov --cov-config=.coveragerc --cov-report=xml examples/

--- a/.github/workflows/pytest-core-mpi.yml
+++ b/.github/workflows/pytest-core-mpi.yml
@@ -59,7 +59,7 @@ jobs:
       runs-on: ubuntu-latest
       strategy:
         matrix:
-          arch: [gcc, icc, icx]
+          arch: [gcc, icx]
       
       steps:
       - name: Checkout devito

--- a/.github/workflows/pytest-core-mpi.yml
+++ b/.github/workflows/pytest-core-mpi.yml
@@ -15,7 +15,7 @@ on:
       - master
 
 jobs:
-  build:
+  test-mpi-basic:
     name: pytest-mpi
     runs-on: ubuntu-20.04
     strategy:
@@ -25,6 +25,7 @@ jobs:
     env:
       DEVITO_LANGUAGE: "openmp"
       DEVITO_ARCH: "gcc-9"
+      OMP_NUM_THREADS: "1"
       CC: "gcc-9"
       CXX: "g++-9"
 
@@ -52,3 +53,22 @@ jobs:
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         name: pytest-mpi
+
+  test-mpi-docker:
+      name: pytest-mpi
+      runs-on: ubuntu-latest
+      strategy:
+        matrix:
+          arch: [gcc, icc, icx]
+      
+      steps:
+      - name: Checkout devito
+        uses: actions/checkout@v3
+      
+      - name: Build docker image
+        run: |
+          docker build . --file docker/Dockerfile.devito --tag devito_img --build-arg base=devitocodes/bases:cpu-${{ matrix.arch }}
+      
+      - name: Test with pytest
+        run: |
+          docker run --rm -e CODECOV_TOKEN=${{ secrets.CODECOV_TOKEN }} -e OMP_NUM_THREADS=1 --name testrun devito_img pytest tests/test_mpi.py

--- a/.github/workflows/pytest-core-nompi.yml
+++ b/.github/workflows/pytest-core-nompi.yml
@@ -141,7 +141,7 @@ jobs:
     - name: Set run prefix
       run: |
           if [[ "${{ matrix.name }}" =~ "docker" ]]; then
-              echo "RUN_CMD=docker run --rm -e CODECOV_TOKEN=${{ secrets.CODECOV_TOKEN }} -e DEVITO_ARCH=${{ matrix.arch }} --name testrun devito_img"  >> $GITHUB_ENV
+              echo "RUN_CMD=docker run --rm -e CODECOV_TOKEN=${{ secrets.CODECOV_TOKEN }} --name testrun devito_img"  >> $GITHUB_ENV
           else
               echo "RUN_CMD=" >> $GITHUB_ENV
           fi

--- a/.github/workflows/pytest-core-nompi.yml
+++ b/.github/workflows/pytest-core-nompi.yml
@@ -37,9 +37,8 @@ jobs:
            pytest-ubuntu-py38-gcc8-omp,
            pytest-ubuntu-py39-gcc9-omp,
            pytest-osx-py37-clang-omp,
-           pytest-docker-py37-gcc-omp,
-           pytest-docker-py37-icc-omp,
-           pytest-docker-py38-icx-omp
+           pytest-docker-py39-gcc-omp,
+           pytest-docker-py39-icx-omp
         ]
         set: [base, adjoint]
         include:
@@ -92,26 +91,19 @@ jobs:
           language: "C"
           sympy: "1.9"
 
-        - name: pytest-docker-py37-gcc-omp
-          python-version: '3.7'
+        - name: pytest-docker-py39-gcc-omp
+          python-version: '3.9'
           os: ubuntu-latest
           arch: "gcc"
           language: "openmp"
-          sympy: "1.10"
+          sympy: "1.12"
 
-        - name: pytest-docker-py37-icc-omp
-          python-version: '3.7'
-          os: ubuntu-22.04
-          arch: "icc"
-          language: "openmp"
-          sympy: "1.11"
-
-        - name: pytest-docker-py38-icx-omp
-          python-version: '3.8'
+        - name: pytest-docker-py39-icx-omp
+          python-version: '3.9'
           os: ubuntu-22.04
           arch: "icx"
           language: "openmp"
-          sympy: "1.11"
+          sympy: "1.12"
 
         - set: base
           test-set: 'not adjoint'

--- a/.github/workflows/pytest-gpu.yml
+++ b/.github/workflows/pytest-gpu.yml
@@ -74,7 +74,7 @@ jobs:
           test_drive_cmd: "rocm-smi"
           # Attach the AMD GPU devices `/dev` and add user to video and render (109 on wampa) group
           # Options from https://rocmdocs.amd.com/en/latest/ROCm_Virtualization_Containers/ROCm-Virtualization-&-Containers.html
-          flags: "--network=host --device=/dev/kfd --device=/dev/dri --ipc=host --group-add video --group-add 109 --cap-add=SYS_PTRACE --security-opt seccomp=unconfined --rm --name testrun-amd"
+          flags: "--network=host --device=/dev/kfd --device=/dev/dri --ipc=host --group-add video --group-add $(getent group render | cut -d: -f3) --cap-add=SYS_PTRACE --security-opt seccomp=unconfined --rm --name testrun-amd"
 
     steps:
     - name: Checkout devito

--- a/.github/workflows/tutorials.yml
+++ b/.github/workflows/tutorials.yml
@@ -32,7 +32,7 @@ jobs:
           tutos-ubuntu-gcc-py37,
           tutos-osx-gcc-py37,
           tutos-osx-clang-py37,
-          tutos-docker-gcc-py37
+          tutos-docker-gcc-py39
           ]
 
         include:
@@ -51,7 +51,7 @@ jobs:
             compiler: clang
             language: "C"
 
-          - name: tutos-docker-gcc-py37
+          - name: tutos-docker-gcc-py39
             os: ubuntu-latest
             compiler: gcc
             language: "openmp"
@@ -61,7 +61,7 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Set up Python 3.7
-      if: matrix.name != 'tutos-docker-gcc-py37'
+      if: "!contains(matrix.name, 'docker')"
       uses: actions/setup-python@v4
       with:
         python-version: 3.7
@@ -72,13 +72,13 @@ jobs:
         xcode-version: latest-stable
 
     - name: Build docker image
-      if: matrix.name == 'tutos-docker-gcc-py37'
+      if: "contains(matrix.name, 'docker')"
       run: |
           docker build . --file docker/Dockerfile.devito --tag devito_img
 
     - name: Set run prefix
       run: |
-          if [ "${{ matrix.name }}" == 'tutos-docker-gcc-py37' ]; then
+          if [ "${{ matrix.name }}" == 'tutos-docker-gcc-py39' ]; then
               echo "RUN_CMD=docker run --rm --name testrun devito_img" >> $GITHUB_ENV
           else
               echo "RUN_CMD=" >> $GITHUB_ENV
@@ -86,7 +86,7 @@ jobs:
       id: set-run
 
     - name: Install dependencies
-      if: matrix.name != 'tutos-docker-gcc-py37'
+      if: matrix.name != 'tutos-docker-gcc-py39'
       run: |
         python -m pip install --upgrade pip
         pip install -e .[tests,extras]

--- a/.github/workflows/tutorials.yml
+++ b/.github/workflows/tutorials.yml
@@ -89,8 +89,8 @@ jobs:
       if: matrix.name != 'tutos-docker-gcc-py37'
       run: |
         python -m pip install --upgrade pip
-        pip install -e .[tests]
-        pip install matplotlib blosc
+        pip install -e .[tests,extras]
+        pip install blosc
 
     - name: Seismic notebooks
       run: |

--- a/conftest.py
+++ b/conftest.py
@@ -21,6 +21,11 @@ except ImportError:
     MPI = None
 
 
+def pytest_collectstart(collector):
+    if collector.fspath and collector.fspath.ext == '.ipynb':
+        collector.skip_compare += ('text/latex', 'stderr')
+
+
 def skipif(items, whole_module=False):
     assert isinstance(whole_module, bool)
     items = as_tuple(items)

--- a/devito/arch/compiler.py
+++ b/devito/arch/compiler.py
@@ -707,6 +707,7 @@ class IntelCompiler(Compiler):
             if mpi_distro != 'IntelMPI':
                 warning("Expected Intel MPI distribution with `%s`, but found `%s`"
                         % (self.__class__.__name__, mpi_distro))
+            self.cflags.append("-cc=%s" % self.CC)
 
     def __lookup_cmds__(self):
         self.CC = 'icc'

--- a/devito/arch/compiler.py
+++ b/devito/arch/compiler.py
@@ -10,7 +10,7 @@ import time
 
 import numpy.ctypeslib as npct
 from codepy.jit import compile_from_string
-from codepy.toolchain import GCCToolchain
+from codepy.toolchain import GCCToolchain, call_capture_output
 
 from devito.arch import (AMDGPUX, Cpu64, M1, NVIDIAX, POWER8, POWER9, GRAVITON,
                          INTELGPUX, IntelSkylake, get_nvidia_cc, check_cuda_runtime,
@@ -54,6 +54,8 @@ def sniff_compiler_version(cc):
         compiler = "clang"
     elif ver.startswith("icc"):
         compiler = "icc"
+    elif ver.startswith("icx"):
+        compiler = "icx"
     elif ver.startswith("pgcc"):
         compiler = "pgcc"
     elif ver.startswith("cray"):
@@ -62,7 +64,7 @@ def sniff_compiler_version(cc):
         compiler = "unknown"
 
     ver = Version("0")
-    if compiler in ["gcc", "icc"]:
+    if compiler in ["gcc", "icc", "icx"]:
         try:
             # gcc-7 series only spits out patch level on dumpfullversion.
             res = run([cc, "-dumpfullversion"], stdout=PIPE, stderr=DEVNULL)
@@ -707,7 +709,17 @@ class IntelCompiler(Compiler):
             if mpi_distro != 'IntelMPI':
                 warning("Expected Intel MPI distribution with `%s`, but found `%s`"
                         % (self.__class__.__name__, mpi_distro))
-            self.cflags.append("-cc=%s" % self.CC)
+            self.cflags.insert(0, '-cc=%s' % self.CC)
+
+    def get_version(self):
+        if configuration['mpi']:
+            cmd = [self.cc, "-cc=%s" % self.CC, "--version"]
+        else:
+            cmd = [self.cc, "--version"]
+        result, stdout, stderr = call_capture_output(cmd)
+        if result != 0:
+            raise RuntimeError(f"version query failed: {stderr}")
+        return stdout
 
     def __lookup_cmds__(self):
         self.CC = 'icc'
@@ -720,9 +732,9 @@ class IntelCompiler(Compiler):
         # we try to use `mpiicc` first, while `mpicc` is our fallback, which may
         # or may not be an Intel distribution
         try:
-            check_output(["mpiicc", "--version"]).decode("utf-8")
+            check_output(["mpiicc", "-cc=%s" % self.CC, "--version"]).decode("utf-8")
             self.MPICC = 'mpiicc'
-            self.MPICXX = 'mpiicpc'
+            self.MPICXX = 'mpicxx'
         except FileNotFoundError:
             self.MPICC = 'mpicc'
             self.MPICXX = 'mpicxx'
@@ -777,7 +789,7 @@ class OneapiCompiler(IntelCompiler):
         self.CC = 'icx'
         self.CXX = 'icpx'
         self.MPICC = 'mpicc'
-        self.MPICX = 'mpicx'
+        self.MPICXX = 'mpicxx'
 
 
 class CustomCompiler(Compiler):

--- a/devito/core/autotuning.py
+++ b/devito/core/autotuning.py
@@ -122,7 +122,8 @@ def autotune(operator, args, level, mode):
             at_args.update(dict(run))
 
             # Drop run if not at least one block per thread
-            if not configuration['develop-mode'] and nblocks_per_thread.subs(at_args) < 1:
+            if not configuration['develop-mode'] and \
+                    nblocks_per_thread.subs(normalize_args(at_args)) < 1:
                 continue
 
             # Run the Operator

--- a/devito/types/dense.py
+++ b/devito/types/dense.py
@@ -16,7 +16,7 @@ from devito.exceptions import InvalidArgument
 from devito.logger import debug, warning
 from devito.mpi import MPI
 from devito.parameters import configuration
-from devito.symbolics import FieldFromPointer
+from devito.symbolics import FieldFromPointer, normalize_args
 from devito.finite_differences import Differentiable, generate_fd_shortcuts
 from devito.tools import (ReducerMap, as_tuple, c_restrict_void_p, flatten, is_integer,
                           memoized_meth, dtype_to_ctype, humanbytes)
@@ -1580,8 +1580,9 @@ class TempFunction(DiscreteFunction):
                 raise ValueError("Either `shape` or `kwargs` (Operator overrides) "
                                  "must be provided.")
             shape = []
+            args = normalize_args(kwargs)
             for n, i in enumerate(self.shape):
-                v = i.subs(kwargs)
+                v = i.subs(args)
                 if not v.is_Integer:
                     raise ValueError("Couldn't resolve `shape[%d]=%s` with the given "
                                      "kwargs (obtained: `%s`)" % (n, i, v))

--- a/devito/types/dimension.py
+++ b/devito/types/dimension.py
@@ -321,7 +321,8 @@ class Dimension(ArgProvider):
                 upper = interval.upper
             else:
                 # Autopadding causes non-integer upper limit
-                upper = interval.upper.subs(args)
+                from devito.symbolics import normalize_args
+                upper = interval.upper.subs(normalize_args(args))
             if args[self.max_name] + upper >= size:
                 raise InvalidArgument("OOB detected due to %s=%d" % (self.max_name,
                                                                      args[self.max_name]))

--- a/docker/Dockerfile.amd
+++ b/docker/Dockerfile.amd
@@ -65,7 +65,7 @@ WORKDIR /tmp
 
 # Install UCX
 RUN cd /tmp/ \
-    && git clone https://github.com/openucx/ucx.git -b ${UCX_BRANCH} \
+    && git clone --depth 1 https://github.com/openucx/ucx.git -b ${UCX_BRANCH} \
     && cd ucx \
     && ./autogen.sh \
     && mkdir build \
@@ -82,8 +82,26 @@ RUN cd /tmp/ \
     && make -j ${nproc} \
     && make install
 
+# Install OpenMPI
+RUN cd /tmp \
+    && git clone --depth 1 --recursive https://github.com/open-mpi/ompi.git -b ${OMPI_BRANCH} \
+    && cd ompi \
+    && ./autogen.pl \
+    && mkdir build \
+    && cd build \
+    && ../configure --prefix=$OMPI_HOME --with-ucx=$UCX_HOME \
+        CC=amdclang CXX=amdclang++ FC=amdflang F90=amdflang \
+        --enable-mca-no-build=btl-uct  \
+        --without-verbs \
+        --with-pmix  \
+        --enable-mpi \
+        --enable-mpi-fortran=yes \
+        --disable-debug \
+    && make -j ${nproc} \
+    && make install
+
 # Cleanup
-RUN rm -rf /tmp/ucx
+RUN rm -rf /tmp/ucx && rm -rf /tmp/ompi
 
 # Adding OpenMPI and UCX to Environment
 ENV PATH=$OMPI_HOME/bin:$UCX_HOME/bin:$PATH \
@@ -117,26 +135,7 @@ CMD ["/bin/bash"]
 # AOMP for GPUs (OpenMP offloading)
 ########################################################################
 # This will only trigger if arch is aomp since the final stage depends on it
-FROM sdk-base as aomp
-
-# Install OpenMPI
-RUN cd /tmp \
-    && git clone --recursive https://github.com/open-mpi/ompi.git -b ${OMPI_BRANCH} \
-    && cd ompi \
-    && ./autogen.pl \
-    && mkdir build \
-    && cd build \
-    && ../configure --prefix=$OMPI_HOME --with-ucx=$UCX_HOME \
-        CC=amdclang CXX=amdclang++ FC=amdflang F90=amdflang \
-        --enable-mca-no-build=btl-uct  \
-        --without-verbs \
-        --with-pmix  \
-        --enable-mpi \
-        --enable-mpi-fortran=yes \
-        --disable-debug \
-    && make -j ${nproc} \
-    && make install
-RUN RUN rm -rf /tmp/ompi
+FROM sdk-base as amdclang
 
 # MPI env
 ENV OMPI_CC="amdclang"
@@ -152,25 +151,6 @@ ENV DEVITO_LANGUAGE="openmp"
 ########################################################################
 # This will only trigger if arch is hip since the final stage depends on it
 FROM sdk-base as hip
-
-# Install OpenMPI
-RUN cd /tmp \
-    && git clone --recursive https://github.com/open-mpi/ompi.git -b ${OMPI_BRANCH} \
-    && cd ompi \
-    && ./autogen.pl \
-    && mkdir build \
-    && cd build \
-    && ../configure --prefix=$OMPI_HOME --with-ucx=$UCX_HOME \
-        CC=hipcc CXX=hipcc FC=hipfort F90=hipfort \
-        --enable-mca-no-build=btl-uct  \
-        --without-verbs \
-        --with-pmix  \
-        --enable-mpi \
-        --enable-mpi-fortran=yes \
-        --disable-debug \
-    && make -j ${nproc} \
-    && make install
-RUN RUN rm -rf /tmp/ompi
 
 # MPI env
 ENV OMPI_CC="hipcc"

--- a/docker/Dockerfile.amd
+++ b/docker/Dockerfile.amd
@@ -3,7 +3,7 @@
 # Based on  https://github.com/amd/InfinityHub-CI/tree/main/base-gpu-mpi-rocm-docker
 ##############################################################
 
-ARG ROCM_VERSION=5.4.2
+ARG ROCM_VERSION=5.5.1
 ARG arch="aomp"
 
 FROM rocm/dev-ubuntu-22.04:${ROCM_VERSION}-complete as sdk-base
@@ -82,26 +82,8 @@ RUN cd /tmp/ \
     && make -j ${nproc} \
     && make install
 
-# Install OpenMPI
-RUN cd /tmp \
-    && git clone --recursive https://github.com/open-mpi/ompi.git -b ${OMPI_BRANCH} \
-    && cd ompi \
-    && ./autogen.pl \
-    && mkdir build \
-    && cd build \
-    && ../configure --prefix=$OMPI_HOME --with-ucx=$UCX_HOME \
-        --enable-mca-no-build=btl-uct  \
-        --without-verbs \
-        --with-pmix  \
-        --enable-mpi \
-        --enable-mpi-fortran=yes \
-        --disable-debug \
-    && make -j ${nproc} \
-    && make install
-
 # Cleanup
-RUN rm -rf /tmp/ompi && rm -rf /tmp/ucx
-
+RUN rm -rf /tmp/ucx
 
 # Adding OpenMPI and UCX to Environment
 ENV PATH=$OMPI_HOME/bin:$UCX_HOME/bin:$PATH \
@@ -112,7 +94,6 @@ ENV PATH=$OMPI_HOME/bin:$UCX_HOME/bin:$PATH \
     CPATH=$OMPI_HOME/include:$UCX_HOME/include:$CPATH \
     INCLUDE=$OMPI_HOME/include:$UCX_HOME/include:$INCLUDE \
     PKG_CONFIG_PATH=$OMPI_HOME/lib/pkgconfig:$UCX_HOME/lib/pkgconfig:$PKG_CONFIG_PATH
-
 
 # Adding environment variable for Running as ROOT
 ENV OMPI_ALLOW_RUN_AS_ROOT=1
@@ -132,11 +113,36 @@ RUN python3 -m venv /venv && \
     /venv/bin/pip install --no-cache-dir mpi4py && \
     rm -rf ~/.cache/pip
 
+RUN apt-get clean && apt-get autoclean && apt-get autoremove && \
+    rm -rf /var/lib/apt/lists/*
+
+EXPOSE 8888
+CMD ["/bin/bash"]
+
 ########################################################################
 # AOMP for GPUs (OpenMP offloading)
 ########################################################################
 # This will only trigger if arch is aomp since the final stage depends on it
 FROM sdk-base as aomp
+
+# Install OpenMPI
+RUN cd /tmp \
+    && git clone --recursive https://github.com/open-mpi/ompi.git -b ${OMPI_BRANCH} \
+    && cd ompi \
+    && ./autogen.pl \
+    && mkdir build \
+    && cd build \
+    && ../configure --prefix=$OMPI_HOME --with-ucx=$UCX_HOME \
+        CC=amdclang CXX=amdclang++ FC=amdflang F90=amdflang \
+        --enable-mca-no-build=btl-uct  \
+        --without-verbs \
+        --with-pmix  \
+        --enable-mpi \
+        --enable-mpi-fortran=yes \
+        --disable-debug \
+    && make -j ${nproc} \
+    && make install
+RUN RUN rm -rf /tmp/ompi
 
 # MPI env
 ENV OMPI_CC="amdclang"
@@ -147,12 +153,30 @@ ENV DEVITO_ARCH="aomp"
 ENV DEVITO_PLATFORM="amdgpuX"
 ENV DEVITO_LANGUAGE="openmp"
 
-
 ########################################################################
 # HIPCC for GPUs (HIP)
 ########################################################################
 # This will only trigger if arch is hip since the final stage depends on it
 FROM sdk-base as hip
+
+# Install OpenMPI
+RUN cd /tmp \
+    && git clone --recursive https://github.com/open-mpi/ompi.git -b ${OMPI_BRANCH} \
+    && cd ompi \
+    && ./autogen.pl \
+    && mkdir build \
+    && cd build \
+    && ../configure --prefix=$OMPI_HOME --with-ucx=$UCX_HOME \
+        CC=hipcc CXX=hipcc FC=hipfort F90=hipfort \
+        --enable-mca-no-build=btl-uct  \
+        --without-verbs \
+        --with-pmix  \
+        --enable-mpi \
+        --enable-mpi-fortran=yes \
+        --disable-debug \
+    && make -j ${nproc} \
+    && make install
+RUN RUN rm -rf /tmp/ompi
 
 # MPI env
 ENV OMPI_CC="hipcc"
@@ -162,15 +186,3 @@ ENV OMPI_CXX="hipcc"
 ENV DEVITO_ARCH="hip"
 ENV DEVITO_PLATFORM="amdgpuX"
 ENV DEVITO_LANGUAGE="hip"
-
-
-########################################################################
-# Final image
-########################################################################
-FROM ${arch} as final
-
-RUN apt-get clean && apt-get autoclean && apt-get autoremove && \
-    rm -rf /var/lib/apt/lists/*
-
-EXPOSE 8888
-CMD ["/bin/bash"]

--- a/docker/Dockerfile.amd
+++ b/docker/Dockerfile.amd
@@ -107,12 +107,6 @@ ENV OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
 RUN apt-get update && \
     apt-get install -y dh-autoreconf python3-venv python3-dev python3-pip
 
-# Build mpi4py against amdclang
-RUN python3 -m venv /venv && \
-    /venv/bin/pip install --no-cache-dir --upgrade pip && \
-    /venv/bin/pip install --no-cache-dir mpi4py && \
-    rm -rf ~/.cache/pip
-
 RUN apt-get clean && apt-get autoclean && apt-get autoremove && \
     rm -rf /var/lib/apt/lists/*
 

--- a/docker/Dockerfile.cpu
+++ b/docker/Dockerfile.cpu
@@ -5,6 +5,7 @@
 
 ARG pyversion=python:3.9
 ARG arch=gcc
+ARG OMPI_BRANCH="v4.1.4"
 
 # Base image 
 FROM ${pyversion}-slim-bullseye as base
@@ -34,8 +35,10 @@ CMD ["/bin/bash"]
 ##############################################################
 FROM base as gcc
 
+ARG OMPI_BRANCH="v4.1.4"
+# Install OpenMPI
 RUN mkdir -p /deps && mkdir -p /opt/openmpi && cd /deps && \
-    git clone --recursive --branch v4.1.4 https://github.com/open-mpi/ompi.git openmpi && \
+    git clone --depth 1 --recursive --branch ${OMPI_BRANCH} https://github.com/open-mpi/ompi.git openmpi && \
     cd openmpi && ./autogen.pl && \
     mkdir build &&  cd build && \
     ../configure --prefix=/opt/openmpi/ \
@@ -71,6 +74,7 @@ ENV FI_PROVIDER_PATH $I_MPI_ROOT/libfabric/lib/prov:/usr/lib64/libfabric:${LD_LI
 
 ##############################################################
 # ICC image
+# This is a legacy setup that is not built anymore but kept for reference
 ##############################################################
 FROM oneapi as icc
 

--- a/docker/Dockerfile.cpu
+++ b/docker/Dockerfile.cpu
@@ -1,23 +1,33 @@
+# syntax=docker/dockerfile:1
 ##############################################################
 # This Dockerfile contains the Devito codes and can be built using different base images.
 ##############################################################
 
-ARG pyversion=python:3.7
+ARG pyversion=python:3.9
 ARG arch=gcc
 
 # Base image 
-FROM ${pyversion} as base
+FROM ${pyversion}-slim-bullseye as base
 
 ENV DEBIAN_FRONTEND noninteractive
 
 # Install for basic base not containing it
-RUN apt-get update && apt-get install -y vim wget git flex libnuma-dev tmux numactl hwloc
+RUN apt-get update && \
+    apt-get install -y vim wget git flex libnuma-dev tmux \
+        numactl hwloc curl \
+        autoconf libtool build-essential
 
 # Install tmpi
 RUN curl https://raw.githubusercontent.com/Azrael3000/tmpi/master/tmpi -o /usr/local/bin/tmpi
 
 # Install OpenGL library, necessary for the installation of GemPy
 RUN apt-get install -y libgl1-mesa-glx
+
+RUN apt-get clean && apt-get autoclean && apt-get autoremove && \
+    rm -rf /var/lib/apt/lists/*
+
+EXPOSE 8888
+CMD ["/bin/bash"]
 
 ##############################################################
 # GCC standard image
@@ -30,7 +40,7 @@ RUN mkdir -p /deps && mkdir -p /opt/openmpi && cd /deps && \
     mkdir build &&  cd build && \
     ../configure --prefix=/opt/openmpi/ \
                  --enable-mca-no-build=btl-uct --enable-mpi1-compatibility && \
-    make -j $(( $(lscpu | awk '/^Socket\(s\)/{ print $2 }') * $(lscpu | awk '/^Core\(s\) per socket/{ print $4 }') )) && \
+    make -j ${nproc} && \
     make install && \
     rm -rf /deps/openmpi
 
@@ -43,46 +53,50 @@ ENV DEVITO_ARCH="gcc"
 ENV DEVITO_LANGUAGE="openmp"
 
 ##############################################################
-# ICC image
+# Intel Oneapi base
 ##############################################################
-FROM base as icc
+FROM base as oneapi
 
- # Download the key to system keyring
- # https://www.intel.com/content/www/us/en/develop/documentation/installation-guide-for-intel-oneapi-toolkits-linux/top/installation/install-using-package-managers/apt.html#apt
+# Download the key to system keyring
+# https://www.intel.com/content/www/us/en/develop/documentation/installation-guide-for-intel-oneapi-toolkits-linux/top/installation/install-using-package-managers/apt.html#apt
 RUN wget -O- https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB | gpg --dearmor > /usr/share/keyrings/oneapi-archive-keyring.gpg
 RUN echo "deb [signed-by=/usr/share/keyrings/oneapi-archive-keyring.gpg] https://apt.repos.intel.com/oneapi all main" > /etc/apt/sources.list.d/oneAPI.list
-
-# Install wanted components only (icc and mpiicc)
-RUN apt-get update -y && apt-get install -y intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic intel-oneapi-mpi-devel
 
 # Set en vars by hand since we can't use entrypoint for intermediate image
 ENV I_ICC_ROOT=/opt/intel/oneapi/compiler/latest/
 ENV I_MPI_ROOT=/opt/intel/oneapi/mpi/latest/
-ENV I_MPI_CFLAGS="-cc=icc"
 ENV PATH $I_MPI_ROOT/libfabric/bin:$I_MPI_ROOT/bin:$I_ICC_ROOT/linux/bin/intel64:$I_ICC_ROOT/linux/bin:${PATH}
 ENV LD_LIBRARY_PATH $I_MPI_ROOT/libfabric/lib:$I_MPI_ROOT/lib/release:$I_MPI_ROOT/lib:$I_ICC_ROOT/linux/lib:$I_ICC_ROOT/linux/lib/x64:$I_ICC_ROOT/linux/compiler/lib/intel64_lin:${LD_LIBRARY_PATH}
 ENV FI_PROVIDER_PATH $I_MPI_ROOT/libfabric/lib/prov:/usr/lib64/libfabric:${LD_LIBRARY_PATH}
+
+##############################################################
+# ICC image
+##############################################################
+FROM oneapi as icc
+
+RUN apt-get update -y && apt-get install -y intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic intel-oneapi-mpi-devel && \
+    apt-get clean && apt-get autoclean && apt-get autoremove && \
+    rm -rf /var/lib/apt/lists/*
 
 # Devito config
 ENV DEVITO_ARCH="icc"
 ENV DEVITO_LANGUAGE="openmp"
 # MPICC compiler for mpi4py
 ENV MPICC=$I_MPI_ROOT/bin/mpiicc
+ENV MPI4PY_FLAGS='CFLAGS="-cc=icc"'
 
-FROM icc as icx
+##############################################################
+# ICX image
+##############################################################
+FROM oneapi as icx
+
+RUN apt-get update -y && apt-get install -y intel-oneapi-compiler-dpcpp-cpp intel-oneapi-mpi-devel && \
+    apt-get clean && apt-get autoclean && apt-get autoremove && \
+    rm -rf /var/lib/apt/lists/*
+
 # Devito config
 ENV DEVITO_ARCH="icx"
 ENV DEVITO_LANGUAGE="openmp"
 # MPICC compiler for mpi4py
-ENV I_MPI_CFLAGS="-cc=icx"
-
-##############################################################
-# Published image
-##############################################################
-FROM ${arch} as final
-
-RUN apt-get clean && apt-get autoclean && apt-get autoremove && \
-    rm -rf /var/lib/apt/lists/*
-
-EXPOSE 8888
-CMD ["/bin/bash"]
+ENV MPICC=$I_MPI_ROOT/bin/mpiicc
+ENV MPI4PY_FLAGS='CFLAGS="-cc=icx"'

--- a/docker/Dockerfile.cpu
+++ b/docker/Dockerfile.cpu
@@ -58,6 +58,7 @@ RUN apt-get update -y && apt-get install -y intel-oneapi-compiler-dpcpp-cpp-and-
 # Set en vars by hand since we can't use entrypoint for intermediate image
 ENV I_ICC_ROOT=/opt/intel/oneapi/compiler/latest/
 ENV I_MPI_ROOT=/opt/intel/oneapi/mpi/latest/
+ENV I_MPI_CFLAGS="-cc=icc"
 ENV PATH $I_MPI_ROOT/libfabric/bin:$I_MPI_ROOT/bin:$I_ICC_ROOT/linux/bin/intel64:$I_ICC_ROOT/linux/bin:${PATH}
 ENV LD_LIBRARY_PATH $I_MPI_ROOT/libfabric/lib:$I_MPI_ROOT/lib/release:$I_MPI_ROOT/lib:$I_ICC_ROOT/linux/lib:$I_ICC_ROOT/linux/lib/x64:$I_ICC_ROOT/linux/compiler/lib/intel64_lin:${LD_LIBRARY_PATH}
 ENV FI_PROVIDER_PATH $I_MPI_ROOT/libfabric/lib/prov:/usr/lib64/libfabric:${LD_LIBRARY_PATH}
@@ -67,6 +68,13 @@ ENV DEVITO_ARCH="icc"
 ENV DEVITO_LANGUAGE="openmp"
 # MPICC compiler for mpi4py
 ENV MPICC=$I_MPI_ROOT/bin/mpiicc
+
+FROM icc as icx
+# Devito config
+ENV DEVITO_ARCH="icx"
+ENV DEVITO_LANGUAGE="openmp"
+# MPICC compiler for mpi4py
+ENV I_MPI_CFLAGS="-cc=icx"
 
 ##############################################################
 # Published image

--- a/docker/Dockerfile.devito
+++ b/docker/Dockerfile.devito
@@ -37,7 +37,10 @@ ENV APP_HOME=/app
 # Create the home directory for the new app user.
 # Create an app user so our program doesn't run as root.
 # Chown all the files to the app user.
-RUN mkdir -p /app && groupadd -r app && useradd -r -g app -d /app -s /sbin/nologin -c "Docker image user" app && chown -R app:app $APP_HOME
+RUN groupadd -g ${GROUP_ID} app && \
+    useradd -l -u ${USER_ID} -g app app && \
+    install -d -m 0755 -o app -g app /app && \
+    chown -R app:app $APP_HOME
 
 COPY --from=builder --chown=app:app /app /app
 

--- a/docker/Dockerfile.devito
+++ b/docker/Dockerfile.devito
@@ -7,9 +7,14 @@ ARG base=devitocodes/bases:cpu-gcc
 
 FROM $base as builder
 
+# User/Group Ids
+ARG USER_ID=1000
+ARG GROUP_ID=1000
+
 ##################  Install devito ############################################
 # Copy Devito
 ADD . /app/devito
+
 # Remove git files
 RUN rm -rf /app/devito/.git
 
@@ -18,6 +23,7 @@ RUN python3 -m venv /venv && \
     /venv/bin/pip install --no-cache-dir --upgrade pip && \
     /venv/bin/pip install --no-cache-dir jupyter && \
     /venv/bin/pip install --no-cache-dir wheel && \
+    eval "$MPI4PY_FLAGS /venv/bin/pip install --no-cache-dir mpi4py" && \
     /venv/bin/pip install --no-cache-dir -e /app/devito[extras,mpi,tests] && \
     rm -rf ~/.cache/pip
 
@@ -28,6 +34,10 @@ RUN apt-get clean && apt-get autoclean && apt-get autoremove && \
 FROM $base as user
 # COPY is much faster than RUN chown by order of magnitude so we have a final step that
 # just copies the built image into the user.
+
+# User/Group Ids
+ARG USER_ID=1000
+ARG GROUP_ID=1000
 
 ## Create App user
 # Set the home directory to our app user's home.

--- a/docker/Dockerfile.nvidia
+++ b/docker/Dockerfile.nvidia
@@ -31,8 +31,8 @@ RUN if [ "$ver" = "nvhpc" ]; then \
         apt-get install -y -q --allow-unauthenticated ${ver}; \
     else \
         export year=$(echo $ver | cut -d "-" -f 2) && export minor=$(echo $ver | cut -d "-" -f 3) && \
-        wget https://developer.download.nvidia.com/hpc-sdk/ubuntu/amd64/nvhpc-20${year}_${year}.${minor}_amd64.deb && \
-        apt-get install --allow-unauthenticated -y -q ./nvhpc-20${year}_${year}.${minor}_amd64.deb; \
+        wget https://developer.download.nvidia.com/hpc-sdk/ubuntu/amd64/nvhpc_${year}.${minor}_amd64.deb && \
+        apt-get install --allow-unauthenticated -y -q ./nvhpc_${year}.${minor}_amd64.deb; \
     fi;
 
 RUN curl -sL https://deb.nodesource.com/setup_18.x | bash - && \
@@ -46,7 +46,6 @@ RUN curl -sL https://deb.nodesource.com/setup_18.x | bash - && \
 # MPI_VER options 3,4,HPCX
 ARG MPI_VER=HPCX
 ENV MPIVER=${MPI_VER}
-
 
 # nvidia-container-runtime
 ENV NVIDIA_VISIBLE_DEVICES all
@@ -74,11 +73,21 @@ ENV UCX_TLS=cuda,cuda_copy,cuda_ipc,sm,shm,self
 #ENV UCX_TLS=cuda,cuda_copy,cuda_ipc,sm,shm,self,rc_x,gdr_copy
 
 # Make simlink for path setup since ENV doesn't accept shell commands.
-RUN export NVARCH=$(ls -1 opt/nvidia/hpc_sdk/Linux_x86_64/ | grep '\.' | head -n 1) && \
-    export CUDA_V=$(ls opt/nvidia/hpc_sdk/Linux_x86_64/${NVARCH}/cuda/ | grep '\.') && \
+RUN export NVARCH=$(ls -1 /opt/nvidia/hpc_sdk/Linux_x86_64/ | grep '\.' | head -n 1) && \
+    export CUDA_V=$(ls /opt/nvidia/hpc_sdk/Linux_x86_64/${NVARCH}/cuda/ | grep '\.') && \
     ln -sf /opt/nvidia/hpc_sdk/Linux_x86_64/${NVARCH} /opt/nvhpc && \
-    ln -sf /opt/nvidia/hpc_sdk/Linux_x86_64/${NVARCH}/cuda/${CUDA_V}/extras/CUPTI /opt/CUPTI
+    ln -sf /opt/nvidia/hpc_sdk/Linux_x86_64/${NVARCH}/cuda/${CUDA_V}/extras/CUPTI /opt/CUPTI && \
+    ln -sf /opt/nvidia/hpc_sdk/Linux_x86_64/comm_libs/${CUDA_V}/nvshmem /opt/nvhpc/comm_libs/nvshmem && \
+    ln -sf /opt/nvidia/hpc_sdk/Linux_x86_64/comm_libs/${CUDA_V}/nccl /opt/nvhpc/comm_libs/nccl
 
+# Starting nvhpc 23.5 and cuda 12.1, hpcx and openmpi are inside the cuda version folder, only the bin is in the comm_libs path
+RUN export CUDA_V=$(ls /opt/nvhpc/${NVARCH}/cuda/ | grep '\.') && \
+    ls /opt/nvhpc/comm_libs/${CUDA_V}/hpcx/ &&\
+    if [ -d /opt/nvhpc/comm_libs/${CUDA_V}/hpcx ]; then \
+        rm -rf /opt/nvhpc/comm_libs/hpcx && rm -rf /opt/nvhpc/comm_libs/openmpi4 && \
+        ln -sf /opt/nvhpc/comm_libs/${CUDA_V}/hpcx /opt/nvhpc/comm_libs/hpcx && \
+        ln -sf /opt/nvhpc/comm_libs/${CUDA_V}/openmpi4 /opt/nvhpc/comm_libs/openmpi4;\
+    fi;
 # Set base path based on version
 ENV HPCSDK_HOME=/opt/nvhpc
 ENV HPCSDK_CUPTI=/opt/CUPTI
@@ -98,15 +107,14 @@ ENV NVHPC_CUDA_HOME $HPCSDK_HOME/cuda
 ENV CUDA_ROOT $HPCSDK_HOME/cuda/bin
 ENV PATH $HPCSDK_HOME/compilers/bin:$HPCSDK_HOME/cuda/bin:$HPCSDK_HOME/comm_libs/mpi/bin:${PATH}
 ENV LD_LIBRARY_PATH $HPCSDK_HOME/cuda/lib:$HPCSDK_HOME/cuda/lib64:$HPCSDK_HOME/compilers/lib:$HPCSDK_HOME/math_libs/lib64:$HPCSDK_HOME/comm_libs/mpi/lib:$HPCSDK_CUPTI/lib64:bitcomp_DIR:${LD_LIBRARY_PATH}
-ENV CPATH $HPCSDK_HOME/comm_libs/mpi/include:${CPATH}
+ENV CPATH $HPCSDK_HOME/comm_libs/mpi/include:$HPCSDK_HOME/comm_libs/nvshmem/include:$HPCSDK_HOME/comm_libs/nccl/include:${CPATH}
 
 # MPI
 RUN if [ "x$MPI_VER" = "x4" ]; then \
         rm -f  $HPCSDK_HOME/comm_libs/mpi && \
-        ln -sf $HPCSDK_HOME/comm_libs/openmpi4/openmpi-4.0.5 \
+        ln -sf $HPCSDK_HOME/comm_libs/openmpi4/latest \
                $HPCSDK_HOME/comm_libs/mpi ; \
-    fi;  \
-    if [ "$MPI_VER" = "HPCX" ]; then \
+    elif [ "$MPI_VER" = "HPCX" ]; then \
         rm -f  $HPCSDK_HOME/comm_libs/mpi && \
         ln -sf $HPCSDK_HOME/comm_libs/hpcx/latest/ompi \
                $HPCSDK_HOME/comm_libs/mpi ; \
@@ -121,6 +129,12 @@ RUN python3 -m venv /venv && \
     /venv/bin/jupyter serverextension enable dask_labextension && \
     rm -rf ~/.cache/pip
 
+RUN apt-get clean && apt-get autoclean && apt-get autoremove && \
+    rm -rf /var/lib/apt/lists/*
+
+EXPOSE 8888
+CMD ["/bin/bash"]
+
 ########################################################################
 # NVC for GPUs via OpenACC config
 ########################################################################
@@ -130,7 +144,7 @@ FROM sdk-base as nvc
 ADD docker/nvdashboard.json /app/nvdashboard.json
 
 # mpi4py
-RUN CC=nvc CFLAGS="-noswitcherror -tp=px" /venv/bin/pip install --no-cache-dir mpi4py && rm -rf ~/.cache/pip
+ENV MPI4PY_FLAGS='CC=nvc CFLAGS="-noswitcherror -tp=px"'
 
 ENV DEVITO_ARCH="nvc"
 ENV DEVITO_PLATFORM="nvidiaX"
@@ -139,13 +153,7 @@ ENV DEVITO_LANGUAGE="openacc"
 ########################################################################
 # NVC for GPUs via CUDA config
 ########################################################################
-FROM sdk-base as nvcc
-
-# Make devito env vars file and extras
-ADD docker/nvdashboard.json /app/nvdashboard.json
-
-# mpi4py
-RUN CC=nvc CFLAGS="-noswitcherror -tp=px" /venv/bin/pip install --no-cache-dir mpi4py && rm -rf ~/.cache/pip
+FROM nvc as nvcc
 
 ENV DEVITO_ARCH="cuda"
 ENV DEVITO_PLATFORM="nvidiaX"
@@ -154,10 +162,7 @@ ENV DEVITO_LANGUAGE="cuda"
 ########################################################################
 # NVC for CPUs config
 ########################################################################
-FROM sdk-base as nvc-host
-
-# mpi4py
-RUN CC=nvc CFLAGS="-noswitcherror -tp=px" /venv/bin/pip install --no-cache-dir mpi4py && rm -rf ~/.cache/pip
+FROM nvc as nvc-host
 
 ENV DEVITO_ARCH="nvc"
 ENV DEVITO_PLATFORM="cpu64"
@@ -193,8 +198,11 @@ RUN cd /llvm-project/build && \
 # Set path
 ENV PATH /llvm/bin:${PATH}
 ENV LD_LIBRARY_PATH /llvm/lib:${LD_LIBRARY_PATH}
+ENV CPATH /llvm/include:${CPATH}
 
 RUN rm -rf llvm-project
+RUN apt-get clean && apt-get autoclean && apt-get autoremove && \
+    rm -rf /var/lib/apt/lists/*
 
 # Recompile mpi4py with clang
 ENV OMPI_CC="clang"
@@ -204,14 +212,3 @@ RUN /venv/bin/pip install --no-cache-dir mpi4py && rm -rf ~/.cache/pip
 ENV DEVITO_ARCH="clang"
 ENV DEVITO_PLATFORM="nvidiaX"
 ENV DEVITO_LANGUAGE="openmp"
-
-########################################################################
-# Final image
-########################################################################
-FROM ${arch} as final
-
-RUN apt-get clean && apt-get autoclean && apt-get autoremove && \
-    rm -rf /var/lib/apt/lists/*
-
-EXPOSE 8888
-CMD ["/bin/bash"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -10,9 +10,9 @@ Devito provides several images that target different architectures and compilers
 
 We provide two CPU images:
 - `devito:gcc-*` with the standard GNU gcc compiler.
-- `devito:icc-*` with the Intel C compiler for Intel architectures.
+- `devito:icx-*` with the Intel C compiler for Intel architectures.
 
-These images provide a working environment for any CPU architecture and come with [Devito], `gcc/icc` and `mpi` preinstalled, and utilities such as `jupyter` for usability and exploration of the package.
+These images provide a working environment for any CPU architecture and come with [Devito], `gcc/icx` and `mpi` preinstalled, and utilities such as `jupyter` for usability and exploration of the package.
 
 To run this image locally, you will first need to install `docker`. Then, the following commands will get you started:
 

--- a/examples/cfd/08_shallow_water_equation.ipynb
+++ b/examples/cfd/08_shallow_water_equation.ipynb
@@ -265,7 +265,7 @@
     "N0 = 0. * M0\n",
     "D0 = eta0 + 50.\n",
     "\n",
-    "grid  = Grid(shape=(ny, nx), extent=(Ly, Lx), dtype=np.float64)"
+    "grid  = Grid(shape=(ny, nx), extent=(Ly, Lx), dtype=np.float32)"
    ]
   },
   {

--- a/examples/seismic/source.py
+++ b/examples/seismic/source.py
@@ -58,10 +58,10 @@ class TimeAxis(object):
         if not isinstance(num, int):
             raise TypeError("input argument must be of type int")
 
-        self.start = start
-        self.stop = stop
-        self.step = step
-        self.num = num
+        self.start = float(start)
+        self.stop = float(stop)
+        self.step = float(step)
+        self.num = int(num)
 
     def __str__(self):
         return "TimeAxis: start=%g, stop=%g, step=%g, num=%g" % \

--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -1,3 +1,5 @@
 matplotlib
 pandas
 pyrevolve
+scipy
+distributed

--- a/requirements-testing.txt
+++ b/requirements-testing.txt
@@ -2,3 +2,7 @@ pytest>=7.2,<8.0
 pytest-runner
 pytest-cov
 codecov
+flake8>=2.1.0
+nbval
+scipy
+cloudpickle

--- a/requirements-testing.txt
+++ b/requirements-testing.txt
@@ -5,4 +5,3 @@ codecov
 flake8>=2.1.0
 nbval
 scipy
-cloudpickle

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ codepy>=2019.1
 click<9.0
 multidict
 anytree>=2.4.3,<=2.9.0
+cloudpickle

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,6 @@
 pip>=9.0.1
 numpy>1.16
 sympy>=1.9,<1.13
-scipy
-flake8>=2.1.0
-nbval
 cached-property
 psutil>=5.1.0,<6.0
 py-cpuinfo<10
@@ -12,4 +9,3 @@ codepy>=2019.1
 click<9.0
 multidict
 anytree>=2.4.3,<=2.9.0
-distributed<2023.8


### PR DESCRIPTION
- Revamp base deployment not to rebuild nvhpc. Reduces the number of jobs and should reduce CI time since all extras are mostly an env var on top of the existing image. Little bit more verbose but I don't think it's really an issue there
- Added icx as a separate image
- Fix MPI flags for oneapi