### PR TITLE
compiler: Guard cond_mapper lookup in halo hoisting (fix nested HaloSpot KeyError)

### DIFF
--- a/devito/passes/iet/mpi.py
+++ b/devito/passes/iet/mpi.py
@@ -88,7 +88,7 @@ def _hoist_redundant_from_conditionals(iet):
         scope = Scope(e.expr for e in FindNodes(Expression).visit(it))
 
         for hs0 in halo_spots:
-            conditions = cond_mapper[hs0]
+            conditions = cond_mapper.get(hs0)
             if not conditions:
                 continue
             condition = conditions[-1]  # Take the innermost Conditional


### PR DESCRIPTION
Fixes #2943.

`_hoist_redundant_from_conditionals` (`devito/passes/iet/mpi.py`) iterated every halo_spot from `_filter_iter_mapper` and did an **unguarded** `cond_mapper[hs0]`, raising `KeyError` for a **nested HaloSpot** (one whose subtree contains another HaloSpot) — `_make_cond_mapper` does not register nested HaloSpots as keys. This switches to the defensive `cond_mapper.get(hs0)` already used in `_merge_halospots`; the existing `if not conditions: continue` handles the absent-key case, so behaviour is preserved for present keys.

Minimal reproducer + before/after output are in #2943. The reproducer also verifies this exact fix by monkeypatching `_make_cond_mapper` to return a `defaultdict(list)`. Confirmed on current `main`.

Happy to add a regression test under `tests/` if you'd like — let me know the preferred home (it needs a nested-HaloSpot SubDomain layout).