### PR TITLE
misc: Add deviceid to configuration and enhance switchconfig

### DIFF
--- a/devito/__init__.py
+++ b/devito/__init__.py
@@ -95,6 +95,9 @@ configuration.add('safe-math', 0, [0, 1], preprocessor=bool, callback=reinit_com
 # Enable/disable automatic padding for allocated data
 configuration.add('autopadding', False, [False, True])
 
+# Select target device
+configuration.add('deviceid', -1, preprocessor=int, impacts_jit=False)
+
 
 def autotune_callback(val):  # noqa
     if isinstance(val, str):

--- a/devito/__init__.py
+++ b/devito/__init__.py
@@ -50,6 +50,7 @@ def reinit_compiler(val):
     """
     configuration['compiler'].__init__(suffix=configuration['compiler'].suffix,
                                        mpi=configuration['mpi'])
+    return val
 
 
 # Setup target platform and compiler

--- a/devito/arch/compiler.py
+++ b/devito/arch/compiler.py
@@ -216,6 +216,10 @@ class Compiler(GCCToolchain):
                               mpi=kwargs.pop('mpi', configuration['mpi']),
                               **kwargs)
 
+    @property
+    def name(self):
+        return self.__class__.__name__
+
     @memoized_meth
     def get_jit_dir(self):
         """A deterministic temporary directory for jit-compiled objects."""

--- a/devito/logger.py
+++ b/devito/logger.py
@@ -56,6 +56,8 @@ def _set_log_level(level):
 
     logger.setLevel(level)
 
+    return level
+
 
 def set_log_level(level, comm=None):
     """

--- a/devito/operator/operator.py
+++ b/devito/operator/operator.py
@@ -1186,7 +1186,7 @@ def parse_kwargs(**kwargs):
 
     # `allocator`
     kwargs['allocator'] = default_allocator(
-        '%s.%s.%s' % (kwargs['compiler'].__class__.__name__,
+        '%s.%s.%s' % (kwargs['compiler'].name,
                       kwargs['language'],
                       kwargs['platform'])
     )

--- a/devito/operator/operator.py
+++ b/devito/operator/operator.py
@@ -1186,7 +1186,9 @@ def parse_kwargs(**kwargs):
 
     # `allocator`
     kwargs['allocator'] = default_allocator(
-        '%s.%s' % (kwargs['compiler'].__class__.__name__, kwargs['language'])
+        '%s.%s.%s' % (kwargs['compiler'].__class__.__name__,
+                      kwargs['language'],
+                      kwargs['platform'])
     )
 
     return kwargs

--- a/devito/parameters.py
+++ b/devito/parameters.py
@@ -7,7 +7,6 @@ from functools import wraps
 from devito.logger import info, warning
 from devito.tools import Signer, filter_ordered
 
-
 __all__ = ['configuration', 'init_configuration', 'print_defaults', 'print_state',
            'switchconfig']
 

--- a/devito/parameters.py
+++ b/devito/parameters.py
@@ -239,12 +239,12 @@ class switchconfig(object):
         self.previous = {}
         for k, v in self.params.items():
             self.previous[k] = configuration[k]
-            configuration[k] = v
+            configuration.update(k, v)
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         for k, v in self.params.items():
             try:
-                configuration[k] = self.previous[k]
+                configuration.update(k, self.previous[k])
             except ValueError:
                 # E.g., `platform` and `compiler` will end up here
                 super(Parameters, configuration).__setitem__(k, self.previous[k])

--- a/devito/parameters.py
+++ b/devito/parameters.py
@@ -247,10 +247,7 @@ class switchconfig(object):
                 configuration[k] = self.previous[k]
             except ValueError:
                 # E.g., `platform` and `compiler` will end up here
-                try:
-                    configuration[k] = self.previous[k].name
-                except AttributeError:
-                    super(Parameters, configuration).__setitem__(k, self.previous[k])
+                super(Parameters, configuration).__setitem__(k, self.previous[k])
 
     def __call__(self, func, *args, **kwargs):
         @wraps(func)

--- a/devito/parameters.py
+++ b/devito/parameters.py
@@ -239,7 +239,7 @@ class switchconfig(object):
         self.previous = {}
         for k, v in self.params.items():
             self.previous[k] = configuration[k]
-            configuration.update(k, v)
+            configuration[k] = v
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         for k, v in self.params.items():

--- a/devito/types/parallel.py
+++ b/devito/types/parallel.py
@@ -252,7 +252,7 @@ class DeviceID(DeviceSymbol):
 
     @property
     def default_value(self):
-        return -1
+        return configuration['deviceid']
 
 
 class DeviceRM(DeviceSymbol):

--- a/devito/types/parallel.py
+++ b/devito/types/parallel.py
@@ -252,7 +252,15 @@ class DeviceID(DeviceSymbol):
 
     @property
     def default_value(self):
-        return configuration['deviceid']
+        return -1
+
+    def _arg_values(self, **kwargs):
+        if self.name in kwargs:
+            return {self.name: kwargs.pop(self.name)}
+        elif configuration['deviceid'] != self.default_value:
+            return {self.name: configuration['deviceid']}
+        else:
+            return {self.name: self.default_value}
 
 
 class DeviceRM(DeviceSymbol):


### PR DESCRIPTION
Adds `deviceid` to `configuration` and updates `switchconfig` so that it can act both as a decorator and a context manager.