### PR TITLE
arch: fix json erro with no card

### DIFF
--- a/devito/arch/archinfo.py
+++ b/devito/arch/archinfo.py
@@ -328,7 +328,7 @@ def get_gpu_info():
 
         return gpu_info
 
-    except OSError:
+    except (json.JSONDecodeError, OSError):
         pass
 
     # *** Third try: `sycl-ls`, clearly only works with Intel cards


### PR DESCRIPTION
Makes cache line size detection error when there is no GPU (json.loads line 302 errors with empty lines)