### PR TITLE
compiler: Add pass to abridge SubDimension names where possible

### DIFF
--- a/devito/passes/clusters/aliases.py
+++ b/devito/passes/clusters/aliases.py
@@ -781,10 +781,10 @@ def optimize_schedule_rotations(schedule, sregistry):
         iis = candidate.lower
         iib = candidate.upper
 
-        ii = ModuloDimension('%sii' % d, ds, iis, incr=iib)
-        cd = CustomDimension(name='%s%s' % (d, d), symbolic_min=ii, symbolic_max=iib,
-                             symbolic_size=n)
-        dsi = ModuloDimension('%si' % ds, cd, cd + ds - iis, n)
+        ii = ModuloDimension('%sii' % d.root.name, ds, iis, incr=iib)
+        cd = CustomDimension(name='%s%s' % (d.root.name, d.root.name), symbolic_min=ii,
+                             symbolic_max=iib, symbolic_size=n)
+        dsi = ModuloDimension('%si' % ds.root.name, cd, cd + ds - iis, n)
 
         mapper = OrderedDict()
         for i in g:
@@ -795,7 +795,7 @@ def optimize_schedule_rotations(schedule, sregistry):
                 try:
                     md = mapper[v]
                 except KeyError:
-                    name = sregistry.make_name(prefix='%sr' % d.name)
+                    name = sregistry.make_name(prefix='%sr' % d.root.name)
                     md = mapper.setdefault(v, ModuloDimension(name, ds, v, n))
                 mds.append(md)
             indicess = [indices[:ridx] + [md] + indices[ridx + 1:]

--- a/devito/tools/abc.py
+++ b/devito/tools/abc.py
@@ -135,6 +135,12 @@ class Reconstructable(object):
                 args += tuple(getattr(self, i[1:]))
             else:
                 args += (getattr(self, i),)
+
+        args = list(args)
+        for k in list(kwargs):
+            if k in self.__rargs__:
+                args[self.__rargs__.index(k)] = kwargs.pop(k)
+
         kwargs.update({i: getattr(self, i) for i in self.__rkwargs__ if i not in kwargs})
 
         # Should we use a constum reconstructor?

--- a/devito/types/grid.py
+++ b/devito/types/grid.py
@@ -549,7 +549,10 @@ class MultiSubDimension(SubDimension):
     A special SubDimension for graceful lowering of MultiSubDomains.
     """
 
-    def __init_finalize__(self, name, parent, msd):
+    __rargs__ = ('name', 'parent', 'msd')
+    __rkwargs__ = ('thickness',)
+
+    def __init_finalize__(self, name, parent, msd, thickness=None):
         # NOTE: a MultiSubDimension stashes a reference to the originating MultiSubDomain.
         # This creates a circular pattern as the `msd` itself carries references to
         # its MultiSubDimensions. This is currently necessary because during compilation
@@ -558,7 +561,15 @@ class MultiSubDimension(SubDimension):
         # definitely possible, but not straightforward
         self.msd = msd
 
-        lst, rst = self._symbolic_thickness(name)
+        if not thickness:
+            lst, rst = self._symbolic_thickness(name)
+        else:  # Used for rebuilding. Reuse thickness symbols rather than making new ones
+            try:
+                ((lst, _), (rst, _)) = thickness
+            except ValueError:
+                raise ValueError("Invalid thickness specification: %s does not match"
+                                 "expected format ((left_symbol, left_thickness),"
+                                 " (right_symbol, right_thickness))" % thickness)
         left = parent.symbolic_min + lst
         right = parent.symbolic_max - rst
 

--- a/examples/performance/00_overview.ipynb
+++ b/examples/performance/00_overview.ipynb
@@ -1360,12 +1360,12 @@
       "        {\n",
       "          for (int y = y0_blk0, ys = 0, yr0 = (ys)%(5), yr1 = (ys + 3)%(5), yr2 = (ys + 4)%(5), yr3 = (ys + 1)%(5), yii = -2; y <= MIN(y_M, y0_blk0 + y0_blk0_size - 1); y += 1, ys += 1, yr0 = (ys)%(5), yr1 = (ys + 3)%(5), yr2 = (ys + 4)%(5), yr3 = (ys + 1)%(5), yii = 2)\n",
       "          {\n",
-      "            for (int yy = yii, ysi = (yy + ys + 2)%(5); yy <= 2; yy += 1, ysi = (yy + ys + 2)%(5))\n",
+      "            for (int yy = yii, yi = (yy + ys + 2)%(5); yy <= 2; yy += 1, yi = (yy + ys + 2)%(5))\n",
       "            {\n",
       "              #pragma omp simd aligned(u:32)\n",
       "              for (int z = z_m; z <= z_M; z += 1)\n",
       "              {\n",
-      "                r2[ysi][z] = r1*(8.33333333e-2F*(u[t0][x + 4][y + yy + 2][z + 4] - u[t0][x + 4][y + yy + 6][z + 4]) + 6.66666667e-1F*(-u[t0][x + 4][y + yy + 3][z + 4] + u[t0][x + 4][y + yy + 5][z + 4]));\n",
+      "                r2[yi][z] = r1*(8.33333333e-2F*(u[t0][x + 4][y + yy + 2][z + 4] - u[t0][x + 4][y + yy + 6][z + 4]) + 6.66666667e-1F*(-u[t0][x + 4][y + yy + 3][z + 4] + u[t0][x + 4][y + yy + 5][z + 4]));\n",
       "              }\n",
       "            }\n",
       "            #pragma omp simd aligned(f,u:32)\n",
@@ -1744,7 +1744,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.16"
+   "version": "3.11.5"
   },
   "varInspector": {
    "cols": {

--- a/tests/test_dle.py
+++ b/tests/test_dle.py
@@ -140,7 +140,11 @@ def test_cache_blocking_structure_subdims():
         tree[2].dim.root is x
     assert tree[3].dim.is_Block and tree[3].dim.parent is tree[1].dim and\
         tree[3].dim.root is y
-    assert not tree[4].dim.is_Block and tree[4].dim is zi and tree[4].dim.parent is z
+    # zi is rebuilt with name z, so check symbolic max and min are preserved
+    # Also check the zi was rebuilt
+    assert not tree[4].dim.is_Block and tree[4].dim is not zi and\
+        tree[4].dim.symbolic_min is zi.symbolic_min and\
+        tree[4].dim.symbolic_max is zi.symbolic_max and tree[4].dim.parent is z
 
 
 @pytest.mark.parallel(mode=[(1, 'full')])  # Shortcut to put loops in nested efuncs
@@ -1280,8 +1284,9 @@ class TestNestedParallelism(object):
             tree[3].dim.root is y
 
         if blocklevels == 1:
-            assert not tree[4].dim.is_Block and tree[4].dim is zi and\
-                tree[4].dim.parent is z
+            assert not tree[4].dim.is_Block and tree[4].dim is not zi and\
+                tree[4].dim.symbolic_min is zi.symbolic_min and\
+                tree[4].dim.symbolic_max is zi.symbolic_max and tree[4].dim.parent is z
         elif blocklevels == 2:
             assert tree[3].dim.is_Block and tree[3].dim.parent is tree[1].dim and\
                 tree[3].dim.root is y
@@ -1289,8 +1294,9 @@ class TestNestedParallelism(object):
                 tree[4].dim.root is x
             assert tree[5].dim.is_Block and tree[5].dim.parent is tree[3].dim and\
                 tree[5].dim.root is y
-            assert not tree[6].dim.is_Block and tree[6].dim is zi and\
-                tree[6].dim.parent is z
+            assert not tree[6].dim.is_Block and tree[6].dim is not zi and\
+                tree[6].dim.symbolic_min is zi.symbolic_min and\
+                tree[6].dim.symbolic_max is zi.symbolic_max and tree[6].dim.parent is z
 
         assert trees[0][0].pragmas[0].value ==\
             'omp for collapse(2) schedule(dynamic,1)'

--- a/tests/test_dse.py
+++ b/tests/test_dse.py
@@ -2652,7 +2652,7 @@ class TestAliases(object):
         u = TimeFunction(name="u", grid=grid)
         op = Operator(Eq(u.forward, u.dy.dy.subs(mapper),
                          subdomain=grid.interior))
-        assert_structure(op, ['t,i0x,i0y'], 'ti0xi0y')
+        assert_structure(op, ['t,x,y'], 'txy')
 
     def test_dtype_aliases(self):
         a = np.arange(64).reshape((8, 8))

--- a/tests/test_fission.py
+++ b/tests/test_fission.py
@@ -33,12 +33,12 @@ def test_issue_1725():
 
     # Note the `x` loop is fissioned, so now both loop nests can be collapsed
     # for maximum parallelism
-    assert_structure(op, ['t,x,i1y', 't,x,i2y'], 't,x,i1y,x,i2y')
+    assert_structure(op, ['t,x,y', 't,x,y'], 't,x,y,x,y')
 
 
 def test_nofission_as_unprofitable():
     """
-    Test there's no fission if not gonna increase number of collapsable loops.
+    Test there's no fission if no increase in number of collapsable loops.
     """
     grid = Grid(shape=(20, 20))
     x, y = grid.dimensions
@@ -54,7 +54,7 @@ def test_nofission_as_unprofitable():
 
     op = Operator(eqns, opt='fission')
 
-    assert_structure(op, ['t,x,yl', 't,x,yr'], 't,x,yl,yr')
+    assert_structure(op, ['t,x,y', 't,x,y'], 't,x,y,y')
 
 
 def test_nofission_as_illegal():
@@ -78,7 +78,7 @@ def test_nofission_as_illegal():
 
 def test_fission_partial():
     """
-    Test there's no fission if not gonna increase number of collapsable loops.
+    Test there's no fission if no increase in number of collapsable loops.
     """
     grid = Grid(shape=(20, 20))
     x, y = grid.dimensions
@@ -95,7 +95,7 @@ def test_fission_partial():
 
     op = Operator(eqns, opt='fission')
 
-    assert_structure(op, ['t,x,yl', 't,x,yr', 't,x,y'], 't,x,yl,yr,x,y')
+    assert_structure(op, ['t,x,y', 't,x,y', 't,x,y'], 't,x,y,y,x,y')
 
 
 def test_issue_1921():

--- a/tests/test_operator.py
+++ b/tests/test_operator.py
@@ -1518,7 +1518,7 @@ class TestLoopScheduling(object):
         # Here the difference is that we're using SubDimensions
         (('Eq(tv[t,xi,yi,zi], tu[t,xi-1,yi,zi] + tu[t,xi+1,yi,zi])',
           'Eq(tu[t+1,xi,yi,zi], tu[t,xi,yi,zi] + tv[t,xi-1,yi,zi] + tv[t,xi+1,yi,zi])'),
-         '+++++++', ['ti0xi0yi0z', 'ti0xi0yi0z'], 'ti0xi0yi0zi0xi0yi0z'),
+         '+++++++', ['txyz', 'txyz'], 'txyzxyz'),
         # 16) RAW 3->1; expected=2
         # Time goes backward, but the third equation should get fused with
         # the first one, as the time dependence is loop-carried
@@ -1545,7 +1545,7 @@ class TestLoopScheduling(object):
         (('Eq(tv[t+1,x,y,z], tu[t,x,y,z] + tu[t,x+1,y,z])',
           'Eq(tu[t+1,xi,yi,zi], tv[t+1,xi,yi,zi] + tv[t+1,xi+1,yi,zi])',
           'Eq(tw[t+1,x,y,z], tv[t+1,x,y,z] + tv[t+1,x+1,y,z])'),
-         '++++++++++', ['txyz', 'ti0xi0yi0z', 'txyz'], 'txyzi0xi0yi0zxyz'),
+         '++++++++++', ['txyz', 'txyz', 'txyz'], 'txyzxyzxyz'),
     ])
     def test_consistency_anti_dependences(self, exprs, directions, expected, visit):
         """


### PR DESCRIPTION
Making the PR to run it through CI and get some opinions. Still needs tests and probably the option to pass a keyword argument to `Operator` along the lines of `shorten_subdims=False` (lmk if anyone has a snappier name).