### PR TITLE
api: enforce sympy shifts

### DIFF
--- a/.github/workflows/pytest-core-nompi.yml
+++ b/.github/workflows/pytest-core-nompi.yml
@@ -149,7 +149,7 @@ jobs:
       run : |
           if [ "${{ runner.os }}" == 'macOS' ]; then
             brew install llvm libomp
-            echo "/opt/homebrew/bin:/opt/homebrew/opt/llvm/bin" >> $GITHUB_PATH
+            echo "/opt/homebrew/opt/llvm/bin" >> $GITHUB_PATH
           fi
       id: set-tests
     

--- a/devito/finite_differences/tools.py
+++ b/devito/finite_differences/tools.py
@@ -2,7 +2,7 @@ from functools import wraps, partial
 from itertools import product
 
 import numpy as np
-from sympy import S, finite_diff_weights, cacheit, sympify, Function
+from sympy import S, finite_diff_weights, cacheit, sympify, Function, Rational
 
 from devito.tools import Tag, as_tuple
 from devito.types.dimension import StencilDimension
@@ -308,8 +308,8 @@ def make_shift_x0(shift, ndim):
     """
     if shift is None:
         return lambda s, d, i, j: None
-    elif isinstance(shift, float):
-        return lambda s, d, i, j: d + s * d.spacing
+    elif sympify(shift).is_Number:
+        return lambda s, d, i, j: d + Rational(s) * d.spacing
     elif type(shift) is tuple and np.shape(shift) == ndim:
         if len(ndim) == 1:
             return lambda s, d, i, j: d + s[j] * d.spacing

--- a/devito/symbolics/printer.py
+++ b/devito/symbolics/printer.py
@@ -7,6 +7,7 @@ import sympy
 
 from mpmath.libmp import prec_to_dps, to_str
 from packaging.version import Version
+
 from sympy.logic.boolalg import BooleanFunction
 from sympy.printing.precedence import PRECEDENCE_VALUES, precedence
 from sympy.printing.c import C99CodePrinter
@@ -185,6 +186,7 @@ class CodePrinter(C99CodePrinter):
             dps = 0
         else:
             dps = prec_to_dps(expr._prec)
+
         if self._settings["full_prec"] is True:
             strip = False
         elif self._settings["full_prec"] is False:

--- a/tests/test_tensors.py
+++ b/tests/test_tensors.py
@@ -1,5 +1,6 @@
 import numpy as np
 import sympy
+from sympy import Rational
 
 import pytest
 
@@ -372,7 +373,8 @@ def test_shifted_lap_of_vector(shift, ndim):
             assert dfvi == ref
 
 
-@pytest.mark.parametrize('shift, ndim', [(None, 2), (.5, 2), (.5, 3),
+@pytest.mark.parametrize('shift, ndim', [(None, 2), (Rational(1/2), 2),
+                                         (Rational(1/2), 3),
                                          (tuple([tuple([.5]*3)]*3), 3)])
 def test_shifted_lap_of_tensor(shift, ndim):
     grid = Grid(tuple([11]*ndim))


### PR DESCRIPTION
Was preventing this

https://github.com/devitocodes/devito/blob/779522508a45d677f233811846fcc7eb36cea916/examples/seismic/tti/operators.py#L158

to simplify leading to `u.dx2 + u.dy2 - u.dy2` expressions....