### PR TITLE
compiler: Fixup nbytes-avail-mapper

### DIFF
--- a/devito/operator/operator.py
+++ b/devito/operator/operator.py
@@ -1343,7 +1343,11 @@ class ArgumentsMap(dict):
                     continue
                 try:
                     if i._mem_mapped:
-                        mapper[device_layer] -= i.nbytes
+                        try:
+                            v = self[i.name]._obj.nbytes
+                        except AttributeError:
+                            v = i.nbytes
+                        mapper[device_layer] -= v
                 except AttributeError:
                     pass
 


### PR DESCRIPTION
We need to use the runtime overrides