### PR TITLE
compiler: fix cse with different conditionals

### DIFF
--- a/devito/ir/support/utils.py
+++ b/devito/ir/support/utils.py
@@ -186,7 +186,7 @@ def detect_accesses(exprs):
     other_dims = set()
     for e in as_tuple(exprs):
         other_dims.update(i for i in e.free_symbols if isinstance(i, Dimension))
-        other_dims.update(e.implicit_dims)
+        other_dims.update(e.implicit_dims or {})
     other_dims = filter_sorted(other_dims)
     mapper[None] = Stencil([(i, 0) for i in other_dims])
 

--- a/devito/types/equation.py
+++ b/devito/types/equation.py
@@ -5,7 +5,7 @@ import sympy
 from functools import cached_property
 
 from devito.finite_differences import default_rules
-from devito.tools import as_tuple
+from devito.tools import as_tuple, frozendict
 from devito.types.lazy import Evaluable
 
 __all__ = ['Eq', 'Inc', 'ReduceMax', 'ReduceMin']
@@ -139,7 +139,7 @@ class Eq(sympy.Eq, Evaluable):
 
     @property
     def conditionals(self):
-        return None
+        return frozendict()
 
     @cached_property
     def _uses_symbolic_coefficients(self):

--- a/devito/types/equation.py
+++ b/devito/types/equation.py
@@ -137,6 +137,10 @@ class Eq(sympy.Eq, Evaluable):
     def implicit_dims(self):
         return self._implicit_dims
 
+    @property
+    def conditionals(self):
+        return None
+
     @cached_property
     def _uses_symbolic_coefficients(self):
         return bool(self._symbolic_functions)

--- a/tests/test_dse.py
+++ b/tests/test_dse.py
@@ -2783,7 +2783,7 @@ class TestIsoAcoustic:
 
         assert summary1[('section0', None)].ops == 31
         assert summary1[('section1', None)].ops == 88
-        assert summary1[('section2', None)].ops == 28
+        assert summary1[('section2', None)].ops == 25
         assert np.isclose(summary1[('section0', None)].oi, 1.767, atol=0.001)
 
         assert np.allclose(u0.data, u1.data, atol=10e-5)


### PR DESCRIPTION
Fix cse to make sure expression from different conditionals get properly handled.

avoids things like

```
if (a){
  f1 = expr
 }
if (b){
  f1 = expr
 }
```


to be converted to

```
if (a){
  r0 = expr
  f1 = r0
 }
if (b){
  f1 = r0
 }
```

CSE now counts expression based on the equation's conditional. We could also just lift all `rxx` out of conditionals but that would be computing those cse temps way more than needed which I don't think it great
