### PR TITLE
api: fix backward compatibility of Substitution, missing function check

### DIFF
--- a/devito/finite_differences/derivative.py
+++ b/devito/finite_differences/derivative.py
@@ -307,7 +307,8 @@ class Derivative(sympy.Derivative, Differentiable, Pickable):
         if self in subs:
             new = subs.pop(self)
             try:
-                return new._xreplace(subs)
+                new, flag = new._xreplace(subs)
+                return new, True
             except AttributeError:
                 return new, True
 

--- a/devito/finite_differences/tools.py
+++ b/devito/finite_differences/tools.py
@@ -265,7 +265,7 @@ def generate_indices(expr, dim, order, side=None, matvec=None, x0=None, nweights
     if nweights > 0:
         do, dw = order + 1 + order % 2, nweights
         if do < dw:
-            raise ValueError(f"More weights ({nweights}) provided than the maximum"
+            raise ValueError(f"More weights ({nweights}) provided than the maximum "
                              f"stencil size ({order + 1}) for order {order} scheme")
         elif do > dw:
             warning(f"Less weights ({nweights}) provided than the stencil size"

--- a/devito/types/equation.py
+++ b/devito/types/equation.py
@@ -90,6 +90,7 @@ class Eq(sympy.Eq, Evaluable, Pickable):
         for coeff in coefficients.coefficients:
             derivs = [d for d in retrieve_derivatives(expr)
                       if coeff.dimension in d.dims and
+                      coeff.function in d.expr._functions and
                       coeff.deriv_order == d.deriv_order.get(coeff.dimension, None)]
             if not derivs:
                 continue


### PR DESCRIPTION
Fix backward compat that was applying weights to all derivative missing the `coeff.function` check