### PR TITLE
dsl: Fix missing sympy assumptions during rebuilding

### DIFF
--- a/devito/tools/abc.py
+++ b/devito/tools/abc.py
@@ -143,6 +143,14 @@ class Reconstructable:
 
         kwargs.update({i: getattr(self, i) for i in self.__rkwargs__ if i not in kwargs})
 
+        # If this object has SymPy assumptions associated with it, which were not
+        # in the kwargs, then include them
+        try:
+            assumptions = self._assumptions_orig
+            kwargs.update({k: v for k, v in assumptions.items() if k not in kwargs})
+        except AttributeError:
+            pass
+
         # Should we use a custom reconstructor?
         try:
             cls = self._rcls

--- a/devito/types/basic.py
+++ b/devito/types/basic.py
@@ -332,19 +332,29 @@ class AbstractSymbol(sympy.Symbol, Basic, Pickable, Evaluable):
     is_imaginary = False
     is_commutative = True
 
-    __rkwargs__ = ('name', 'dtype', 'is_const')
+    __rkwargs__ = ('name', 'dtype', 'is_const', 'assumptions0')
 
     @classmethod
     def _filter_assumptions(cls, **kwargs):
         """Extract sympy.Symbol-specific kwargs."""
+        assumptions0 = kwargs.get('assumptions0', {})
+
         assumptions = {}
-        # pop predefined assumptions
+        # Pop predefined assumptions
         for key in ('real', 'imaginary', 'commutative'):
             kwargs.pop(key, None)
-        # extract sympy.Symbol-specific kwargs
+            assumptions0.pop(key, None)
+
+        # Extract sympy.Symbol-specific kwargs
         for i in list(kwargs):
             if i in _assume_rules.defined_facts:
                 assumptions[i] = kwargs.pop(i)
+
+        # Extract any remaining unset assumptions
+        for k, v in assumptions0.items():
+            if k not in assumptions:
+                assumptions[k] = v
+
         return assumptions, kwargs
 
     def __new__(cls, *args, **kwargs):

--- a/devito/types/basic.py
+++ b/devito/types/basic.py
@@ -332,29 +332,20 @@ class AbstractSymbol(sympy.Symbol, Basic, Pickable, Evaluable):
     is_imaginary = False
     is_commutative = True
 
-    __rkwargs__ = ('name', 'dtype', 'is_const', 'assumptions0')
+    __rkwargs__ = ('name', 'dtype', 'is_const')
 
     @classmethod
     def _filter_assumptions(cls, **kwargs):
         """Extract sympy.Symbol-specific kwargs."""
-        assumptions0 = kwargs.get('assumptions0', {})
-
         assumptions = {}
         # Pop predefined assumptions
         for key in ('real', 'imaginary', 'commutative'):
             kwargs.pop(key, None)
-            assumptions0.pop(key, None)
 
         # Extract sympy.Symbol-specific kwargs
         for i in list(kwargs):
             if i in _assume_rules.defined_facts:
                 assumptions[i] = kwargs.pop(i)
-
-        # Extract any remaining unset assumptions
-        for k, v in assumptions0.items():
-            if k not in assumptions:
-                assumptions[k] = v
-
         return assumptions, kwargs
 
     def __new__(cls, *args, **kwargs):

--- a/tests/test_caching.py
+++ b/tests/test_caching.py
@@ -11,6 +11,7 @@ from devito import (Grid, Function, TimeFunction, SparseFunction, SparseTimeFunc
                     TensorFunction, TensorTimeFunction, VectorTimeFunction)
 from devito.types import (DeviceID, NThreadsBase, NPThreads, Object, LocalObject,
                           Scalar, Symbol, ThreadID)
+from devito.types.basic import AbstractSymbol
 
 
 @pytest.fixture
@@ -43,6 +44,16 @@ class TestHashing:
     """
     Test hashing of symbolic objects.
     """
+
+    def test_abstractsymbol(self):
+        """Test that different Symbols have different hash values."""
+        s0 = AbstractSymbol('s')
+        s1 = AbstractSymbol('s')
+        assert s0 is not s1
+        assert hash(s0) == hash(s1)
+
+        s2 = AbstractSymbol('s', nonnegative=True)
+        assert hash(s0) != hash(s2)
 
     def test_constant(self):
         """Test that different Constants have different hash value."""

--- a/tests/test_pickle.py
+++ b/tests/test_pickle.py
@@ -18,7 +18,7 @@ from devito.types import (Array, CustomDimension, Symbol as dSymbol, Scalar,
                           PointerArray, Lock, PThreadArray, SharedData, Timer,
                           DeviceID, NPThreads, ThreadID, TempFunction, Indirection,
                           FIndexed)
-from devito.types.basic import BoundSymbol
+from devito.types.basic import BoundSymbol, AbstractSymbol
 from devito.tools import EnrichedTuple
 from devito.symbolics import (IntDiv, ListInitializer, FieldFromPointer,
                               CallFromPointer, DefFunction)
@@ -28,6 +28,22 @@ from examples.seismic import (demo_model, AcquisitionGeometry,
 
 @pytest.mark.parametrize('pickle', [pickle0, pickle1])
 class TestBasic:
+
+    def test_abstractsymbol(self, pickle):
+        s0 = AbstractSymbol('s')
+        s1 = AbstractSymbol('s', nonnegative=True, integer=False)
+
+        pkl_s0 = pickle.dumps(s0)
+        pkl_s1 = pickle.dumps(s1)
+
+        new_s0 = pickle.loads(pkl_s0)
+        new_s1 = pickle.loads(pkl_s1)
+
+        assert s0.assumptions0 == new_s0.assumptions0
+        assert s1.assumptions0 == new_s1.assumptions0
+
+        assert s0 == new_s0
+        assert s1 == new_s1
 
     def test_constant(self, pickle):
         c = Constant(name='c')

--- a/tests/test_symbolics.py
+++ b/tests/test_symbolics.py
@@ -97,6 +97,12 @@ def test_sympy_assumptions():
     assert s1.assumptions0 == s1r.assumptions0
     assert s1 == s1r
 
+    # Check that sympy assumptions can be changed during a rebuild
+    s2 = s0._rebuild(nonnegative=True, integer=False, real=True)
+
+    assert s2.assumptions0 == s1.assumptions0
+    assert s2 == s1
+
 
 def test_constant():
     c = Constant(name='c')

--- a/tests/test_symbolics.py
+++ b/tests/test_symbolics.py
@@ -97,7 +97,14 @@ def test_sympy_assumptions():
     assert s1.assumptions0 == s1r.assumptions0
     assert s1 == s1r
 
-    # Check that sympy assumptions can be changed during a rebuild
+
+def test_modified_sympy_assumptions():
+    """
+    Check that sympy assumptions can be changed during a rebuild.
+    """
+    s0 = AbstractSymbol('s')
+    s1 = AbstractSymbol('s', nonnegative=True, integer=False, real=True)
+
     s2 = s0._rebuild(nonnegative=True, integer=False, real=True)
 
     assert s2.assumptions0 == s1.assumptions0

--- a/tests/test_symbolics.py
+++ b/tests/test_symbolics.py
@@ -17,6 +17,7 @@ from devito.symbolics import (retrieve_functions, retrieve_indexed, evalrel,  # 
 from devito.tools import as_tuple
 from devito.types import (Array, Bundle, FIndexed, LocalObject, Object,
                           Symbol as dSymbol)
+from devito.types.basic import AbstractSymbol
 
 
 def test_float_indices():
@@ -68,6 +69,33 @@ def test_floatification_issue_1627(dtype, expected):
     exprs = FindNodes(Expression).visit(op)
     assert len(exprs) == 2
     assert str(exprs[0]) == expected
+
+
+def test_sympy_assumptions():
+    """
+    Ensure that AbstractSymbol assumptions are set correctly and
+    preserved during rebuild.
+    """
+    s0 = AbstractSymbol('s')
+    s1 = AbstractSymbol('s', nonnegative=True, integer=False, real=True)
+
+    assert s0.is_negative is None
+    assert s0.is_positive is None
+    assert s0.is_integer is None
+    assert s0.is_real is True
+    assert s1.is_negative is False
+    assert s1.is_positive is True
+    assert s1.is_integer is False
+    assert s1.is_real is True
+
+    s0r = s0._rebuild()
+    s1r = s1._rebuild()
+
+    assert s0.assumptions0 == s0r.assumptions0
+    assert s0 == s0r
+
+    assert s1.assumptions0 == s1r.assumptions0
+    assert s1 == s1r
 
 
 def test_constant():


### PR DESCRIPTION
SymPy assumptions currently disappear when objects inheriting from `sympy.Symbol` are rebuilt. This PR adds a patch and tests.

#2431 needs rebasing on this patch.