### PR TITLE
fix: permute Data._decomposition and _modulo on transpose (fixes #2187)

### DIFF
--- a/devito/data/data.py
+++ b/devito/data/data.py
@@ -208,6 +208,57 @@ class Data(np.ndarray):
     def __str__(self):
         return super(Data, self._local).__str__()
 
+    def transpose(self, *axes):
+        """
+        Return a view of ``self`` with permuted axes.
+
+        Overridden so that ``_decomposition``, ``_modulo`` (and the convenience
+        flag ``_is_distributed``) are permuted to match the new axis ordering,
+        rather than copied verbatim from ``self`` as ``__array_finalize__``
+        would otherwise leave them. Without this, a subsequent slice on the
+        transposed view (e.g. ``f.data.T[::2, ::2]``) is computed against the
+        wrong per-axis decomposition and silently returns a wrong-shaped
+        result (see issue #2187).
+        """
+        # Accept the same axis-spec forms as ``numpy.ndarray.transpose``:
+        # no args, a single ``None``, a single tuple/list, or per-arg.
+        if len(axes) == 1:
+            axes = as_tuple(axes[0])
+        new_order = (
+            tuple(range(self.ndim - 1, -1, -1)) if not axes
+            else tuple(ax % self.ndim for ax in axes)
+        )
+
+        ret = super().transpose(*axes)
+        ret._decomposition = tuple(self._decomposition[i] for i in new_order)
+        ret._modulo = tuple(self._modulo[i] for i in new_order)
+        ret._is_distributed = any(d is not None for d in ret._decomposition)
+        return ret
+
+    def swapaxes(self, axis1, axis2):
+        """
+        Return a view of ``self`` with ``axis1`` and ``axis2`` swapped, with
+        ``_decomposition`` / ``_modulo`` swapped in the same way (see
+        :meth:`transpose`).
+        """
+        axis1 = axis1 % self.ndim
+        axis2 = axis2 % self.ndim
+        ret = super().swapaxes(axis1, axis2)
+        order = list(range(self.ndim))
+        order[axis1], order[axis2] = order[axis2], order[axis1]
+        ret._decomposition = tuple(self._decomposition[i] for i in order)
+        ret._modulo = tuple(self._modulo[i] for i in order)
+        ret._is_distributed = any(d is not None for d in ret._decomposition)
+        return ret
+
+    @property
+    def T(self):
+        """
+        The transposed array. Overridden so the C-level ``ndarray.T`` shortcut
+        also permutes the per-axis metadata (see :meth:`transpose`).
+        """
+        return self.transpose()
+
     @_check_idx
     def __getitem__(self, glb_idx, comm_type, gather_rank=None):
         loc_idx = self._index_glb_to_loc(glb_idx)

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -211,6 +211,78 @@ class TestDataBasic:
         sf.data[1:-1, 0] = np.arange(8)
         assert np.all(sf.data[1:-1, 0] == np.arange(8))
 
+    def test_slice_after_transpose(self):
+        """
+        Slicing a ``Data`` view that has been transposed (via ``.T``,
+        ``transpose`` or ``swapaxes``) must use the new axis ordering for
+        per-axis metadata. Previously the metadata was copied verbatim from
+        the un-transposed array, so a subsequent slice was computed against
+        the wrong decomposition and silently returned a wrong-shaped result
+        (see issue #2187).
+        """
+        grid = Grid(shape=(4, 6))
+        f = Function(name='f', grid=grid)
+        f.data[:] = np.arange(24).reshape((4, 6)).astype(np.float32)
+        ref = np.array(f.data)
+
+        # ``.T`` (C-level shortcut) then slice
+        assert np.array_equal(f.data.T[::2, ::2], ref.T[::2, ::2])
+
+        # Equivalent: slice then ``.T``
+        assert np.array_equal(f.data[::2, ::2].T, ref[::2, ::2].T)
+
+        # Explicit ``transpose`` call -- same behavior as ``.T``
+        assert np.array_equal(f.data.transpose()[::2, ::2],
+                              ref.transpose()[::2, ::2])
+
+        # ``swapaxes`` between non-conforming dims
+        assert np.array_equal(f.data.swapaxes(0, 1)[::2, ::2],
+                              ref.swapaxes(0, 1)[::2, ::2])
+
+        # 3D transpose with an explicit axis order, then per-axis slice
+        grid3 = Grid(shape=(2, 4, 6))
+        g = Function(name='g3', grid=grid3)
+        g.data[:] = np.arange(48).reshape((2, 4, 6)).astype(np.float32)
+        ref3 = np.array(g.data)
+
+        assert np.array_equal(g.data.T[::2, ::2, ::2], ref3.T[::2, ::2, ::2])
+        assert np.array_equal(g.data.transpose((1, 0, 2))[::2, ::1, ::3],
+                              ref3.transpose((1, 0, 2))[::2, ::1, ::3])
+
+    def test_transpose_permutes_data_metadata(self):
+        """
+        After a transpose-like operation, ``_decomposition`` and ``_modulo``
+        must be permuted to match the new axis order so that subsequent
+        ``__getitem__`` translations use the right per-axis ranges.
+        """
+        grid = Grid(shape=(4, 6))
+        f = Function(name='f', grid=grid)
+
+        original_decomp = f.data._decomposition
+        assert len(original_decomp) == 2
+
+        # ``.T`` reverses everything
+        tdata = f.data.T
+        assert tdata._decomposition == original_decomp[::-1]
+        assert tdata._modulo == f.data._modulo[::-1]
+
+        # ``transpose()`` with no args == ``.T``
+        tdata2 = f.data.transpose()
+        assert tdata2._decomposition == original_decomp[::-1]
+
+        # ``swapaxes`` swaps the two named axes
+        sdata = f.data.swapaxes(0, 1)
+        assert sdata._decomposition == (original_decomp[1], original_decomp[0])
+
+        # Explicit axis-order
+        grid3 = Grid(shape=(2, 4, 6))
+        g = Function(name='g3', grid=grid3)
+        gdec = g.data._decomposition
+        perm = g.data.transpose((1, 2, 0))
+        assert perm._decomposition == (gdec[1], gdec[2], gdec[0])
+        assert perm._modulo == (g.data._modulo[1], g.data._modulo[2],
+                                g.data._modulo[0])
+
     @pytest.mark.parallel(mode=1)
     def test_indexing_into_sparse_subfunc_singlempi(self, mode):
         grid = Grid(shape=(4, 4))


### PR DESCRIPTION
# Fix: permute `Data._decomposition` / `_modulo` on transpose

Fixes #2187.

## Problem

A `Data` view created via `.T`, `transpose(...)` or `swapaxes(...)`
inherited the source's `_decomposition` and `_modulo` tuples unchanged
through `__array_finalize__` (the `self.ndim == obj.ndim` branch
explicitly does `self._modulo = obj._modulo`,
`self._decomposition = obj._decomposition`). Both tuples are indexed by
*axis*, so after the axes are permuted they point at the wrong
dimensions. A subsequent slice goes through `__getitem__` →
`_index_glb_to_loc(glb_idx)`, which uses the (stale) `_decomposition`
to translate the global slice into local-axis ranges, and silently
returns a wrong-shaped view.

The minimal example from #2187:

```python
import numpy as np
from devito import Grid, Function

grid = Grid(shape=(4, 6))
f = Function(name='f', grid=grid)

# NumPy reference -- expected shape (3, 2):
np.zeros((4, 6)).T[::2, ::2].shape   # (3, 2)

# Devito on `main` -- wrong shape:
f.data.T[::2, ::2].shape             # (2, 2)
```

`f.data[::2, ::2].T` (slice *then* transpose) works because the slice
goes through `__getitem__` first and the second-step transpose only
flips a 2-element metadata tuple whose entries are already aligned.

## Why both `transpose()` and `T` need overriding

`ndarray.T` is a C-level shortcut: it does *not* dispatch through
Python's `transpose` method on a subclass. Verified directly:

```python
class A(np.ndarray):
    def transpose(self, *axes): print("called!"); return super().transpose(*axes)

a = np.zeros((3, 4)).view(A)
a.T              # silent -- C path
a.transpose()    # prints "called!"
np.transpose(a)  # prints "called!"
```

So overriding `transpose` alone leaves `.T` buggy; overriding `T` alone
leaves explicit `transpose` / `swapaxes` calls buggy. Three thin
overrides are added on `Data`:

* **`transpose(*axes)`** — normalize `axes` (no-arg, single
  tuple/list/iterable, or per-arg individual axes), call
  `super().transpose`, then permute `_decomposition` / `_modulo` into
  the new axis order and refresh `_is_distributed` so it stays
  consistent.
* **`swapaxes(axis1, axis2)`** — same treatment for the two-axis case.
* **`T`** — explicit Python property that forwards to `transpose()`.

## Verification

The two new tests in `tests/test_data.py::TestDataBasic`:

* `test_slice_after_transpose` — covers `.T`, `transpose()`,
  `transpose((1, 0, 2))`, `swapaxes(0, 1)`, in both 2D and 3D, with
  the NumPy reference array as the source of truth (shape **and**
  values are compared).
* `test_transpose_permutes_data_metadata` — asserts
  `_decomposition` / `_modulo` end up in the new order (reverse for
  `.T`, swap for `swapaxes`, explicit permutation for
  `transpose((1, 2, 0))`).

Local run on `main` HEAD (no MPI installed; MPI-only tests pre-existing
failures are unchanged):

```console
$ pytest tests/test_data.py -v -k "not gather and not singlempi and not Distributed and not mpi"
============ 37 passed, 2 skipped, ...
$ pytest tests/test_pickle.py tests/test_dimension.py -k "not parallel"
============ 600 passed, ...
$ ruff check devito/data/data.py tests/test_data.py
All checks passed!
```

## Scope

Just `devito/data/data.py` (production fix) and `tests/test_data.py`
(regression tests). No public API change — `transpose` / `T` /
`swapaxes` signatures are unchanged; behavior matches NumPy.
