### PR TITLE
compiler: Block reductions irrespective of par-tile

### DIFF
--- a/devito/core/cpu.py
+++ b/devito/core/cpu.py
@@ -43,7 +43,9 @@ class Cpu64OperatorMixin(object):
         o['blocklazy'] = oo.pop('blocklazy', not o['blockeager'])
         o['blockrelax'] = oo.pop('blockrelax', cls.BLOCK_RELAX)
         o['skewing'] = oo.pop('skewing', False)
-        o['par-tile'] = ParTile(oo.pop('par-tile', False), default=16)
+        o['par-tile'] = ParTile(oo.pop('par-tile', False), default=16,
+                                sparse=oo.pop('par-tile-sparse', None),
+                                reduce=oo.pop('par-tile-reduce', None))
 
         # CIRE
         o['min-storage'] = oo.pop('min-storage', False)

--- a/devito/core/gpu.py
+++ b/devito/core/gpu.py
@@ -65,7 +65,9 @@ class DeviceOperatorMixin(object):
         o['cire-schedule'] = oo.pop('cire-schedule', cls.CIRE_SCHEDULE)
 
         # GPU parallelism
-        o['par-tile'] = ParTile(oo.pop('par-tile', False), default=(32, 4, 4))
+        o['par-tile'] = ParTile(oo.pop('par-tile', False), default=(32, 4, 4),
+                                sparse=oo.pop('par-tile-sparse', None),
+                                reduce=oo.pop('par-tile-reduce', None))
         o['par-collapse-ncores'] = 1  # Always collapse (meaningful if `par-tile=False`)
         o['par-collapse-work'] = 1  # Always collapse (meaningful if `par-tile=False`)
         o['par-chunk-nonaffine'] = oo.pop('par-chunk-nonaffine', cls.PAR_CHUNK_NONAFFINE)

--- a/devito/core/operator.py
+++ b/devito/core/operator.py
@@ -341,7 +341,7 @@ class ParTileArg(UnboundTuple):
 
 class ParTile(UnboundedMultiTuple, OptOption):
 
-    def __new__(cls, items, default=None):
+    def __new__(cls, items, default=None, sparse=None, reduce=None):
         if not items:
             return UnboundedMultiTuple()
         elif isinstance(items, bool):
@@ -397,5 +397,7 @@ class ParTile(UnboundedMultiTuple, OptOption):
 
         obj = super().__new__(cls, *items)
         obj.default = as_tuple(default)
+        obj.sparse = as_tuple(sparse)
+        obj.reduce = as_tuple(reduce)
 
         return obj


### PR DESCRIPTION
Test is in PRO

I also took the chance to create opt-options to allow specifying different par-tiles for reduction loops