### PR TITLE
compiler: Lazy IET visitors + Search

### DIFF
--- a/devito/ir/iet/visitors.py
+++ b/devito/ir/iet/visitors.py
@@ -1194,6 +1194,7 @@ class FindWithin(FindNodes, LazyVisitor[Node, list[Node], bool]):
 
         # Update the flag if we found a stop
         flag &= (o is not self.stop)
+
         return flag
 
 

--- a/devito/ir/iet/visitors.py
+++ b/devito/ir/iet/visitors.py
@@ -68,27 +68,21 @@ class LazyVisitor(GenericVisitor, Generic[ResultType]):
     A generic visitor that lazily yields results instead of flattening results
     from children at every step.
 
-    Subclass-defined visit methods (and default_retval) should be generators.
+    Subclass-defined visit methods should be generators.
     """
-
-    @classmethod
-    def default_retval(cls) -> Iterator[Any]:
-        yield from ()
 
     def lookup_method(self, instance) -> Callable[..., Iterator[Any]]:
         return super().lookup_method(instance)
 
     def _visit(self, o, *args, **kwargs) -> Iterator[Any]:
-        """Visit `o`."""
         meth = self.lookup_method(o)
         yield from meth(o, *args, **kwargs)
 
     def _post_visit(self, ret: Iterator[Any]) -> ResultType:
-        """Postprocess the visitor output before returning it to the caller."""
         return list(ret)
 
     def visit_object(self, o: object, **kwargs) -> Iterator[Any]:
-        yield from self.default_retval()
+        yield from ()
 
     def visit_Node(self, o: Node, **kwargs) -> Iterator[Any]:
         yield from self._visit(o.children, **kwargs)
@@ -1053,6 +1047,7 @@ class FindSymbols(LazyVisitor[list[Any]]):
         - `defines-aliases`: Collect all defined objects and their aliases
     """
 
+    @staticmethod
     def _defines_aliases(n):
         for i in n.defines:
             f = i.function

--- a/devito/symbolics/search.py
+++ b/devito/symbolics/search.py
@@ -104,14 +104,15 @@ def search(exprs: Expression | Iterable[Expression],
     # Search doesn't actually use a BFS (rather, a preorder DFS), but the terminology
     # is retained in this function's parameters for backwards compatibility
     searcher = Search(Q, deep)
-    if visit == 'dfs':
-        _search = searcher.visit_postorder
-    elif visit == 'bfs':
-        _search = searcher.visit_preorder
-    elif visit == 'bfs_first_hit':
-        _search = searcher.visit_preorder_first_hit
-    else:
-        raise ValueError(f"Unknown visit mode '{visit}'")
+    match visit:
+        case 'dfs':
+            _search = searcher.visit_postorder
+        case 'bfs':
+            _search = searcher.visit_preorder
+        case 'bfs_first_hit':
+            _search = searcher.visit_preorder_first_hit
+        case _:
+            raise ValueError(f"Unknown visit mode '{visit}'")
 
     exprs = filter(lambda e: isinstance(e, sympy.Basic), as_tuple(exprs))
     found = modes[mode](chain(*map(_search, exprs)))

--- a/devito/symbolics/search.py
+++ b/devito/symbolics/search.py
@@ -17,25 +17,19 @@ __all__ = ['retrieve_indexed', 'retrieve_functions', 'retrieve_function_carriers
 Expression = sympy.Basic | np.number | int | float
 
 
-class Set(set[Expression]):
-    @staticmethod
-    def wrap(obj: Expression) -> set[Expression]:
-        return {obj}
-
-
 class List(list[Expression]):
-    @staticmethod
-    def wrap(obj: Expression) -> list[Expression]:
-        return [obj]
+    """
+    A list that aliases `extend` to `update` to mirror the `set` interface.
+    """
 
     def update(self, obj: Iterable[Expression]) -> None:
         self.extend(obj)
 
 
 Mode = Literal['all', 'unique']
-modes: dict[Mode, type[List] | type[Set]] = {
+modes: dict[Mode, type[List] | type[set[Expression]]] = {
     'all': List,
-    'unique': Set
+    'unique': set
 }
 
 
@@ -97,7 +91,7 @@ def search(exprs: Expression | Iterable[Expression],
            query: type | Callable[[Any], bool],
            mode: Mode = 'unique',
            visit: Literal['dfs', 'bfs', 'bfs_first_hit'] = 'dfs',
-           deep: bool = False) -> List | Set:
+           deep: bool = False) -> List | set[Expression]:
     """Interface to Search."""
 
     assert mode in ('all', 'unique'), "Unknown mode"
@@ -118,7 +112,7 @@ def search(exprs: Expression | Iterable[Expression],
         _search = searcher.visit_preorder_first_hit
     else:
         raise ValueError(f"Unknown visit mode '{visit}'")
-    
+
     exprs = filter(lambda e: isinstance(e, sympy.Basic), as_tuple(exprs))
     found = modes[mode](chain(*map(_search, exprs)))
 

--- a/devito/symbolics/search.py
+++ b/devito/symbolics/search.py
@@ -1,3 +1,8 @@
+from collections.abc import Callable, Iterable, Iterator
+from itertools import chain
+from typing import Any, Literal
+
+import numpy as np
 import sympy
 
 from devito.symbolics.queries import (q_indexed, q_function, q_terminal, q_leaf,
@@ -9,129 +14,113 @@ __all__ = ['retrieve_indexed', 'retrieve_functions', 'retrieve_function_carriers
            'retrieve_derivatives', 'search']
 
 
+Expression = sympy.Basic | np.number | int | float
+
+
+class Set(set[Expression]):
+    @staticmethod
+    def wrap(obj: Expression) -> set[Expression]:
+        return {obj}
+
+
+class List(list[Expression]):
+    @staticmethod
+    def wrap(obj: Expression) -> list[Expression]:
+        return [obj]
+
+    def update(self, obj: Iterable[Expression]) -> None:
+        self.extend(obj)
+
+
+Mode = Literal['all', 'unique']
+modes: dict[Mode, type[List] | type[Set]] = {
+    'all': List,
+    'unique': Set
+}
+
+
 class Search:
-
-    class Set(set):
-
-        @staticmethod
-        def wrap(obj):
-            return {obj}
-
-    class List(list):
-
-        @staticmethod
-        def wrap(obj):
-            return [obj]
-
-        def update(self, obj):
-            return self.extend(obj)
-
-    modes = {
-        'unique': Set,
-        'all': List
-    }
-
-    def __init__(self, query, mode, deep=False):
+    def __init__(self, query: Callable[[Expression], bool], deep: bool = False) -> None:
         """
-        Search objects in an expression. This is much quicker than the more
-        general SymPy's find.
+        Search objects in an expression. This is much quicker than the more general
+        SymPy's find.
 
         Parameters
         ----------
         query
             Any query from :mod:`queries`.
-        mode : str
-            Either 'unique' or 'all' (catch all instances).
         deep : bool, optional
             If True, propagate the search within an Indexed's indices. Defaults to False.
         """
         self.query = query
-        self.collection = self.modes[mode]
         self.deep = deep
 
-    def _next(self, expr):
+    def _next(self, expr: Expression) -> Iterable[Expression]:
         if self.deep and expr.is_Indexed:
             return expr.indices
         elif q_leaf(expr):
             return ()
-        else:
-            return expr.args
+        return expr.args
 
-    def dfs(self, expr):
+    def visit_postorder(self, expr: Expression) -> Iterator[Expression]:
         """
-        Perform a DFS search.
-
-        Parameters
-        ----------
-        expr : expr-like
-            The searched expression.
+        Visit the expression with a postorder traversal, yielding all hits.
         """
-        found = self.collection()
-        for a in self._next(expr):
-            found.update(self.dfs(a))
+        for i in self._next(expr):
+            yield from self.visit_postorder(i)
         if self.query(expr):
-            found.update(self.collection.wrap(expr))
-        return found
+            yield expr
 
-    def bfs(self, expr):
+    def visit_preorder(self, expr: Expression) -> Iterator[Expression]:
         """
-        Perform a BFS search.
-
-        Parameters
-        ----------
-        expr : expr-like
-            The searched expression.
+        Visit the expression with a preorder traversal, yielding all hits.
         """
-        found = self.collection()
         if self.query(expr):
-            found.update(self.collection.wrap(expr))
-        for a in self._next(expr):
-            found.update(self.bfs(a))
-        return found
+            yield expr
+        for i in self._next(expr):
+            yield from self.visit_preorder(i)
 
-    def bfs_first_hit(self, expr):
+    def visit_preorder_first_hit(self, expr: Expression) -> Iterator[Expression]:
         """
-        Perform a BFS search, returning immediately when a node matches the query.
-
-        Parameters
-        ----------
-        expr : expr-like
-            The searched expression.
+        Visit the expression in preorder and return a tuple containing the first hit,
+        if any. This can return more than a single result, as it looks for the first
+        hit from any branch but may find a hit in multiple branches.
         """
-        found = self.collection()
         if self.query(expr):
-            found.update(self.collection.wrap(expr))
-            return found
-        for a in self._next(expr):
-            found.update(self.bfs_first_hit(a))
-        return found
+            yield expr
+            return
+        for i in self._next(expr):
+            yield from self.visit_preorder_first_hit(i)
 
 
-def search(exprs, query, mode='unique', visit='dfs', deep=False):
+def search(exprs: Expression | Iterable[Expression],
+           query: type | Callable[[Any], bool],
+           mode: Mode = 'unique',
+           visit: Literal['dfs', 'bfs', 'bfs_first_hit'] = 'dfs',
+           deep: bool = False) -> List | Set:
     """Interface to Search."""
 
-    assert mode in Search.modes, "Unknown mode"
+    assert mode in ('all', 'unique'), "Unknown mode"
 
     if isinstance(query, type):
         Q = lambda obj: isinstance(obj, query)
     else:
         Q = query
 
-    searcher = Search(Q, mode, deep)
-
-    found = Search.modes[mode]()
-    for e in as_tuple(exprs):
-        if not isinstance(e, sympy.Basic):
-            continue
-
-        if visit == 'dfs':
-            found.update(searcher.dfs(e))
-        elif visit == 'bfs':
-            found.update(searcher.bfs(e))
-        elif visit == "bfs_first_hit":
-            found.update(searcher.bfs_first_hit(e))
-        else:
-            raise ValueError("Unknown visit type `%s`" % visit)
+    # Search doesn't actually use a BFS (rather, a preorder DFS), but the terminology
+    # is retained in this function's parameters for backwards compatibility
+    searcher = Search(Q, deep)
+    if visit == 'dfs':
+        _search = searcher.visit_postorder
+    elif visit == 'bfs':
+        _search = searcher.visit_preorder
+    elif visit == 'bfs_first_hit':
+        _search = searcher.visit_preorder_first_hit
+    else:
+        raise ValueError(f"Unknown visit mode '{visit}'")
+    
+    exprs = filter(lambda e: isinstance(e, sympy.Basic), as_tuple(exprs))
+    found = modes[mode](chain(*map(_search, exprs)))
 
     return found
 


### PR DESCRIPTION
This PR implements lazy visitors in the IET layer which operate via generators instead of flattening lists of children's results at every node. Replaces `FindSymbols`, `FindNodes`, `FindWithin` and `FindApplications` with such versions, as well as introducing type hints for the affected visitors.

From my testing this results in a speedup in IET lowering of up to 50%.

Also reimplements `Search` similarly, benchmarks forthcoming.