### PR TITLE
install: Remove files and directories not needed for install

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,7 +1,16 @@
-include versioneer.py
-include devito/_version.py
+# Explicitly include the requirements files
 include requirements.txt
 include requirements-optional.txt
 include requirements-testing.txt
 include requirements-mpi.txt
 include requirements-nvidia.txt
+
+# Exclude the Github, Binder and Docker directories
+prune .github
+prune binder
+prune docker
+# Exclude hidden files and YAML files
+exclude .* *.yml
+
+# Exclude compiled and temporary files
+global-exclude *~ *.py[cod] *.so

--- a/devito/builtins/arithmetic.py
+++ b/devito/builtins/arithmetic.py
@@ -180,20 +180,28 @@ def inner(f, g):
     return f.dtype(n.data[0])
 
 
-red_doc = lambda func: f"""
-    Retrieve the {func}imum.
+def mmin(f):
+    """
+    Retrieve the minimum.
 
     Parameters
     ----------
     f : array_like or Function
         Input operand.
     """
+    return _reduce_func(f, np.min, dv.mpi.MPI.MIN)
 
 
-mmin = lambda f: _reduce_func(f, np.min, dv.mpi.MPI.MIN)
-mmin.__doc__ = red_doc('min')
-mmax = lambda f: _reduce_func(f, np.max, dv.mpi.MPI.MAX)
-mmax.__doc__ = red_doc('max')
+def mmax(f):
+    """
+    Retrieve the maximum.
+
+    Parameters
+    ----------
+    f : array_like or Function
+        Input operand.
+    """
+    return _reduce_func(f, np.max, dv.mpi.MPI.MAX)
 
 
 @dv.switchconfig(log_level='ERROR')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,8 +64,7 @@ extras = { file = ["requirements-optional.txt"] }
 
 [tool.setuptools.packages.find]
 where   = ["."]
-exclude = ["docs", "tests", "examples"]
-
+exclude = ["binder", "docker", "docs", "tests", "examples"]
 
 [tool.setuptools_scm]
 fallback_version = "0+untagged"


### PR DESCRIPTION
Removes unnecessary files from sdist and wheel builds.

This prevents directories such as `docker` appearing in `site-packages` when a non-editable install is performed