### PR TITLE
tests: Remove floating point equality assertions

### DIFF
--- a/tests/test_symbolics.py
+++ b/tests/test_symbolics.py
@@ -712,7 +712,7 @@ def test_pow_precision(dtype, expected):
     op.apply()
 
     assert expected in str(op)
-    assert np.all(f.data == 8.0)
+    assert np.allclose(f.data, 8.0, rtol=np.finfo(dtype).eps)
 
 
 @pytest.mark.parametrize('dtype,expected', [


### PR DESCRIPTION
I'm guessing we are going to find more