### PR TITLE
FD weights: 17-digit C literals + canonicalized Taylor weights (fixes #2976)

### DIFF
--- a/devito/finite_differences/finite_difference.py
+++ b/devito/finite_differences/finite_difference.py
@@ -1,6 +1,7 @@
 from collections.abc import Iterable
 from contextlib import suppress
 
+import sympy
 from sympy import sympify
 
 from devito.logger import warning
@@ -22,9 +23,38 @@ __all__ = [
     'transpose',
 ]
 
-# Number of digits for FD coefficients to avoid roundup errors and non-deterministic
-# code generation
-_PRECISION = 9
+# Number of digits for FD coefficients. 17 significant digits is the minimum that
+# round-trips an IEEE-754 double exactly, so the C literals the printer emits parse
+# back to the exact rational weight (sub-ULP); evalf is deterministic, so code
+# generation stays deterministic. (The previous value, 9, truncated the weights at
+# ~1.7e-10 relative -- see issue #2976.)
+_PRECISION = 17
+
+
+def _canonicalize_weight(w):
+    """Render a weight's numeric atoms as canonical fixed-precision Floats.
+
+    Taylor weights are mathematically rational, but depending on the route a
+    stencil is built through (e.g. a float ``x0`` shift) they can arrive as
+    binary-float approximations that differ in the last ULP between routes,
+    which would make otherwise-identical stencils compare unequal. Recover the
+    nearby rational when one exists within 5e-14 relative (float-route Fornberg
+    recursions accumulate ~1e-14 relative error; an arbitrary float far from a
+    small rational maps to a rational of the same double value, so
+    non-rational user-supplied coefficients are value-preserved), then render
+    at ``_PRECISION`` so the emitted C literal round-trips the intended double
+    exactly.
+    """
+    def _canon(a):
+        try:
+            r = sympy.Rational(a).limit_denominator(10**12)
+        except (TypeError, ValueError, ZeroDivisionError):
+            return a
+        if a == 0 or abs(float(r) - float(a)) <= 5e-14 * abs(float(a)):
+            return r
+        return a
+
+    return w.replace(lambda a: a.is_Float, _canon).evalf(_PRECISION)
 
 
 @check_input
@@ -168,23 +198,32 @@ def make_derivative(expr, dim, fd_order, deriv_order, side, matvec, x0, coeffici
                                    x0=x0, nweights=nweights)
     # Finite difference weights corresponding to the indices. Computed via the
     # `coefficients` method (`taylor` or `symbolic`)
+    computed_weights = False
     if weights is None:
         weights = fd_weights_registry[coefficients](expr, deriv_order, indices, x0)
         _, wdim, _ = process_weights(weights, expr, dim)
+        computed_weights = coefficients == 'taylor'
     elif isinstance(weights, Iterable) and len(weights) != len(indices):
         warning(f"Number of weights ({len(weights)}) does not match "
                 f"number of indices ({len(indices)}), reverting to Taylor")
         scale = False
         wdim = None
         weights = fd_weights_registry['taylor'](expr, deriv_order, indices, x0)
+        computed_weights = True
 
     # Did fd_weights_registry return a new Function/Expression instead of a values?
     if wdim is not None:
         weights = [weights._subs(wdim, i) for i in range(len(indices))]
 
-    # Enforce fixed precision FD coefficients to avoid variations in results
+    # Enforce fixed precision FD coefficients to avoid variations in results.
+    # Taylor-computed weights are additionally canonicalized (rational
+    # recovery) so route-dependent float error cannot make identical stencils
+    # compare unequal; user-supplied weights are rendered as-is.
     scale = dim.spacing**(-deriv_order) if scale else 1
-    weights = [sympify(scale * w).evalf(_PRECISION) for w in weights]
+    if computed_weights:
+        weights = [_canonicalize_weight(sympify(scale * w)) for w in weights]
+    else:
+        weights = [sympify(scale * w).evalf(_PRECISION) for w in weights]
 
     # Transpose the FD, if necessary
     if matvec == transpose:

--- a/tests/test_derivatives.py
+++ b/tests/test_derivatives.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+import sympy
 from sympy import Float, Symbol, diff, simplify, sympify
 
 from conftest import assert_structure
@@ -16,7 +17,7 @@ from devito.symbolics import indexify, retrieve_indexed
 from devito.types.dimension import StencilDimension
 from devito.warnings import DevitoWarning
 
-_PRECISION = 9
+from devito.finite_differences.finite_difference import _PRECISION  # noqa
 
 
 def x(grid):
@@ -423,15 +424,15 @@ class TestFD:
 
     @pytest.mark.parametrize('so, expected', [
         (2, 'u(x)/h_x - u(x - h_x)/h_x'),
-        (4, '1.125*u(x)/h_x + 0.0416666667*u(x - 2*h_x)/h_x - '
-            '1.125*u(x - h_x)/h_x - 0.0416666667*u(x + h_x)/h_x'),
+        (4, '1.125*u(x)/h_x + 0.041666666666666667*u(x - 2*h_x)/h_x - '
+            '1.125*u(x - h_x)/h_x - 0.041666666666666667*u(x + h_x)/h_x'),
         (6, '1.171875*u(x)/h_x - 0.0046875*u(x - 3*h_x)/h_x + '
-            '0.0651041667*u(x - 2*h_x)/h_x - 1.171875*u(x - h_x)/h_x - '
-            '0.0651041667*u(x + h_x)/h_x + 0.0046875*u(x + 2*h_x)/h_x'),
-        (8, '1.19628906*u(x)/h_x + 0.000697544643*u(x - 4*h_x)/h_x - '
-            '0.0095703125*u(x - 3*h_x)/h_x + 0.0797526042*u(x - 2*h_x)/h_x - '
-            '1.19628906*u(x - h_x)/h_x - 0.0797526042*u(x + h_x)/h_x + '
-            '0.0095703125*u(x + 2*h_x)/h_x - 0.000697544643*u(x + 3*h_x)/h_x')])
+            '0.065104166666666667*u(x - 2*h_x)/h_x - 1.171875*u(x - h_x)/h_x - '
+            '0.065104166666666667*u(x + h_x)/h_x + 0.0046875*u(x + 2*h_x)/h_x'),
+        (8, '1.1962890625*u(x)/h_x + 0.00069754464285714286*u(x - 4*h_x)/h_x - '
+            '0.0095703125*u(x - 3*h_x)/h_x + 0.079752604166666667*u(x - 2*h_x)/h_x - '
+            '1.1962890625*u(x - h_x)/h_x - 0.079752604166666667*u(x + h_x)/h_x + '
+            '0.0095703125*u(x + 2*h_x)/h_x - 0.00069754464285714286*u(x + 3*h_x)/h_x')])
     def test_fd_new_x0(self, so, expected):
         grid = Grid((10,))
         x = grid.dimensions[0]
@@ -560,10 +561,10 @@ class TestFD:
 
         f = TimeFunction(name='f', grid=grid, space_order=4)
 
-        assert str(f.dx.T.evaluate) == ("-0.0833333333*f(t, x - 2*h_x, y)/h_x "
-                                        "+ 0.666666667*f(t, x - h_x, y)/h_x "
-                                        "- 0.666666667*f(t, x + h_x, y)/h_x "
-                                        "+ 0.0833333333*f(t, x + 2*h_x, y)/h_x")
+        assert str(f.dx.T.evaluate) == ("-0.083333333333333333*f(t, x - 2*h_x, y)/h_x "
+                                        "+ 0.66666666666666667*f(t, x - h_x, y)/h_x "
+                                        "- 0.66666666666666667*f(t, x + h_x, y)/h_x "
+                                        "+ 0.083333333333333333*f(t, x + 2*h_x, y)/h_x")
 
     @pytest.mark.parametrize('so', [2, 4, 8, 12])
     @pytest.mark.parametrize('ndim', [1, 2])
@@ -1461,3 +1462,39 @@ class TestDimension:
         assert Derivative(self.x, self.t)
         assert Derivative(self.x, self.y, self.t)
         assert Derivative(self.x, (self.x, 0))
+
+
+class TestCoefficientPrecision:
+
+    """
+    _PRECISION must round-trip every FD weight to its exact rational value as an
+    IEEE-754 double: the C literal the printer emits is parsed by the compiler to
+    the nearest double, so >= 17 significant digits makes the truncation sub-ULP.
+    With the previous _PRECISION = 9 the order-8 weight 8/315 was emitted as
+    2.53968254e-2 -- a ~1.7e-10 relative coefficient error that silently floored
+    fp64 cross-implementation checks (issue #2976).
+    """
+
+    @pytest.mark.parametrize('p, q', [
+        (-205, 72), (8, 5), (-1, 5), (8, 315), (-1, 560),  # 8th-order d2 weights
+        (-49, 18), (3, 2), (-3, 20), (1, 90),              # 6th-order d2 weights
+        (9, 8), (-1, 24),                                  # 4th-order staggered d1
+    ])
+    def test_fd_weight_literal_roundtrips_fp64(self, p, q):
+        w = sympy.Rational(p, q)
+        emitted = float(sympy.sympify(w).evalf(_PRECISION))
+        exact = p / q
+        assert emitted == exact, (
+            f"{p}/{q}: evalf(_PRECISION={_PRECISION}) -> {emitted!r} != {exact!r} "
+            f"(rel err {abs(emitted - exact) / abs(exact):.3e})")
+
+    def test_evaluated_derivative_floats_roundtrip_fp64(self):
+        grid = Grid(shape=(11, 11))
+        u = Function(name='u_prec', grid=grid, space_order=8)
+        floats = u.dx2.evaluate.atoms(sympy.Float)
+        assert floats, "expected Float weights in the evaluated derivative"
+        for f in floats:
+            r = sympy.nsimplify(f, rational=True, tolerance=1e-8, full=True)
+            assert float(f) == float(r), (
+                f"weight {f} does not round-trip to its rational {r} "
+                f"(rel err {abs(float(f) - float(r)) / abs(float(r)):.3e})")


### PR DESCRIPTION
Fixes #2976.

## What

1. **`_PRECISION` 9 → 17** (`finite_differences/finite_difference.py`). 17 significant digits is the minimum that round-trips an IEEE-754 double, so the C literal parses back to the exact rational weight (sub-ULP) instead of carrying a ~1.7e-10 relative truncation. No runtime cost — only the codegen text changes.

2. **Taylor-weight canonicalization.** Raising the precision exposed a latent inconsistency the 9-digit rendering had been masking (this is what the old "avoid roundup errors" comment was living with): Taylor weights built through a float `x0` shift (e.g. `div(f, shift=.5)`) accumulate ~1e-14 relative float error in the weight recursion, so the *same* stencil built through two routes compared unequal at 17 digits (`0.041666666666666664` vs `…667`, caught by `test_shifted_div`). Taylor-computed weights are now canonicalized — nearby-rational recovery within 5e-14 relative via `Rational(w).limit_denominator(1e12)`, then `evalf(_PRECISION)` — so identical stencils are identical expressions and every emitted literal is the correctly-rounded double of the exact rational. **User-supplied weights (`weights=` / symbolic coefficients) are rendered exactly as before** — canonicalization applies only to the computed Taylor path.

3. **Tests.** `test_derivatives.py` now imports the library `_PRECISION` rather than pinning a local copy (so these exact-equality tests track the library value, like `test_symbolic_coefficients.py` already does); the four 9-digit string expectations are regenerated at 17 digits; and a new `TestCoefficientPrecision` class pins the invariant: every FD weight literal round-trips to its exact rational as a double (this class *fails* at `_PRECISION = 9` — e.g. `8/315` → `2.53968254e-2`, 1.7e-10 off — and passes at 17).

## Why it matters

In a downstream verification corpus we swept 332 Devito-vs-reference gates and found 11 (in 9 projects) whose tolerances had been silently loosened into the 1e-7..1e-9 range specifically to swallow this floor, several with in-code comments like "Devito's generated C rounds the rational stencil coefficients". Each such gate is blind to real coefficient defects at the magnitude its tolerance implies. Details and measurements in #2976.

## Test status

Ran locally (macOS, fp64): `tests/test_derivatives.py` + `tests/test_symbolic_coefficients.py` — 409 passed; `tests/test_unexpansion.py` 25 passed; `tests/test_caching.py` 60 passed. A repo-wide grep found no other 9-digit literal expectations. Please run the full CI matrix — happy to iterate on anything it surfaces.

**Note:** to be reviewed and merged by the devito maintainers (@mloubout) — not by us.