### PR TITLE
compiler: Revamp lowering of IndexDerivatives

### DIFF
--- a/devito/core/cpu.py
+++ b/devito/core/cpu.py
@@ -65,9 +65,12 @@ class Cpu64OperatorMixin(object):
         # Distributed parallelism
         o['dist-drop-unwritten'] = oo.pop('dist-drop-unwritten', cls.DIST_DROP_UNWRITTEN)
 
-        # Misc
+        # Code generation options for derivatives
         o['expand'] = oo.pop('expand', cls.EXPAND)
         o['deriv-schedule'] = oo.pop('deriv-schedule', cls.DERIV_SCHEDULE)
+        o['deriv-unroll'] = oo.pop('deriv-unroll', False)
+
+        # Misc
         o['opt-comms'] = oo.pop('opt-comms', True)
         o['linearize'] = oo.pop('linearize', False)
         o['mapify-reduce'] = oo.pop('mapify-reduce', cls.MAPIFY_REDUCE)

--- a/devito/core/cpu.py
+++ b/devito/core/cpu.py
@@ -67,6 +67,7 @@ class Cpu64OperatorMixin(object):
 
         # Misc
         o['expand'] = oo.pop('expand', cls.EXPAND)
+        o['deriv-schedule'] = oo.pop('deriv-schedule', cls.DERIV_SCHEDULE)
         o['opt-comms'] = oo.pop('opt-comms', True)
         o['linearize'] = oo.pop('linearize', False)
         o['mapify-reduce'] = oo.pop('mapify-reduce', cls.MAPIFY_REDUCE)

--- a/devito/core/cpu.py
+++ b/devito/core/cpu.py
@@ -67,7 +67,7 @@ class Cpu64OperatorMixin(object):
 
         # Misc
         o['expand'] = oo.pop('expand', cls.EXPAND)
-        o['optcomms'] = oo.pop('optcomms', True)
+        o['opt-comms'] = oo.pop('opt-comms', True)
         o['linearize'] = oo.pop('linearize', False)
         o['mapify-reduce'] = oo.pop('mapify-reduce', cls.MAPIFY_REDUCE)
         o['index-mode'] = oo.pop('index-mode', cls.INDEX_MODE)

--- a/devito/core/gpu.py
+++ b/devito/core/gpu.py
@@ -82,6 +82,7 @@ class DeviceOperatorMixin(object):
 
         # Misc
         o['expand'] = oo.pop('expand', cls.EXPAND)
+        o['deriv-schedule'] = oo.pop('deriv-schedule', cls.DERIV_SCHEDULE)
         o['opt-comms'] = oo.pop('opt-comms', True)
         o['linearize'] = oo.pop('linearize', False)
         o['mapify-reduce'] = oo.pop('mapify-reduce', cls.MAPIFY_REDUCE)

--- a/devito/core/gpu.py
+++ b/devito/core/gpu.py
@@ -82,7 +82,7 @@ class DeviceOperatorMixin(object):
 
         # Misc
         o['expand'] = oo.pop('expand', cls.EXPAND)
-        o['optcomms'] = oo.pop('optcomms', True)
+        o['opt-comms'] = oo.pop('opt-comms', True)
         o['linearize'] = oo.pop('linearize', False)
         o['mapify-reduce'] = oo.pop('mapify-reduce', cls.MAPIFY_REDUCE)
         o['index-mode'] = oo.pop('index-mode', cls.INDEX_MODE)

--- a/devito/core/gpu.py
+++ b/devito/core/gpu.py
@@ -80,9 +80,12 @@ class DeviceOperatorMixin(object):
         # Distributed parallelism
         o['dist-drop-unwritten'] = oo.pop('dist-drop-unwritten', cls.DIST_DROP_UNWRITTEN)
 
-        # Misc
+        # Code generation options for derivatives
         o['expand'] = oo.pop('expand', cls.EXPAND)
         o['deriv-schedule'] = oo.pop('deriv-schedule', cls.DERIV_SCHEDULE)
+        o['deriv-unroll'] = oo.pop('deriv-unroll', False)
+
+        # Misc
         o['opt-comms'] = oo.pop('opt-comms', True)
         o['linearize'] = oo.pop('linearize', False)
         o['mapify-reduce'] = oo.pop('mapify-reduce', cls.MAPIFY_REDUCE)

--- a/devito/core/operator.py
+++ b/devito/core/operator.py
@@ -1,7 +1,7 @@
 from collections.abc import Iterable
 
 from devito.core.autotuning import autotune
-from devito.exceptions import InvalidOperator
+from devito.exceptions import InvalidArgument, InvalidOperator
 from devito.logger import warning
 from devito.mpi.routines import mpi_registry
 from devito.parameters import configuration
@@ -149,6 +149,11 @@ class BasicOperator(Operator):
 
         if oo['mpi'] and oo['mpi'] not in cls.MPI_MODES:
             raise InvalidOperator("Unsupported MPI mode `%s`" % oo['mpi'])
+
+        if oo['deriv-schedule'] not in ('basic', 'smart'):
+            raise InvalidArgument("Illegal `deriv-schedule` value")
+        if oo['deriv-unroll'] not in (False, 'inner', 'full'):
+            raise InvalidArgument("Illegal `deriv-unroll` value")
 
     def _autotune(self, args, setup):
         if setup in [False, 'off']:

--- a/devito/core/operator.py
+++ b/devito/core/operator.py
@@ -96,6 +96,12 @@ class BasicOperator(Operator):
     finite-difference derivatives.
     """
 
+    DERIV_SCHEDULE = 'basic'
+    """
+    The schedule to use for the computation of finite-difference derivatives.
+    Only meaningful when `EXPAND=False`.
+    """
+
     MPI_MODES = tuple(mpi_registry)
     """
     The supported MPI modes.

--- a/devito/finite_differences/differentiable.py
+++ b/devito/finite_differences/differentiable.py
@@ -735,9 +735,9 @@ class Weights(Array):
 
 class IndexDerivative(IndexSum):
 
-    __rargs__ = ('expr', 'mapper', 'order')
+    __rargs__ = ('expr', 'mapper')
 
-    def __new__(cls, expr, mapper, order, **kwargs):
+    def __new__(cls, expr, mapper, **kwargs):
         dimensions = as_tuple(set(mapper.values()))
 
         # Detect the Weights among the arguments
@@ -758,12 +758,11 @@ class IndexDerivative(IndexSum):
         obj = super().__new__(cls, expr, dimensions)
         obj._weights = weights
         obj._mapper = frozendict(mapper)
-        obj._order = order
 
         return obj
 
     def _hashable_content(self):
-        return super()._hashable_content() + (self.mapper, self.order)
+        return super()._hashable_content() + (self.mapper,)
 
     def compare(self, other):
         if self is other:
@@ -786,14 +785,6 @@ class IndexDerivative(IndexSum):
     @property
     def mapper(self):
         return self._mapper
-
-    @property
-    def order(self):
-        return self._order
-
-    @property
-    def scaling(self):
-        return Mul(*[d.spacing**self.order for d in self.mapper])
 
     @property
     def depth(self):
@@ -936,7 +927,7 @@ def diff2sympy(expr):
 
         # Handle special objects
         if isinstance(obj, DiffDerivative):
-            return IndexDerivative(*args, obj.mapper, obj.order), True
+            return IndexDerivative(*args, obj.mapper), True
 
         # Handle generic objects such as arithmetic operations
         try:

--- a/devito/finite_differences/finite_difference.py
+++ b/devito/finite_differences/finite_difference.py
@@ -1,6 +1,6 @@
 from sympy import sympify
 
-from .differentiable import EvalDerivative, IndexDerivative, Weights
+from .differentiable import EvalDerivative, DiffDerivative, Weights
 from .tools import (numeric_weights, symbolic_weights, left, right,
                     generate_indices, centered, direct, transpose,
                     check_input, check_symbolic)
@@ -247,7 +247,7 @@ def make_derivative(expr, dim, fd_order, deriv_order, side, matvec, x0, symbolic
             # Pure number
             pass
 
-        deriv = IndexDerivative(expr*weights, {dim: indices.free_dim}, deriv_order)
+        deriv = DiffDerivative(expr*weights, {dim: indices.free_dim}, deriv_order)
     else:
         terms = []
         for i, c in zip(indices, weights):

--- a/devito/finite_differences/finite_difference.py
+++ b/devito/finite_differences/finite_difference.py
@@ -247,7 +247,7 @@ def make_derivative(expr, dim, fd_order, deriv_order, side, matvec, x0, symbolic
             # Pure number
             pass
 
-        deriv = DiffDerivative(expr*weights, {dim: indices.free_dim}, deriv_order)
+        deriv = DiffDerivative(expr*weights, {dim: indices.free_dim})
     else:
         terms = []
         for i, c in zip(indices, weights):

--- a/devito/finite_differences/finite_difference.py
+++ b/devito/finite_differences/finite_difference.py
@@ -247,7 +247,7 @@ def make_derivative(expr, dim, fd_order, deriv_order, side, matvec, x0, symbolic
             # Pure number
             pass
 
-        deriv = IndexDerivative(expr*weights, {dim: indices.free_dim})
+        deriv = IndexDerivative(expr*weights, {dim: indices.free_dim}, deriv_order)
     else:
         terms = []
         for i, c in zip(indices, weights):

--- a/devito/operator/operator.py
+++ b/devito/operator/operator.py
@@ -4,7 +4,6 @@ from operator import attrgetter
 from math import ceil
 
 from cached_property import cached_property
-import numpy as np
 from sympy import sympify
 
 from devito.arch import compiler_registry, platform_registry
@@ -1222,18 +1221,6 @@ def parse_kwargs(**kwargs):
     )
 
     # Normalize `subs`, if any
-    subs = {}
-    for k, v in kwargs.get('subs', {}).items():
-        if isinstance(v, np.floating):
-            # Cast to a Python float, as otherwise SymPy would behave as follows:
-            # sympy.Float(np.float32(10)) -> 10.0000
-            # sympy.Float(10) -> 10.0000000000000
-            v1 = float(v)
-        else:
-            # Other handlers might be added in the future
-            v1 = v
-
-        subs[k] = sympify(v1)
-    kwargs['subs'] = subs
+    kwargs['subs'] = {k: sympify(v) for k, v in kwargs.get('subs', {}).items()}
 
     return kwargs

--- a/devito/passes/clusters/derivatives.py
+++ b/devito/passes/clusters/derivatives.py
@@ -96,7 +96,7 @@ def _core(expr, c, weights, reusables, mapper, sregistry):
     try:
         w = weights[k]
     except KeyError:
-        w = weights[k] = w0._rebuild(name=name, dtype=expr.dtype)
+        w = weights[k] = w0._rebuild(name=name, dtype=c.dtype)
     expr = uxreplace(expr, {w0.indexed: w.indexed})
 
     dims = retrieve_dimensions(expr, deep=True)

--- a/devito/passes/clusters/derivatives.py
+++ b/devito/passes/clusters/derivatives.py
@@ -102,11 +102,13 @@ def _core(expr, c, weights, reusables, mapper, sregistry):
     dims = retrieve_dimensions(expr, deep=True)
     dims = filter_ordered(d for d in dims if isinstance(d, StencilDimension))
 
-    dims = tuple(reversed(dims))
-
     # If a StencilDimension already appears in `c.ispace`, perhaps with its custom
     # upper and lower offsets, we honor it
     dims = tuple(d for d in dims if d not in c.ispace)
+
+    # The IndexDerivative iteration Dimensions must be, by construction, the
+    # innermost ones
+    dims = tuple(sorted(dims, key=lambda d: d in expr.dimensions))
 
     intervals = [Interval(d) for d in dims]
     directions = {d: Backward if d.backward else Forward for d in dims}

--- a/devito/passes/clusters/derivatives.py
+++ b/devito/passes/clusters/derivatives.py
@@ -24,6 +24,7 @@ def lower_index_derivatives(clusters, mode=None, **kwargs):
     # previously were just not detectable via e.g. plain CSE. For example, if
     # there were two IndexDerivatives such as `(p.dx + m.dx).dx` and `m.dx.dx`
     # then it's only after `_lower_index_derivatives` that they're detectable!
+    # TODO: see https://github.com/devitocodes/devito/issues/2306
     clusters = CDE(mapper).process(clusters)
 
     return clusters
@@ -188,6 +189,9 @@ class CDE(Queue):
     """
     Common derivative elimination.
     """
+
+    _q_guards_in_key = True
+    _q_syncs_in_key = True
 
     def __init__(self, mapper):
         super().__init__()

--- a/devito/passes/iet/mpi.py
+++ b/devito/passes/iet/mpi.py
@@ -345,7 +345,7 @@ def mpiize(graph, **kwargs):
     """
     options = kwargs['options']
 
-    if options['optcomms']:
+    if options['opt-comms']:
         optimize_halospots(graph, **kwargs)
 
     mpimode = options['mpi']

--- a/tests/test_derivatives.py
+++ b/tests/test_derivatives.py
@@ -6,7 +6,7 @@ from devito import (Grid, Function, TimeFunction, Eq, Operator, NODE, cos, sin,
                     ConditionalDimension, left, right, centered, div, grad)
 from devito.finite_differences import Derivative, Differentiable
 from devito.finite_differences.differentiable import (Add, EvalDerivative, IndexSum,
-                                                      IndexDerivative, Weights)
+                                                      IndexDerivative, Weights, Pow)
 from devito.symbolics import indexify, retrieve_indexed
 from devito.types.dimension import StencilDimension
 
@@ -708,24 +708,26 @@ class TestTwoStageEvaluation(object):
         grid = Grid((10,))
         x, = grid.dimensions
 
+        so = 2
         i = StencilDimension('i', 0, 2)
 
-        u = Function(name="u", grid=grid, space_order=2)
+        u = Function(name="u", grid=grid, space_order=so)
 
         ui = u.subs(x, x + i*x.spacing)
         w = Weights(name='w0', dimensions=i, initvalue=[-0.5, 0, 0.5])
 
-        idxder = IndexDerivative(ui*w, {x: i})
+        idxder = IndexDerivative(ui*w, {x: i}, so)
 
+        assert idxder.scaling == Pow(x.spacing, so)
         assert idxder.evaluate == -0.5*u + 0.5*ui.subs(i, 2)
 
         # Make sure subs works as expected
-        v = Function(name="v", grid=grid, space_order=2)
+        v = Function(name="v", grid=grid, space_order=so)
 
         vi0 = v.subs(x, x + i*x.spacing)
         vi1 = idxder.subs(ui, vi0)
 
-        assert IndexDerivative(vi0*w, {x: i}) == vi1
+        assert IndexDerivative(vi0*w, {x: i}, so) == vi1
 
     def test_dx2(self):
         grid = Grid(shape=(4, 4))

--- a/tests/test_derivatives.py
+++ b/tests/test_derivatives.py
@@ -6,7 +6,7 @@ from devito import (Grid, Function, TimeFunction, Eq, Operator, NODE, cos, sin,
                     ConditionalDimension, left, right, centered, div, grad)
 from devito.finite_differences import Derivative, Differentiable
 from devito.finite_differences.differentiable import (Add, EvalDerivative, IndexSum,
-                                                      IndexDerivative, Weights, Pow)
+                                                      IndexDerivative, Weights)
 from devito.symbolics import indexify, retrieve_indexed
 from devito.types.dimension import StencilDimension
 
@@ -716,9 +716,8 @@ class TestTwoStageEvaluation(object):
         ui = u.subs(x, x + i*x.spacing)
         w = Weights(name='w0', dimensions=i, initvalue=[-0.5, 0, 0.5])
 
-        idxder = IndexDerivative(ui*w, {x: i}, so)
+        idxder = IndexDerivative(ui*w, {x: i})
 
-        assert idxder.scaling == Pow(x.spacing, so)
         assert idxder.evaluate == -0.5*u + 0.5*ui.subs(i, 2)
 
         # Make sure subs works as expected
@@ -727,7 +726,7 @@ class TestTwoStageEvaluation(object):
         vi0 = v.subs(x, x + i*x.spacing)
         vi1 = idxder.subs(ui, vi0)
 
-        assert IndexDerivative(vi0*w, {x: i}, so) == vi1
+        assert IndexDerivative(vi0*w, {x: i}) == vi1
 
     def test_dx2(self):
         grid = Grid(shape=(4, 4))

--- a/tests/test_operator.py
+++ b/tests/test_operator.py
@@ -1572,7 +1572,7 @@ class TestLoopScheduling(object):
 
         # Note: `topofuse` is a subset of `advanced` mode. We use it merely to
         # bypass 'blocking', which would complicate the asserts below
-        op = Operator(eqns, opt=('topofuse', {'openmp': False, 'optcomms': False}))
+        op = Operator(eqns, opt=('topofuse', {'openmp': False, 'opt-comms': False}))
 
         trees = retrieve_iteration_tree(op)
         iters = FindNodes(Iteration).visit(op)

--- a/tests/test_unexpansion.py
+++ b/tests/test_unexpansion.py
@@ -324,9 +324,11 @@ class Test1Pass(object):
         assert len(get_arrays(op)) == 0
         assert op._profiler._sections['section0'].sops == 74
         exprs = FindNodes(Expression).visit(op)
-        assert len(exprs) == 6
+        assert len(exprs) == 5
         temps = [i for i in FindSymbols().visit(exprs) if isinstance(i, Symbol)]
         assert len(temps) == 2
+
+        op.cfunction
 
 
 class Test2Pass(object):


### PR DESCRIPTION
This paves the way for external customisation, e.g.

* `w[i]*u[x + i]` vs `w[i]*(u[x + i] - u[x - i])`
* loops vs unroll
* etc