### PR TITLE
dsl: Make CondEq and CondNe easier to import

### DIFF
--- a/devito/__init__.py
+++ b/devito/__init__.py
@@ -22,6 +22,7 @@ from devito.types.tensor import *  # noqa
 from devito.finite_differences import *  # noqa
 from devito.operations.solve import *
 from devito.operator import Operator  # noqa
+from devito.symbolics import CondEq, CondNe  # noqa
 
 # Other stuff exposed to the user
 from devito.builtins import *  # noqa


### PR DESCRIPTION
Allow import of `CondEq` and `CondNe` from `devito` rather than requiring `devito.symbolics`. In due course, these should probably move to `devito.types.relational` and use the `AbstractRel` mixin.