### PR TITLE
compiler: Check `sympy_type` returns a floating `point type` in the code printer

### DIFF
--- a/devito/symbolics/printer.py
+++ b/devito/symbolics/printer.py
@@ -44,7 +44,10 @@ class CodePrinter(C99CodePrinter):
         return self._settings['compiler']
 
     def single_prec(self, expr=None):
+        # Extract the dtype of the expression
         dtype = sympy_dtype(expr) if expr is not None else self.dtype
+        # Check that the dtype is a floating point type
+        dtype = dtype if np.issubdtype(dtype, np.floating) else self.dtype
         return dtype in [np.float32, np.float16]
 
     def parenthesize(self, item, level, strict=False):

--- a/devito/symbolics/printer.py
+++ b/devito/symbolics/printer.py
@@ -170,12 +170,12 @@ class CodePrinter(C99CodePrinter):
         # AOMPCC errors with abs, always use fabs
         if isinstance(self.compiler, AOMPCompiler):
             return "fabs(%s)" % self._print(expr.args[0])
-        # Check if argument is an integer
-        if has_integer_args(*expr.args[0].args):
+        # Check if argument (always exactly one!) is an integer
+        if has_integer_args(expr.args[0]):
             func = "abs"
-        elif self.single_prec(expr):
+        elif self.single_prec(expr.args[0]):
             func = "fabsf"
-        elif any([isinstance(a, Real) for a in expr.args[0].args]):
+        elif isinstance(expr.args[0], Real):
             # The previous condition isn't sufficient to detect case with
             # Python `float`s in that case, fall back to the "default"
             func = "fabsf" if self.single_prec() else "fabs"

--- a/devito/types/dimension.py
+++ b/devito/types/dimension.py
@@ -128,10 +128,11 @@ class Dimension(ArgProvider):
         This is only necessary for backwards compatibility, as originally
         there was no BasicDimension (i.e., Dimension was just the top class).
         """
+        # Dimensions can only be integers, so pass this assumption to the constructor
         if cls is Dimension:
-            return BasicDimension(*args, **kwargs)
+            return BasicDimension(*args, integer=True, **kwargs)
         else:
-            return BasicDimension.__new__(cls, *args, **kwargs)
+            return BasicDimension.__new__(cls, *args, integer=True, **kwargs)
 
     @classmethod
     def class_key(cls):

--- a/tests/test_symbolics.py
+++ b/tests/test_symbolics.py
@@ -313,7 +313,7 @@ def test_cos_vs_cosf():
 
     # Doesn't make much sense, but it's legal
     c = dSymbol('c', dtype=np.int32)
-    assert ccode(cos(c)) == "cos(c)"
+    assert ccode(cos(c)) == "cosf(c)"
 
 
 def test_intdiv():


### PR DESCRIPTION
This aims to fix a bug in code generation for certain platforms