### PR TITLE
compiler: Fix ConditionalDimensions on SubDomains

### DIFF
--- a/devito/ir/clusters/algorithms.py
+++ b/devito/ir/clusters/algorithms.py
@@ -238,7 +238,7 @@ def guard(clusters):
                 if cd._factor is not None:
                     k = d
                 else:
-                    dims = pull_dims(cd.condition)
+                    dims = pull_dims(cd.condition, flag=False)  # Don't want parent dims
                     k = max(dims, default=d, key=lambda i: c.ispace.index(i))
 
                 # Pull `cd` from any expr


### PR DESCRIPTION
Tweak dimension extraction from conditions so that ConditionalDimensions can have SubDimension parents.

Now you can do
```
class Middle(SubDomain):
    name = 'middle'
    def define(self, dimensions):
        return {x: x, y: ('middle', 2, 4)}
mid = Middle() 
my_grid = Grid(shape = shape, subdomains = (mid, ))

_, yi = mid.dimensions
condition = Lt(sdf, 1).subs(y, yi)
ci = ConditionalDimension(name='ci', condition=condition, parent=yi)
```
and the `ConditionalDimension` will be nested inside the `SubDimension` in the generated loops.