### PR TITLE
deps: Add upper bound to all deps to avoid surprises

### DIFF
--- a/requirements-nvidia.txt
+++ b/requirements-nvidia.txt
@@ -1,6 +1,6 @@
-cupy-cuda12x
-dask-cuda
-jupyterlab>=3
-jupyterlab-nvdashboard
-dask_labextension
-fsspec
+cupy-cuda12x<13.4.2
+dask-cuda<25.4.1
+jupyterlab>=3,<4.4.2
+jupyterlab-nvdashboard<0.13.1
+dask_labextension<7.0.1
+fsspec<2025.3.3

--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -1,5 +1,5 @@
-matplotlib
-pillow>11
+matplotlib<3.10.2
+pillow>11,<11.2.2
 pyrevolve==2.2.4
-scipy
-distributed
+scipy<1.15.3
+distributed<2025.4.2

--- a/requirements-testing.txt
+++ b/requirements-testing.txt
@@ -1,8 +1,7 @@
 pytest>=7.2,<9.0
-pytest-runner
-pytest-cov
-codecov
-flake8>=2.1.0
-nbval
-scipy
-pooch
+pytest-runner<6.0.2
+pytest-cov<6.1.2
+flake8>=2.1.0,<7.2.1
+nbval<0.11.1
+scipy<1.15.3
+pooch<1.8.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,10 +3,10 @@ numpy>1.16,<2.3
 sympy>=1.9,<1.14
 psutil>=5.1.0,<8.0
 py-cpuinfo<10
-cgen>=2020.1
+cgen>=2020.1,<2021
 codepy>=2019.1,<2025
 click<9.0
 multidict<6.3
 anytree>=2.4.3,<=2.13.0
-cloudpickle
-packaging
+cloudpickle<3.1.2
+packaging<25.1


### PR DESCRIPTION
Add an upper bound to all dependencies to avoid nasty surprises, forcing every dependency change to go through CI with the dependabot.