### PR TITLE
compiler: Revamp MPI hoisting and merging

### DIFF
--- a/devito/ir/iet/nodes.py
+++ b/devito/ir/iet/nodes.py
@@ -1516,8 +1516,8 @@ class HaloSpot(Node):
         return self.halo_scheme.arguments
 
     @property
-    def is_empty(self):
-        return len(self.halo_scheme) == 0
+    def is_void(self):
+        return self.halo_scheme.is_void
 
     @property
     def body(self):

--- a/devito/ir/iet/visitors.py
+++ b/devito/ir/iet/visitors.py
@@ -1145,7 +1145,10 @@ class FindWithin(FindNodes):
         if flag and self.rule(self.match, o):
             found.append(o)
         for i in o.children:
-            found, flag = self._visit(i, ret=(found, flag))
+            found, newflag = self._visit(i, ret=(found, flag))
+            if flag and not newflag:
+                return found, newflag
+            flag = newflag
 
         if o is self.stop:
             flag = False

--- a/devito/ir/support/basic.py
+++ b/devito/ir/support/basic.py
@@ -385,7 +385,7 @@ class TimedAccess(IterationInstance, AccessMode):
             # Compute the distance along the current IterationInterval
             if self.function._mem_shared:
                 # Special case: the distance between two regular, thread-shared
-                # objects fallbacks to zero, as any other value would be
+                # objects falls back to zero, as any other value would be
                 # nonsensical
                 ret.append(S.Zero)
             elif degenerating_dimensions(sai, oai):

--- a/devito/mpi/halo_scheme.py
+++ b/devito/mpi/halo_scheme.py
@@ -389,6 +389,10 @@ class HaloScheme:
         return mapper
 
     @cached_property
+    def functions(self):
+        return frozenset(self.fmapper)
+
+    @cached_property
     def dimensions(self):
         retval = set()
         for i in set().union(*self.halos.values()):

--- a/devito/mpi/halo_scheme.py
+++ b/devito/mpi/halo_scheme.py
@@ -441,8 +441,9 @@ class HaloScheme:
                 return False
 
             loc_dirs = hse0.loc_dirs
-            loc_indices = {**hse0.loc_indices, **hse1.loc_indices}
-            projected_loc_indices, _ = process_loc_indices(loc_indices, loc_dirs)
+            raw_loc_indices = {d: (hse0.loc_indices[d], hse1.loc_indices[d])
+                               for d in hse0.loc_indices}
+            projected_loc_indices, _ = process_loc_indices(raw_loc_indices, loc_dirs)
             if projected_loc_indices != hse1.loc_indices:
                 return False
 

--- a/devito/mpi/halo_scheme.py
+++ b/devito/mpi/halo_scheme.py
@@ -43,7 +43,7 @@ class HaloSchemeEntry(EnrichedTuple):
         return hash((self.loc_indices, self.loc_dirs, self.halos, self.dims,
                      self.bundle))
 
-    @property
+    @cached_property
     def loc_values(self):
         return frozenset(self.loc_indices.values())
 

--- a/devito/passes/iet/mpi.py
+++ b/devito/passes/iet/mpi.py
@@ -386,7 +386,9 @@ def _rule0(dep, hs, loc_indices):
 
 def _rule1(dep, hs, loc_indices):
     # E.g., `dep=W<f,[t1, x+1]> -> R<f,[t1, xl+1]>` and `loc_indices={t: t0}` => True
-    return any(dep.distance_mapper[d] == 0 and dep.source[d] is not v
+    return any(dep.distance_mapper[d] == 0 and
+               dep.source[d] is not v and
+               dep.sink[d] is not v
                for d, v in loc_indices.items())
 
 

--- a/devito/passes/iet/mpi.py
+++ b/devito/passes/iet/mpi.py
@@ -458,9 +458,6 @@ def _derive_scope(it, hs0, hs1):
     and ends at the HaloSpot `hs1`.
     """
     expressions = FindWithin(Expression, hs0, stop=hs1).visit(it)
-    assert len(expressions) > 0, \
-        "Expected at least one Expression between %s and %s" % (hs0, hs1)
-
     return Scope([e.expr for e in expressions])
 
 
@@ -515,8 +512,5 @@ def _is_mergeable(hsf0, hsf1, scope):
        not hsf0.functions & hsf1.functions:
         return False
 
-    # Then, check the data dependences would be satisfied
-    if not _is_iter_carried(hsf1, scope):
-        return False
-
-    return True
+    # Finally, check the data dependences would be satisfied
+    return _is_iter_carried(hsf1, scope)

--- a/devito/passes/iet/mpi.py
+++ b/devito/passes/iet/mpi.py
@@ -41,7 +41,7 @@ def _drop_reduction_halospots(iet):
 
     # If all HaloSpot reads pertain to reductions, then the HaloSpot is useless
     for hs, expressions in MapNodes(HaloSpot, Expression).visit(iet).items():
-        scope = Scope([i.expr for i in expressions])
+        scope = Scope(i.expr for i in expressions)
         for f, v in scope.reads.items():
             if f in hs.fmapper and all(i.is_reduction for i in v):
                 mapper[hs].add(f)
@@ -79,7 +79,7 @@ def _hoist_redundant_from_conditionals(iet):
 
     mapper = HaloSpotMapper()
     for it, halo_spots in iter_mapper.items():
-        scope = Scope([e.expr for e in FindNodes(Expression).visit(it)])
+        scope = Scope(e.expr for e in FindNodes(Expression).visit(it))
 
         for hs0 in halo_spots:
             conditions = cond_mapper[hs0]
@@ -156,6 +156,7 @@ def _merge_halospots(iet):
                 # `hsf1` out of `it`, otherwise we just drop it
                 if hsf0.loc_values != hsf1.loc_values:
                     continue
+
                 mapper.drop(hs1, f)
 
     iet = mapper.apply(iet)
@@ -278,7 +279,7 @@ def _mark_overlappable(iet):
         if not expressions:
             continue
 
-        scope = Scope([i.expr for i in expressions])
+        scope = Scope(i.expr for i in expressions)
 
         # Comp/comm overlaps is legal only if the OWNED regions can grow
         # arbitrarly, which means all of the dependences must be carried
@@ -448,8 +449,8 @@ def _make_cond_mapper(iet):
     """
     Return a mapper from HaloSpots to the Conditionals that contain them.
     """
-    return {hs: tuple(i for i in v if i.is_Conditional)
-            for hs, v in MapHaloSpots().visit(iet).items()}
+    mapper = MapHaloSpots().visit(iet)
+    return {hs: tuple(i for i in v if i.is_Conditional) for hs, v in mapper.items()}
 
 
 def _derive_scope(it, hs0, hs1):
@@ -458,7 +459,7 @@ def _derive_scope(it, hs0, hs1):
     and ends at the HaloSpot `hs1`.
     """
     expressions = FindWithin(Expression, hs0, stop=hs1).visit(it)
-    return Scope([e.expr for e in expressions])
+    return Scope(e.expr for e in expressions)
 
 
 def _check_control_flow(hs0, hs1, cond_mapper):

--- a/tests/test_dle.py
+++ b/tests/test_dle.py
@@ -169,9 +169,10 @@ def test_cache_blocking_structure_distributed(mode):
     eqns += [Eq(U.forward, U.dx + u.forward)]
 
     op = Operator(eqns)
+    op.cfunction
 
     bns0, _ = assert_blocking(op._func_table['compute0'].root, {'x0_blk0'})
-    bns1, _ = assert_blocking(op, {'x1_blk0'})
+    bns1, _ = assert_blocking(op._func_table['compute2'].root, {'x1_blk0'})
 
     for i in [bns0['x0_blk0'], bns1['x1_blk0']]:
         iters = FindNodes(Iteration).visit(i)


### PR DESCRIPTION
besides making things generally more efficient, by generating code that sometimes avoids redundant halo exchanges, we are here achieving:

fixes #2622 