### PR TITLE
compiler: Tweak par-tile unrolling and revamp MPI topology

### DIFF
--- a/devito/__init__.py
+++ b/devito/__init__.py
@@ -71,12 +71,18 @@ configuration.add('compiler', 'custom', compiler_registry,
 # Setup language for shared-memory parallelism
 preprocessor = lambda i: {0: 'C', 1: 'openmp'}.get(i, i)  # Handles DEVITO_OPENMP deprec
 configuration.add('language', 'C', [0, 1] + list(operator_registry._languages),
-                  preprocessor=preprocessor, callback=reinit_compiler, deprecate='openmp')
+                  preprocessor=preprocessor, callback=reinit_compiler,
+                  deprecate='openmp')
 
 # MPI mode (0 => disabled, 1 == basic)
 preprocessor = lambda i: bool(i) if isinstance(i, int) else i
 configuration.add('mpi', 0, [0, 1] + list(mpi_registry),
                   preprocessor=preprocessor, callback=reinit_compiler)
+
+# Domain decomposition topology. Only relevant with MPI
+preprocessor = lambda i: CustomTopology._shortcuts.get(i)
+configuration.add('topology', None, [None] + list(CustomTopology._shortcuts),
+                  preprocessor=preprocessor)
 
 # Should Devito run a first-touch Operator upon data allocation?
 configuration.add('first-touch', 0, [0, 1], preprocessor=bool, impacts_jit=False)

--- a/devito/core/operator.py
+++ b/devito/core/operator.py
@@ -430,3 +430,7 @@ class ParTile(UnboundedMultiTuple, OptOption):
         obj.reduce = as_tuple(reduce)
 
         return obj
+
+    @property
+    def is_multi(self):
+        return len(self) > 1

--- a/devito/mpi/distributed.py
+++ b/devito/mpi/distributed.py
@@ -242,9 +242,7 @@ class Distributor(AbstractDistributor):
                 self._topology = compute_dims(self._input_comm.size, len(shape))
             else:
                 # A custom topology may contain integers or the wildcard '*'
-                topology = CustomTopology(topology, self._input_comm)
-
-                self._topology = topology
+                self._topology = CustomTopology(topology, self._input_comm)
 
             if self._input_comm is not input_comm:
                 # By default, Devito arranges processes into a cartesian topology.
@@ -634,8 +632,9 @@ class CustomTopology(tuple):
 
     Examples
     --------
-    For example, let's consider a domain with three distributed dimensions: x, y, and z,
-    and an MPI communicator with N processes. Here are a few examples of CustomTopology:
+    For example, let's consider a domain with three distributed dimensions: x,
+    y, and z, and an MPI communicator with N processes. Here are a few examples
+    of CustomTopology:
 
     With N known, say N=4:
     * `(1, 1, 4)`: the z Dimension is decomposed into 4 chunks
@@ -643,14 +642,15 @@ class CustomTopology(tuple):
                    is decomposed into 2 chunks
 
     With N unknown:
-    * `(1, '*', 1)`: the wildcard `'*'` indicates that the runtime should decompose the y
-                     Dimension into N chunks
-    * `('*', '*', 1)`: the wildcard `'*'` indicates that the runtime should decompose both
-                       the x and y Dimensions in `nstars` factors of N, prioritizing
-                       the outermost dimension
+    * `(1, '*', 1)`: the wildcard `'*'` indicates that the runtime should
+                     decompose the y Dimension into N chunks
+    * `('*', '*', 1)`: the wildcard `'*'` indicates that the runtime should
+                       decompose both the x and y Dimensions in `nstars` factors
+                       of N, prioritizing the outermost dimension
 
-    Assuming that the number of ranks `N` cannot evenly be decomposed to the requested
-    stars=6 we decompose as evenly as possible by prioritising the outermost dimension
+    Assuming that the number of ranks `N` cannot evenly be decomposed to the
+    requested stars=6 we decompose as evenly as possible by prioritising the
+    outermost dimension
 
     For N=3
     * `('*', '*', 1)` gives: (3, 1, 1)
@@ -673,6 +673,13 @@ class CustomTopology(tuple):
     Users should not directly use the CustomTopology class. It is instantiated
     by the Devito runtime based on user input.
     """
+
+    _shortcuts = {
+        'x': ('*', 1, 1),
+        'y': (1, '*', 1),
+        'z': (1, 1, '*'),
+        'xy': ('*', '*', 1),
+    }
 
     def __new__(cls, items, input_comm):
         # Keep track of nstars and already defined decompositions

--- a/devito/parameters.py
+++ b/devito/parameters.py
@@ -146,6 +146,7 @@ env_vars_mapper = {
     'DEVITO_DEVELOP': 'develop-mode',
     'DEVITO_OPT': 'opt',
     'DEVITO_MPI': 'mpi',
+    'DEVITO_TOPOLOGY': 'topology',
     'DEVITO_LANGUAGE': 'language',
     'DEVITO_AUTOTUNING': 'autotuning',
     'DEVITO_LOGGING': 'log-level',

--- a/devito/passes/clusters/blocking.py
+++ b/devito/passes/clusters/blocking.py
@@ -502,30 +502,33 @@ class BlockSizeGenerator:
 
     def __init__(self, par_tile):
         self.tip = -1
-
-        # The default par-tile, as an UnboundedMultiTuple. It will be used
-        # for most cases
         self.umt = par_tile
 
-        # Special case 1: a smaller par-tile to avoid under-utilizing
-        # computational resources when the iteration spaces are too small
-        self.umt_small = UnboundedMultiTuple(par_tile.default)
-
-        # Special case 2: par-tiles for iteration spaces that must be fully
-        # blocked for correctness
-        if par_tile.sparse:
-            self.umt_sparse = UnboundTuple(*par_tile.sparse, 1)
-        elif len(par_tile) == 1:
-            self.umt_sparse = UnboundTuple(*par_tile[0], 1)
+        if par_tile.is_multi:
+            # The user has supplied one specific par-tile per blocked nest
+            self.umt_small = par_tile
+            self.umt_sparse = par_tile
+            self.umt_reduce = par_tile
         else:
-            self.umt_sparse = UnboundTuple(*par_tile.default, 1)
+            # Special case 1: a smaller par-tile to avoid under-utilizing
+            # computational resources when the iteration spaces are too small
+            self.umt_small = UnboundedMultiTuple(par_tile.default)
 
-        if par_tile.reduce:
-            self.umt_reduce = UnboundTuple(*par_tile.reduce, 1)
-        elif len(par_tile) == 1:
-            self.umt_reduce = UnboundTuple(*par_tile[0], 1)
-        else:
-            self.umt_reduce = UnboundTuple(*par_tile.default, 1)
+            # Special case 2: par-tiles for iteration spaces that must be fully
+            # blocked for correctness
+            if par_tile.sparse:
+                self.umt_sparse = UnboundTuple(*par_tile.sparse, 1)
+            elif len(par_tile) == 1:
+                self.umt_sparse = UnboundTuple(*par_tile[0], 1)
+            else:
+                self.umt_sparse = UnboundTuple(*par_tile.default, 1)
+
+            if par_tile.reduce:
+                self.umt_reduce = UnboundTuple(*par_tile.reduce, 1)
+            elif len(par_tile) == 1:
+                self.umt_reduce = UnboundTuple(*par_tile[0], 1)
+            else:
+                self.umt_reduce = UnboundTuple(*par_tile.default, 1)
 
     def next(self, prefix, d, clusters):
         # If a whole new set of Dimensions, move the tip -- this means `clusters`

--- a/tests/test_mpi.py
+++ b/tests/test_mpi.py
@@ -228,6 +228,16 @@ class TestDistributor:
         custom_topology = CustomTopology(topology, dummy_comm)
         assert custom_topology == dist_topology
 
+    @pytest.mark.parallel(mode=[(4, 'diag2')])
+    @switchconfig(topology='y')
+    def test_custom_topology_fallback(self, mode):
+        grid = Grid(shape=(16,))
+        f = Function(name='f', grid=grid)
+
+        # The input topology was `y` but Grid only has one axis, so we decompose
+        # along that instead
+        assert f.shape == (4,)
+
 
 class TestFunction:
 


### PR DESCRIPTION
Admittedly two orthogonal things