### PR TITLE
dsl: Add ArgProvider inheritance to AbstractSymbol

### DIFF
--- a/devito/types/basic.py
+++ b/devito/types/basic.py
@@ -297,7 +297,7 @@ class Basic(CodeSymbol):
         return set()
 
 
-class AbstractSymbol(sympy.Symbol, Basic, Pickable, Evaluable, ArgProvider):
+class AbstractSymbol(sympy.Symbol, Basic, Pickable, Evaluable):
 
     """
     Base class for scalar symbols.
@@ -526,7 +526,7 @@ class Symbol(AbstractSymbol, Cached):
     __hash__ = Cached.__hash__
 
 
-class DataSymbol(AbstractSymbol, Uncached):
+class DataSymbol(AbstractSymbol, Uncached, ArgProvider):
 
     """
     A unique scalar symbol that carries data.
@@ -549,7 +549,7 @@ class DataSymbol(AbstractSymbol, Uncached):
     __hash__ = Uncached.__hash__
 
 
-class Scalar(Symbol):
+class Scalar(Symbol, ArgProvider):
 
     """
     Like a Symbol, but in addition it can pass runtime values to an Operator.

--- a/devito/types/basic.py
+++ b/devito/types/basic.py
@@ -297,7 +297,7 @@ class Basic(CodeSymbol):
         return set()
 
 
-class AbstractSymbol(sympy.Symbol, Basic, Pickable, Evaluable):
+class AbstractSymbol(sympy.Symbol, Basic, Pickable, Evaluable, ArgProvider):
 
     """
     Base class for scalar symbols.
@@ -549,7 +549,7 @@ class DataSymbol(AbstractSymbol, Uncached):
     __hash__ = Uncached.__hash__
 
 
-class Scalar(Symbol, ArgProvider):
+class Scalar(Symbol):
 
     """
     Like a Symbol, but in addition it can pass runtime values to an Operator.

--- a/devito/types/constant.py
+++ b/devito/types/constant.py
@@ -2,13 +2,12 @@ import numpy as np
 
 from devito.exceptions import InvalidArgument
 from devito.logger import warning
-from devito.types.args import ArgProvider
 from devito.types.basic import DataSymbol
 
 __all__ = ['Constant']
 
 
-class Constant(DataSymbol, ArgProvider):
+class Constant(DataSymbol):
 
     """
     Symbol representing a constant, scalar value in symbolic equations.

--- a/devito/types/dimension.py
+++ b/devito/types/dimension.py
@@ -570,9 +570,6 @@ class Thickness(DataSymbol):
     def value(self):
         return self._value
 
-    def _arg_check(self, *args, **kwargs):
-        pass
-
     def _arg_values(self, grid=None, **kwargs):
         # Allow override of thickness values to disable BCs
         # However, arguments from the user are considered global
@@ -596,12 +593,6 @@ class Thickness(DataSymbol):
             tkn = rtkn or 0
 
         return {self.name: tkn}
-
-    def _arg_finalize(self, *args, **kwargs):
-        return {}
-
-    def _arg_apply(self, *args, **kwargs):
-        pass
 
 
 class AbstractSubDimension(DerivedDimension):


### PR DESCRIPTION
Adds a default no-op `_arg_values`, `_arg_check` etc to any subclasses of `AbstractSymbol`.