### PR TITLE
deps: Bump upper NumPy version to 2.3.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 pip>=9.0.1
-numpy>=2,<2.3.1
+numpy>=2,<=2.3.1
 sympy>=1.12.1,<1.15
 psutil>=5.1.0,<8.0
 py-cpuinfo<10


### PR DESCRIPTION
Missed by Dependabot for some reason