### PR TITLE
compiler: Keep -qopenmp by default after icx 2023.2

### DIFF
--- a/devito/arch/compiler.py
+++ b/devito/arch/compiler.py
@@ -763,7 +763,7 @@ class OneapiCompiler(IntelCompiler):
         platform = kwargs.pop('platform', configuration['platform'])
         language = kwargs.pop('language', configuration['language'])
 
-        # Earlier to versions to OneAPI 2023.2.0 (clang17 underneath), have an OpenMP bug
+        # Earlier versions to OneAPI 2023.2.0 (clang17 underneath), have an OpenMP bug
         if self.version < Version('17.0.0') and language == 'openmp':
             self.ldflags.remove('-qopenmp')
             self.ldflags.append('-fopenmp')

--- a/devito/arch/compiler.py
+++ b/devito/arch/compiler.py
@@ -52,6 +52,8 @@ def sniff_compiler_version(cc):
         compiler = "clang"
     elif ver.startswith("Homebrew clang"):
         compiler = "clang"
+    elif ver.startswith("Intel"):
+        compiler = "icx"
     elif ver.startswith("icc"):
         compiler = "icc"
     elif ver.startswith("icx"):
@@ -761,7 +763,8 @@ class OneapiCompiler(IntelCompiler):
         platform = kwargs.pop('platform', configuration['platform'])
         language = kwargs.pop('language', configuration['language'])
 
-        if language == 'openmp':
+        # Earlier to versions to OneAPI 2023.2.0 (clang17 underneath), have an OpenMP bug
+        if self.version < Version('17.0.0') and language == 'openmp':
             self.ldflags.remove('-qopenmp')
             self.ldflags.append('-fopenmp')
 

--- a/tests/test_mpi.py
+++ b/tests/test_mpi.py
@@ -7,6 +7,7 @@ from devito import (Grid, Constant, Function, TimeFunction, SparseFunction,
                     SparseTimeFunction, Dimension, ConditionalDimension, SubDimension,
                     SubDomain, Eq, Ne, Inc, NODE, Operator, norm, inner, configuration,
                     switchconfig, generic_derivative)
+from devito.arch.compiler import OneapiCompiler
 from devito.data import LEFT, RIGHT
 from devito.ir.iet import (Call, Conditional, Iteration, FindNodes, FindSymbols,
                            retrieve_iteration_tree)
@@ -514,6 +515,8 @@ class TestSparseFunction(object):
         assert np.all(sf.data == data[sf.local_indices]*2)
 
     @pytest.mark.parallel(mode=4)
+    @switchconfig(condition=isinstance(configuration['compiler'],
+                  (OneapiCompiler)), safe_math=True)
     def test_sparse_coords(self):
         grid = Grid(shape=(21, 31, 21), extent=(20, 30, 20))
         x, y, z = grid.dimensions
@@ -1492,6 +1495,8 @@ class TestOperatorAdvanced(object):
         assert np.all(f.data == 1.25)
 
     @pytest.mark.parallel(mode=4)
+    @switchconfig(condition=isinstance(configuration['compiler'],
+                  (OneapiCompiler)), safe_math=True)
     def test_injection_wodup_wtime(self):
         """
         Just like ``test_injection_wodup``, but using a SparseTimeFunction


### PR DESCRIPTION
Passes locally
After icx 2023.2.0, reductions should are passing