### PR TITLE
misc: Switch off develop-mode

### DIFF
--- a/devito/__init__.py
+++ b/devito/__init__.py
@@ -122,9 +122,10 @@ configuration.add('autotuning', 'off', accepted, callback=autotune_callback,
                   impacts_jit=False)
 
 # In develop-mode:
-# - Some optimizations may not be applied to the generated code.
-# - The compiler performs more type and value checking
-configuration.add('develop-mode', True, [False, True])
+# - The ALLOC_GUARD data allocator is used. This will trigger segfaults as soon
+#   as an out-of-bounds memory access is performed
+# - Some autoi-tuning optimizations are disabled
+configuration.add('develop-mode', False, [False, True])
 
 # Setup optimization level
 configuration.add('opt', 'advanced', list(operator_registry._accepted), deprecate='dle')

--- a/devito/data/data.py
+++ b/devito/data/data.py
@@ -3,7 +3,7 @@ from functools import wraps
 
 import numpy as np
 
-from devito.data.allocators import ALLOC_FLAT
+from devito.data.allocators import ALLOC_ALIGNED
 from devito.data.utils import *
 from devito.logger import warning
 from devito.parameters import configuration
@@ -28,7 +28,7 @@ class Data(np.ndarray):
     modulo : tuple of bool, optional
         If the i-th entry is True, then the i-th array dimension uses modulo indexing.
     allocator : MemoryAllocator, optional
-        Used to allocate memory. Defaults to ``ALLOC_FLAT``.
+        Used to allocate memory. Defaults to `ALLOC_ALIGNED`.
     distributor : Distributor, optional
         The distributor from which the original decomposition was produced. Note that
         the decomposition Parameter above may be different to distributor.decomposition.
@@ -44,8 +44,8 @@ class Data(np.ndarray):
     `Data`.
     """
 
-    def __new__(cls, shape, dtype, decomposition=None, modulo=None, allocator=ALLOC_FLAT,
-                distributor=None):
+    def __new__(cls, shape, dtype, decomposition=None, modulo=None,
+                allocator=ALLOC_ALIGNED, distributor=None):
         assert len(shape) == len(modulo)
         ndarray, memfree_args = allocator.alloc(shape, dtype)
         obj = ndarray.view(cls)

--- a/examples/compiler/01_data_regions.ipynb
+++ b/examples/compiler/01_data_regions.ipynb
@@ -491,6 +491,7 @@
    ],
    "source": [
     "u_pad = TimeFunction(name='u_pad', grid=grid, space_order=2, padding=(0,2,2))\n",
+    "u_pad._data_allocated[:] = 0\n",
     "u_pad.data_with_halo[:] = 1\n",
     "u_pad.data[:] = 2\n",
     "equation = Eq(u_pad.forward, u_pad + 2)\n",

--- a/tests/test_autotuner.py
+++ b/tests/test_autotuner.py
@@ -7,7 +7,7 @@ from devito.data import LEFT
 from devito.core.autotuning import options  # noqa
 
 
-@switchconfig(log_level='DEBUG')
+@switchconfig(log_level='DEBUG', develop_mode=True)
 @pytest.mark.parametrize("shape,expected", [
     ((30, 30), 13),
     ((30, 30, 30), 17)
@@ -113,6 +113,7 @@ def test_blocking_only():
     assert 'nthreads' not in op._state['autotuning'][0]['tuned']
 
 
+@switchconfig(develop_mode=True)
 def test_mixed_blocking_nthreads():
     grid = Grid(shape=(96, 96, 96))
     f = TimeFunction(name='f', grid=grid)
@@ -126,6 +127,7 @@ def test_mixed_blocking_nthreads():
     assert 'nthreads' in op._state['autotuning'][0]['tuned']
 
 
+@switchconfig(develop_mode=True)
 @pytest.mark.parametrize('openmp, expected', [
     (False, 2), (True, 3)
 ])
@@ -145,6 +147,7 @@ def test_mixed_blocking_w_skewing(openmp, expected):
         assert 'nthreads' not in op._state['autotuning'][0]['tuned']
 
 
+@switchconfig(develop_mode=True)
 @pytest.mark.parametrize('opt', ['advanced', ('blocking', {'skewing': True})])
 def test_tti_aggressive(opt):
     from test_dse import TestTTI
@@ -223,6 +226,7 @@ def test_at_w_mpi():
         assert np.all(f.data_ro_domain[1, 7] == 5)
 
 
+@switchconfig(develop_mode=True)
 def test_multiple_blocking():
     """
     Test that if there are more than one blocked Iteration nests, then
@@ -287,7 +291,7 @@ def test_hierarchical_blocking(opt_options):
     assert len(op._state['autotuning'][1]['tuned']) == 4
 
 
-@switchconfig(platform='cpu64-dummy')  # To fix the core count
+@switchconfig(platform='cpu64-dummy', develop_mode=True)  # `cpu64-dummy `to fix ncores
 @pytest.mark.parametrize('opt_options', [{'skewing': False}, {'skewing': True}])
 def test_multiple_threads(opt_options):
     """
@@ -307,7 +311,7 @@ def test_multiple_threads(opt_options):
 
 
 @skipif('cpu64-arm')
-@switchconfig(platform='knl7210')  # To trigger nested parallelism
+@switchconfig(platform='knl7210', develop_mode=True)  # `knl7210` for nested parallelsim
 def test_nested_nthreads():
     grid = Grid(shape=(96, 96, 96))
     f = TimeFunction(name='f', grid=grid)
@@ -323,6 +327,7 @@ def test_nested_nthreads():
     assert 'nthreads_nested' not in op._state['autotuning'][0]['tuned']
 
 
+@switchconfig(develop_mode=True)
 def test_few_timesteps():
     grid = Grid(shape=(16, 16, 16))
 

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -2,7 +2,8 @@ import pytest
 import numpy as np
 
 from devito import (Grid, Function, TimeFunction, SparseTimeFunction, Dimension, # noqa
-                    Eq, Operator, ALLOC_GUARD, ALLOC_FLAT, configuration, switchconfig)
+                    Eq, Operator, ALLOC_GUARD, ALLOC_ALIGNED, configuration,
+                    switchconfig)
 from devito.data import LEFT, RIGHT, Decomposition, loc_data_idx, convert_index
 from devito.tools import as_tuple
 from devito.types import Scalar
@@ -1494,7 +1495,7 @@ def test_oob_noguard():
     """
     # A tiny grid
     grid = Grid(shape=(4, 4))
-    u = Function(name='u', grid=grid, space_order=0, allocator=ALLOC_FLAT)
+    u = Function(name='u', grid=grid, space_order=0, allocator=ALLOC_ALIGNED)
     Operator(Eq(u[2000, 0], 1.0)).apply()
 
 


### PR DESCRIPTION
This was a legacy thing. Pointless.

In fact, potentially harmful for data transfer performance since aligned based addresses will result in higher performance with most device backends