### PR TITLE
compiler: Intify StencilDimension attributes

### DIFF
--- a/devito/types/dimension.py
+++ b/devito/types/dimension.py
@@ -1567,9 +1567,9 @@ class StencilDimension(BasicDimension):
         if not is_integer(step):
             raise ValueError("Expected integer `step` (got %s)" % step)
 
-        self._min = _min
-        self._max = _max
-        self._step = step
+        self._min = int(_min)
+        self._max = int(_max)
+        self._step = int(step)
 
         self._size = _max - _min + 1
 


### PR DESCRIPTION
Test in PRO as you need to work hard with substitutions to trigger the following error inside sympy

```
/venv/lib/python3.10/site-packages/sympy/core/basic.py:413: in compare
    c = l.compare(r)
/venv/lib/python3.10/site-packages/sympy/core/basic.py:419: in compare
    c = (l > r) - (l < r)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = True, other = False

    def _noop(self, other=None):
>       raise TypeError('BooleanAtom not allowed in this context.')
E       TypeError: BooleanAtom not allowed in this context.
```

This is nothing relevant -- just a stupid exception when sympy needs to establish if A should precede B (or the other way round) in the arguments list of a given expression (in this case, of IndexDerivatives)