### PR TITLE
mpi: Generate deterministic code for overlap mode

### DIFF
--- a/devito/mpi/halo_scheme.py
+++ b/devito/mpi/halo_scheme.py
@@ -11,7 +11,7 @@ from devito.data import CORE, OWNED, LEFT, CENTER, RIGHT
 from devito.ir.support import Forward, Scope
 from devito.symbolics.manipulation import _uxreplace_registry
 from devito.tools import (Reconstructable, Tag, as_tuple, filter_ordered, flatten,
-                          frozendict, is_integer)
+                          frozendict, is_integer, filter_sorted)
 from devito.types import Grid
 
 __all__ = ['HaloScheme', 'HaloSchemeEntry', 'HaloSchemeException', 'HaloTouch']
@@ -287,7 +287,8 @@ class HaloScheme(object):
         ranks*, so the output of this method is guaranteed to be consistent
         across *all MPI ranks*.
         """
-        items = [((d, CENTER), (d, LEFT), (d, RIGHT)) for d in self.dimensions]
+        items = [((d, CENTER), (d, LEFT), (d, RIGHT))
+                 for d in filter_sorted(self.dimensions)]
 
         processed = []
         for item in product(*items):


### PR DESCRIPTION
Overlap mode did not have deterministic code generation.

```c
static void remainder0(struct dataobj *restrict u_vec, const float a, const float dt, float r0, float r1, float r2, int t0, int t1, const int x_M, const int x_m, const int y_M, const int y_m, const int nthreads)
{
  compute0(a,u_vec,dt,r0,r1,r2,t0,t1,x_M - 2,x_m + 2,MIN(y_M, y_m + 1),y_m,nthreads);
  compute0(a,u_vec,dt,r0,r1,r2,t0,t1,x_M - 2,x_m + 2,y_M,MAX(y_m, y_M - 1),nthreads);
  compute0(a,u_vec,dt,r0,r1,r2,t0,t1,MIN(x_M, x_m + 1),x_m,y_M - 2,y_m + 2,nthreads);
  compute0(a,u_vec,dt,r0,r1,r2,t0,t1,MIN(x_M, x_m + 1),x_m,MIN(y_M, y_m + 1),y_m,nthreads);
  compute0(a,u_vec,dt,r0,r1,r2,t0,t1,MIN(x_M, x_m + 1),x_m,y_M,MAX(y_m, y_M - 1),nthreads);
  compute0(a,u_vec,dt,r0,r1,r2,t0,t1,x_M,MAX(x_m, x_M - 1),y_M - 2,y_m + 2,nthreads);
  compute0(a,u_vec,dt,r0,r1,r2,t0,t1,x_M,MAX(x_m, x_M - 1),MIN(y_M, y_m + 1),y_m,nthreads);
  compute0(a,u_vec,dt,r0,r1,r2,t0,t1,x_M,MAX(x_m, x_M - 1),y_M,MAX(y_m, y_M - 1),nthreads);
}
```

compute0 calls could have random order.

Also, MIN/MAX macros could have random order. (this is a side-effect, not overlap specific)


To reproduce, you could run a script multiple times with DEVITO_MPI=overlap