### PR TITLE
Correct the Poisson equation in the cavity flow example

### DIFF
--- a/examples/cfd/07_cavity_flow.ipynb
+++ b/examples/cfd/07_cavity_flow.ipynb
@@ -474,7 +474,7 @@
     "# First order derivatives will be handled with p.dxc\n",
     "eq_u =Eq(u.dt + u*u.dx + v*u.dy, -1./rho * p.dxc + nu*(u.laplace),  subdomain=grid.interior)\n",
     "eq_v =Eq(v.dt + u*v.dx + v*v.dy, -1./rho * p.dyc + nu*(v.laplace),  subdomain=grid.interior)\n",
-    "eq_p =Eq(p.laplace,rho*(1./dt*(u.dxc+v.dyc)-(u.dxc*u.dxc)+2*(u.dyc*v.dxc)+(v.dyc*v.dyc)),  subdomain=grid.interior)\n",
+    "eq_p =Eq(p.laplace,rho*(1./dt*(u.dxc+v.dyc)-(u.dxc*u.dxc)-2*(u.dyc*v.dxc)-(v.dyc*v.dyc)),  subdomain=grid.interior)\n",
     "\n",
     "# NOTE: Pressure has no time dependence so we solve for the other pressure buffer.\n",
     "stencil_u =solve(eq_u , u.forward)\n",


### PR DESCRIPTION
There is a sign mistake in the Poisson equation. It doesn't significantly affect the solution of this particular example, but it can be important when solving Navier Stokes for other problems.