### PR TITLE
ci: Fix pytest regression

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -3,4 +3,3 @@ python_files = test_*.py *_example.py example_*.py
 addopts = --durations=20 --maxfail=5
 filterwarnings =
     ignore::pytest.PytestCacheWarning
-    ignore::pytest.PytestReturnNotNoneWarning

--- a/requirements-testing.txt
+++ b/requirements-testing.txt
@@ -1,4 +1,4 @@
-pytest>=7.2,<9.0
+pytest>=7.2,<8.5
 pytest-runner<6.0.2
 pytest-cov<6.1.2
 flake8-pyproject>=1.2.3,<1.2.4


### PR DESCRIPTION
There is a regression in pytest 8.4 from the undocumented removal of `PytestReturnNotNoneWarning`, which was previously ignored in CI via `pytest.ini`. This PR just removes the line that ignores that warning.