### PR TITLE
compiler: fix deque pop order

### DIFF
--- a/devito/passes/clusters/cse.py
+++ b/devito/passes/clusters/cse.py
@@ -279,7 +279,8 @@ def _toposort(exprs):
             first = sorted(tmps, key=lambda i: i.lhs.name).pop(0)
             queue.remove(first)
         else:
-            first = queue.popleft()
+            first = sorted(queue, key=lambda i: exprs.index(i)).pop(0)
+            queue.remove(first)
         return first
 
     processed = dag.topological_sort(choose_element)

--- a/devito/passes/clusters/cse.py
+++ b/devito/passes/clusters/cse.py
@@ -279,7 +279,7 @@ def _toposort(exprs):
             first = sorted(tmps, key=lambda i: i.lhs.name).pop(0)
             queue.remove(first)
         else:
-            first = queue.pop()
+            first = queue.popleft()
         return first
 
     processed = dag.topological_sort(choose_element)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 pip>=9.0.1
-numpy>=2,<2.3.0
+numpy>=2,<2.3.1
 sympy>=1.12.1,<1.15
 psutil>=5.1.0,<8.0
 py-cpuinfo<10


### PR DESCRIPTION
`.pop` is `popright` by default, it reverses eq order right now breaking a lot of things.