### PR TITLE
Ensure compiler check catches permission errors

### DIFF
--- a/tests/test_error_checking.py
+++ b/tests/test_error_checking.py
@@ -1,8 +1,9 @@
 import pytest
+import re
 
 from devito import Grid, Function, TimeFunction, Eq, Operator, switchconfig
 from devito.exceptions import ExecutionError
-
+from devito.arch.compiler import sniff_compiler_version
 
 @switchconfig(safe_math=True)
 @pytest.mark.parametrize("expr", [
@@ -25,3 +26,11 @@ def test_stability(expr):
 
     with pytest.raises(ExecutionError):
         op.apply(time_M=200, dt=.1)
+
+@pytest.mark.parametrize("cc", [
+    "doesn'texist",
+    "/root/doesn'texist",
+])
+def test_sniff_compiler_version(cc):
+    with pytest.raises(SystemExit) as e:
+        sniff_compiler_version(cc)


### PR DESCRIPTION
I added a test for #2336, but I'm not sure if it will actually error on the bug I was encountering, so I'd like to run the standard test suite to make sure.

Closes #2336 