### PR TITLE
compiler: Call set_device in pthreads

### DIFF
--- a/devito/passes/iet/asynchrony.py
+++ b/devito/passes/iet/asynchrony.py
@@ -170,7 +170,7 @@ def _(iet, key=None, tracker=None, sregistry=None, **kwargs):
                 DummyExpr(i._C_symbol, FieldFromPointer(i._C_symbol, sbase))
             )
         else:
-            unpacks.append(DummyExpr(i, FieldFromPointer(i.base, sbase)))
+            unpacks.append(DummyExpr(i, FieldFromPointer(i.base, sbase), init=True))
 
     body = iet.body._rebuild(body=[wrap, Return(Null)], unpacks=unpacks)
     iet = ThreadCallable(iet.name, body, tparameter)


### PR DESCRIPTION
Without this, MPI+GPU runs might end up allocating extra memory (e.g. pinned memory buffers inside the runtime library) on rank0's GPU because each thread is expected to call set_device() explicitly (yes, even children threads)