### PR TITLE
api: Add retrocompat to is_imaginary for older sympy

### DIFF
--- a/devito/types/basic.py
+++ b/devito/types/basic.py
@@ -429,7 +429,12 @@ class AbstractSymbol(sympy.Symbol, Basic, Pickable, Evaluable):
         return not self.is_imaginary
 
     def _eval_is_imaginary(self):
-        return np.iscomplexobj(self.dtype(0))
+        try:
+            return np.iscomplexobj(self.dtype(0))
+        except TypeError:
+            # Non-callabale dtype, likely non-numpy
+            # Assuming it's not complex
+            return False
 
     @property
     def indices(self):

--- a/tests/test_symbolics.py
+++ b/tests/test_symbolics.py
@@ -15,7 +15,7 @@ from devito.symbolics import (retrieve_functions, retrieve_indexed, evalrel,  # 
                               INT, FieldFromComposite, IntDiv, Namespace, Rvalue,
                               ReservedWord, ListInitializer, uxreplace, pow_to_mul,
                               retrieve_derivatives, BaseCast, SizeOf)
-from devito.tools import as_tuple
+from devito.tools import as_tuple, CustomDtype
 from devito.types import (Array, Bundle, FIndexed, LocalObject, Object,
                           ComponentAccess, StencilDimension, Symbol as dSymbol)
 from devito.types.basic import AbstractSymbol
@@ -912,3 +912,15 @@ def test_print_div():
     b = SizeOf(np.int64)
     cstr = ccode(a / b)
     assert cstr == 'sizeof(int)/sizeof(long)'
+
+
+def test_customdtype_complex():
+    """
+    Test that `CustomDtype` doesn't brak is_imag
+    """
+    grid = Grid(shape=(4, 4))
+
+    f = Function(name='f', grid=grid, dtype=CustomDtype('notnumpy'))
+
+    assert not f.is_imaginary
+    assert f.is_real


### PR DESCRIPTION
Fix backward compatibilty for sympy 1.12, where `is_imaginary` is sometimes called during arithmetic operations 