### PR TITLE
compiler: Generate less integer arithmetic

### DIFF
--- a/devito/ir/clusters/cluster.py
+++ b/devito/ir/clusters/cluster.py
@@ -297,9 +297,9 @@ class Cluster(object):
                 continue
 
             intervals = [Interval(d,
-                                  min([minimum(i) for i in offs]),
-                                  max([maximum(i) for i in offs]))
-                         for d, offs in v.items()]
+                                  min([minimum(i, ispace=self.ispace) for i in o]),
+                                  max([maximum(i, ispace=self.ispace) for i in o]))
+                         for d, o in v.items()]
             intervals = IntervalGroup(intervals)
 
             # Factor in the IterationSpace -- if the min/max points aren't zero,

--- a/devito/ir/support/utils.py
+++ b/devito/ir/support/utils.py
@@ -308,30 +308,42 @@ def _relational(expr, callback, udims=None):
     return expr.subs(mapper)
 
 
-def minimum(expr, udims=None):
+def minimum(expr, udims=None, ispace=None):
     """
     Substitute the unbounded Dimensions in `expr` with their minimum point.
 
     Unbounded Dimensions whose possible minimum value is not known are ignored.
     """
-    return _relational(expr, lambda e: e._min, udims)
+    def callback(sd):
+        try:
+            return sd._min + ispace[sd].lower
+        except (TypeError, KeyError):
+            return sd._min
+
+    return _relational(expr, callback, udims)
 
 
-def maximum(expr, udims=None):
+def maximum(expr, udims=None, ispace=None):
     """
     Substitute the unbounded Dimensions in `expr` with their maximum point.
 
     Unbounded Dimensions whose possible maximum value is not known are ignored.
     """
-    return _relational(expr, lambda e: e._max, udims)
+    def callback(sd):
+        try:
+            return sd._max + ispace[sd].upper
+        except (TypeError, KeyError):
+            return sd._max
+
+    return _relational(expr, callback, udims)
 
 
-def extrema(expr):
+def extrema(expr, ispace=None):
     """
     The minimum and maximum extrema assumed by `expr` once the unbounded
     Dimensions are resolved.
     """
-    return Extrema(minimum(expr), maximum(expr))
+    return Extrema(minimum(expr, ispace=ispace), maximum(expr, ispace=ispace))
 
 
 def minmax_index(expr, d):

--- a/tests/test_unexpansion.py
+++ b/tests/test_unexpansion.py
@@ -93,7 +93,7 @@ class TestSymbolicCoeffs(object):
 
         # w0, w1, ...
         functions = FindSymbols().visit(op)
-        weights = [f for f in functions if isinstance(f, Weights)]
+        weights = {f for f in functions if isinstance(f, Weights)}
         assert len(weights) == expected
 
 


### PR DESCRIPTION
tiny PR that shifts the stencil loops by as much as needed so that we can index e.g. `w[i0] (i0=0)`instead of `w[i0 + 2] (i0 = -2)`  