### PR TITLE
deps: bump numpy supported ver

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 pip>=9.0.1
-numpy>=2,<=2.3.1
+numpy>=2,<=2.3.3
 sympy>=1.12.1,<1.15
 psutil>=5.1.0,<8.0
 py-cpuinfo<10


### PR DESCRIPTION
Missed by dependabot because it has a Python >= 3.11 requirement, so the bot thinks it's not compatible.