### PR TITLE
arch: Correct `march` to `mcpu` for ppc

### DIFF
--- a/devito/arch/compiler.py
+++ b/devito/arch/compiler.py
@@ -386,7 +386,7 @@ class GNUCompiler(Compiler):
 
         platform = kwargs.pop('platform', configuration['platform'])
 
-        self.cflags += ['-march=native', '-Wno-unused-result',
+        self.cflags += ['-Wno-unused-result',
                         '-Wno-unused-variable', '-Wno-unused-but-set-variable']
 
         if configuration['safe-math']:
@@ -399,6 +399,12 @@ class GNUCompiler(Compiler):
             # however, we empirically found that stencils generally benefit
             # from `=512`
             self.cflags.append('-mprefer-vector-width=512')
+
+        if platform in [POWER8, POWER9]:
+           # -march isn't supported on power architectures, is -mtune needed?
+           self.cflags = ['-mcpu=native']  + self.cflags
+        else:
+           self.cflags = ['-march=native'] + self.cflags
 
         language = kwargs.pop('language', configuration['language'])
         try:

--- a/devito/arch/compiler.py
+++ b/devito/arch/compiler.py
@@ -401,10 +401,10 @@ class GNUCompiler(Compiler):
             self.cflags.append('-mprefer-vector-width=512')
 
         if platform in [POWER8, POWER9]:
-           # -march isn't supported on power architectures, is -mtune needed?
-           self.cflags = ['-mcpu=native']  + self.cflags
+            # -march isn't supported on power architectures, is -mtune needed?
+            self.cflags = ['-mcpu=native'] + self.cflags
         else:
-           self.cflags = ['-march=native'] + self.cflags
+            self.cflags = ['-march=native'] + self.cflags
 
         language = kwargs.pop('language', configuration['language'])
         try:


### PR DESCRIPTION
This should be a very minor change: Switch between -march=native (x86) and -mcpu=native -mtune=native (PowerPC)

fixes #2146 

I am not sure if you are testing on PPC (I guess not since the error never showed up) so not sure what to do for an appropriate test.