### PR TITLE
arch: support rocm for gpu info

### DIFF
--- a/.github/workflows/pytest-core-nompi.yml
+++ b/.github/workflows/pytest-core-nompi.yml
@@ -80,7 +80,7 @@ jobs:
         - name: pytest-ubuntu-py39-gcc9-omp
           python-version: '3.9'
           os: ubuntu-20.04
-          arch: "gcc-9"
+          arch: "custom"
           language: "openmp"
           sympy: "1.9"
 
@@ -140,7 +140,7 @@ jobs:
       id: set-run
 
     - name: Install ${{ matrix.arch }} compiler
-      if: "runner.os == 'linux' && !contains(matrix.name, 'docker')"
+      if: "runner.os == 'linux' && !contains(matrix.name, 'docker') && matrix.arch !='custom' "
       run : |
         sudo apt-get install -y ${{ matrix.arch }}
 
@@ -166,8 +166,6 @@ jobs:
 
     - name: Test with pytest
       run: |
-        ${{ env.RUN_CMD }} ${{ matrix.arch }} --version
-        ${{ env.RUN_CMD }} python3 --version
         ${{ env.RUN_CMD }} pytest -k "${{ matrix.test-set }}" -m "not parallel" --cov --cov-config=.coveragerc --cov-report=xml ${{ env.TESTS }}
 
     - name: Upload coverage to Codecov

--- a/devito/arch/compiler.py
+++ b/devito/arch/compiler.py
@@ -870,14 +870,22 @@ class CustomCompiler(Compiler):
     def __init_finalize__(self, **kwargs):
         self._base.__init_finalize__(self, **kwargs)
         # Update cflags
-        extrac = environ.get('CFLAGS', '').split(' ')
-        self.cflags = filter_ordered(self.cflags + extrac)
+        try:
+            extrac = environ.get('CFLAGS').split(' ')
+            self.cflags = self.cflags + extrac
+        except AttributeError:
+            pass
         # Update ldflags
-        extrald = environ.get('LDFLAGS', '').split(' ')
-        self.ldflags = filter_ordered(self.ldflags + extrald)
+        try:
+            extrald = environ.get('LDFLAGS').split(' ')
+            self.ldflags = self.ldflags + extrald
+        except AttributeError:
+            pass
 
     def __lookup_cmds__(self):
         self._base.__lookup_cmds__(self)
+        # TODO: check for conflicts, for example using the nvhpc module file
+        # will set CXX to nvc++ breaking  the cuda backend
         self.CC = environ.get('CC', self.CC)
         self.CXX = environ.get('CXX', self.CXX)
         self.MPICC = environ.get('MPICC', self.MPICC)

--- a/devito/arch/compiler.py
+++ b/devito/arch/compiler.py
@@ -862,8 +862,8 @@ class CustomCompiler(Compiler):
 
         obj = super().__new__(cls)
         # Keep base to initialize accordingly
-        obj._base = _base
-        obj._cpp = _base._cpp
+        obj._base = kwargs.pop('base', _base)
+        obj._cpp = obj._base._cpp
 
         return obj
 
@@ -890,6 +890,9 @@ class CustomCompiler(Compiler):
         self.CXX = environ.get('CXX', self.CXX)
         self.MPICC = environ.get('MPICC', self.MPICC)
         self.MPICXX = environ.get('MPICXX', self.MPICXX)
+
+    def __new_with__(self, **kwargs):
+        return super().__new_with__(base=self._base, **kwargs)
 
 
 compiler_registry = {

--- a/devito/mpi/distributed.py
+++ b/devito/mpi/distributed.py
@@ -17,6 +17,8 @@ from devito.types import CompositeObject, Object
 from devito.types.utils import DimensionTuple
 
 
+__all__ = ['CustomTopology']
+
 # Do not prematurely initialize MPI
 # This allows launching a Devito program from within another Python program
 # that has *already* initialized MPI

--- a/tests/test_gpu_common.py
+++ b/tests/test_gpu_common.py
@@ -25,13 +25,26 @@ class TestGPUInfo(object):
 
     def test_get_gpu_info(self):
         info = get_gpu_info()
-        known = ['nvidia', 'tesla', 'geforce', 'quadro', 'unspecified']
+        known = ['nvidia', 'tesla', 'geforce', 'quadro', 'amd', 'unspecified']
         try:
             assert info['architecture'].lower() in known
         except KeyError:
             # There might be than one GPUs, but for now we don't care
             # as we're not really exploiting this info yet...
-            pass
+            pytest.xfail("Unsupported platform for get_gpu_info")
+
+    def custom_compiler(self):
+        grid = Grid(shape=(4, 4))
+
+        u = TimeFunction(name='u', grid=grid)
+
+        eqn = Eq(u.forward, u + 1)
+
+        with switchconfig(compiler='custom'):
+            op = Operator(eqn)()
+            # Check jit-compilation and correct execution
+            op.apply(time_M=10)
+            assert np.all(u.data[1] == 11)
 
 
 class TestCodeGeneration(object):


### PR DESCRIPTION
currently removes the `Xcompile` flag needed for host side as a duplicate flag

Fixes #2260 