### PR TITLE
ci: Update actions for nodejs version deprecation

### DIFF
--- a/.github/workflows/asv.yml
+++ b/.github/workflows/asv.yml
@@ -36,7 +36,7 @@ jobs:
 
     steps:
     - name: Checkout devito
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Set VIRTUAL_ENV
       run: |
@@ -61,7 +61,7 @@ jobs:
         asv run -v --show-stderr --config benchmarks/regression/asv.conf.json --cpu-affinity 0-7 --machine i7-6700K
 
     - name: Checkout asv-results branch
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         ref: asv-results
         clean: false

--- a/.github/workflows/docker-bases.yml
+++ b/.github/workflows/docker-bases.yml
@@ -31,7 +31,7 @@ jobs:
 
     steps:
       - name: Checkout devito
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Check event name
         run: echo ${{ github.event_name }}
@@ -72,7 +72,7 @@ jobs:
 
     steps:
       - name: Checkout devito
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Check event name
         run: echo ${{ github.event_name }}
@@ -133,7 +133,7 @@ jobs:
 
     steps:
       - name: Checkout devito
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Check event name
         run: echo ${{ github.event_name }}
@@ -194,7 +194,7 @@ jobs:
 
     steps:
       - name: Checkout devito
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Check event name
         run: echo ${{ github.event_name }}

--- a/.github/workflows/docker-devito.yml
+++ b/.github/workflows/docker-devito.yml
@@ -45,7 +45,7 @@ jobs:
 
     steps:
       - name: Checkout devito
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Check event name
         run: echo ${{ github.event_name }}

--- a/.github/workflows/examples-mpi.yml
+++ b/.github/workflows/examples-mpi.yml
@@ -46,7 +46,7 @@ jobs:
 
     steps:
     - name: Checkout devito
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Setup MPI
       uses: mpi4py/setup-mpi@v1

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -34,7 +34,7 @@ jobs:
 
     steps:
     - name: Checkout devito
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Setup conda
       uses: conda-incubator/setup-miniconda@v2
@@ -87,7 +87,7 @@ jobs:
         python examples/cfd/example_diffusion.py
 
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         name: ${{ matrix.name }}

--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -20,9 +20,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python 3.9
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: 3.9
     - name: Install dependencies

--- a/.github/workflows/pytest-core-mpi.yml
+++ b/.github/workflows/pytest-core-mpi.yml
@@ -30,12 +30,12 @@ jobs:
       CXX: "g++-9"
 
     steps:
-    - uses: actions/setup-python@v4
+    - uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
 
     - name: Checkout devito
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Install dependencies
       run: |
@@ -49,7 +49,7 @@ jobs:
         python3 -m pytest --cov --cov-config=.coveragerc --cov-report=xml -m parallel tests/
 
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         name: pytest-mpi
@@ -70,7 +70,7 @@ jobs:
       
       steps:
       - name: Checkout devito
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       
       - name: Build docker image
         run: |

--- a/.github/workflows/pytest-core-nompi.yml
+++ b/.github/workflows/pytest-core-nompi.yml
@@ -117,11 +117,11 @@ jobs:
 
     steps:
     - name: Checkout devito
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Set up Python ${{ matrix.python-version }}
       if: "!contains(matrix.name, 'docker')"
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
 
@@ -176,7 +176,7 @@ jobs:
 
     - name: Upload coverage to Codecov
       if: "!contains(matrix.name, 'docker')"
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         name: ${{ matrix.name }}

--- a/.github/workflows/pytest-gpu.yml
+++ b/.github/workflows/pytest-gpu.yml
@@ -70,7 +70,7 @@ jobs:
 
     steps:
     - name: Checkout devito
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Build docker image
       run: |

--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -8,9 +8,9 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: '3.x'
     - name: Install dependencies

--- a/.github/workflows/triggers.yml
+++ b/.github/workflows/triggers.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Trigger doc build
       uses: peter-evans/repository-dispatch@v2

--- a/.github/workflows/tutorials.yml
+++ b/.github/workflows/tutorials.yml
@@ -52,11 +52,11 @@ jobs:
 
     steps:
     - name: Checkout devito
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Set up Python 3.9
       if: "!contains(matrix.name, 'docker')"
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: 3.9
 


### PR DESCRIPTION
To address this warning:

Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3, actions/setup-python@v4, codecov/codecov-action@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.