### PR TITLE
compiler: Enable AVX512 compiler support when available.

### DIFF
--- a/devito/arch/archinfo.py
+++ b/devito/arch/archinfo.py
@@ -20,7 +20,7 @@ __all__ = ['platform_registry', 'get_cpu_info', 'get_gpu_info', 'get_nvidia_cc',
            'Device', 'NvidiaDevice', 'AmdDevice', 'IntelDevice',
            # Intel
            'INTEL64', 'SNB', 'IVB', 'HSW', 'BDW', 'KNL', 'KNL7210',
-           'SKX', 'KLX', 'CLX', 'CLK',
+           'SKX', 'KLX', 'CLX', 'CLK', 'SPR',
            # ARM
            'AMD', 'ARM', 'M1', 'GRAVITON',
            # Other loosely supported CPU architectures
@@ -616,7 +616,7 @@ class IntelSkylake(Intel64):
     pass
 
 
-class IntelGoldenCode(Intel64):
+class IntelGoldenCove(Intel64):
     pass
 
 
@@ -744,6 +744,7 @@ SKX = IntelSkylake('skx')
 KLX = IntelSkylake('klx')
 CLX = IntelSkylake('clx')
 CLK = IntelSkylake('clk')
+SPR = IntelGoldenCove('spr')
 
 ARM = Arm('arm')
 GRAVITON = Arm('graviton')
@@ -771,6 +772,7 @@ platform_registry = {
     'klx': KLX,  # Kaby Lake
     'clx': CLX,  # Coffee Lake
     'clk': CLK,  # Cascade Lake
+    'spr': SPR,  # Sapphire Rapids
     'knl': KNL,
     'knl7210': KNL7210,
     'arm': ARM,  # Generic ARM CPU

--- a/devito/arch/compiler.py
+++ b/devito/arch/compiler.py
@@ -395,10 +395,14 @@ class GNUCompiler(Compiler):
             self.cflags.append('-ffast-math')
 
         if platform.isa == 'avx512':
-            # The default is `=256` because avx512 slows down the CPU frequency;
-            # however, we empirically found that stencils generally benefit
-            # from `=512`
-            self.cflags.append('-mprefer-vector-width=512')
+            if self.version >= Version("8.0.0"):
+                # The default is `=256` because avx512 slows down the CPU frequency;
+                # however, we empirically found that stencils generally benefit
+                # from `=512`
+                self.cflags.append('-mprefer-vector-width=512')
+            else:
+                # Unsupported on earlier versions
+                pass
 
         if platform in [POWER8, POWER9]:
             # -march isn't supported on power architectures, is -mtune needed?
@@ -698,6 +702,7 @@ class IntelCompiler(Compiler):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
+        platform = kwargs.pop('platform', configuration['platform'])
         language = kwargs.pop('language', configuration['language'])
 
         self.cflags.append("-xHost")


### PR DESCRIPTION
Use configuration['platform'].isa == 'avx512' to determine whether AVX512 is supported rather than DEVITO_PLATFORM. This adds compiler options for long vectors for Intel Skylake and later generations.