### PR TITLE
dsl: Dimension off by one mistake

### DIFF
--- a/devito/types/dimension.py
+++ b/devito/types/dimension.py
@@ -1041,7 +1041,7 @@ class ConditionalDimension(DerivedDimension):
                     raise ValueError(f"Incompatible size for ConditionalDimension "
                                      f"{self.name}: {size} < {size0}")
             else:
-                defaults[dim.parent.max_name] = range(d0, d0 + factor*size - 1)
+                defaults[dim.parent.max_name] = range(d0, d0 + factor*size)
 
         return defaults
 


### PR DESCRIPTION
As reported by Dylan Stark, an off-by-one in `ConditionalDimension._arg_defaults` breaks decoupler `time_M` reduction.