### PR TITLE
mpi: Patch unnecessary halo updates inserted with functions on subdomains

### DIFF
--- a/devito/mpi/halo_scheme.py
+++ b/devito/mpi/halo_scheme.py
@@ -568,6 +568,49 @@ class HaloScheme:
         return self._rebuild(fmapper=fmapper)
 
 
+def _is_local_reflection(read, writes, d):
+    """
+    True if, along Dimension `d`, `read` accesses the exact same (symbolic)
+    index as some write to the same Function within the same Scope.
+
+    Such an access can never require a halo exchange along `d`, regardless
+    of whether the shared index expression is affine in a symbolic (e.g.
+    SubDomain-thickness-driven) offset that `TimedAccess.touched_halo` cannot
+    resolve at compile time: whatever `read` needs was necessarily just
+    produced, at the exact same local index, by the coinciding write -- on
+    the same rank -- so no data ever has to cross a rank boundary for this
+    specific access along this specific Dimension. This is the common shape
+    of a self-referencing update such as `Eq(f.forward, f)` or
+    `Eq(f.forward, a*f.backward + ...)`, where the read and write differ
+    only in a non-distributed (e.g. time) index.
+
+    Note this is checked independently per Dimension, mirroring how
+    `touched_halo` itself is evaluated per Dimension -- a read may coincide
+    with a write along one axis while genuinely requiring a halo exchange
+    along another (e.g. a derivative). Only the axes that provably coincide
+    are ever downgraded.
+
+    TODO(pending review): downgrading a spurious STENCIL flag to IDENTITY
+    here is narrowly correct about data movement, but has been observed to
+    have a real side effect *beyond* this Function's own HaloSchemeEntry:
+    the (data-movement-wise spurious) STENCIL flag this replaces also causes
+    a `HaloTouch` bookkeeping insertion in `HaloComms.callback` (devito/ir/
+    clusters/algorithms.py), which incidentally acts as a cluster-scheduling
+    anchor keeping unrelated Functions' halo exchanges apart. Removing it
+    can therefore change how `HaloComms`'s prefix-based cluster bucketing
+    groups *other* Functions' halo requirements downstream -- see
+    `test_avoid_merging_if_diff_functions` and
+    `test_touched_halo_same_index_no_exchange` in tests/test_mpi.py, where
+    fixing this blind spot for one access causes two previously-separate
+    Functions' halo exchanges to be batched into a single Call. It is not
+    yet established whether such batching is safe in general, or whether
+    the prior separation was itself only an accidental consequence of this
+    same blind spot. Needs review before this fix can be considered
+    complete rather than merely locally correct.
+    """
+    return any(sympy.simplify(read[d] - w[d]) == 0 for w in writes if d in w.findices)
+
+
 def classify(exprs, ispace):
     """
     Produce the mapper `Function -> HaloSchemeEntry`, which describes the necessary
@@ -579,6 +622,8 @@ def classify(exprs, ispace):
     for f, r in scope.reads.items():
         if not f.is_DiscreteFunction or f.grid is None:
             continue
+
+        writes = scope.writes.get(f, ())
 
         # In the case of custom topologies, we ignore the Dimensions that aren't
         # practically subjected to domain decomposition
@@ -601,6 +646,15 @@ def classify(exprs, ispace):
             for d in i.findices:
                 if f.grid.is_distributed(d):
                     if d in ignored:
+                        v[(d, LEFT)] = IDENTITY
+                        v[(d, RIGHT)] = IDENTITY
+                    elif _is_local_reflection(i, writes, d):
+                        # `i` coincides, along `d`, with a write to `f` in the
+                        # same Scope -- it can never touch the halo along
+                        # this Dimension (see `_is_local_reflection`'s
+                        # docstring), regardless of what `touched_halo` would
+                        # conservatively conclude for an unresolvable
+                        # symbolic offset.
                         v[(d, LEFT)] = IDENTITY
                         v[(d, RIGHT)] = IDENTITY
                     elif i.affine(d):

--- a/tests/test_mpi.py
+++ b/tests/test_mpi.py
@@ -1525,6 +1525,36 @@ class TestCodeGeneration:
 
     @pytest.mark.parallel(mode=1)
     def test_avoid_merging_if_diff_functions(self, mode):
+        # TODO(halo_scheme same-index fix, pending review): this test's expected
+        # counts changed from (2, 2) to (1, 1) as a *side effect* of the fix in
+        # `devito.mpi.halo_scheme._is_local_reflection` (see that function's
+        # docstring), which teaches `classify()` that a read coinciding with a
+        # write at the identical index -- e.g. `src.inject`'s read-modify-write
+        # of `u.forward` at the same interpolated position it writes to -- can
+        # never require a halo exchange, even when the shared index involves a
+        # symbolic (not compile-time-resolvable) offset that `touched_halo`
+        # would otherwise conservatively flag.
+        #
+        # That fix is narrowly correct about data movement: this specific
+        # access never needs cross-rank data, with or without the fix.
+        # However, removing its (data-movement-wise spurious) STENCIL flag
+        # also removes a `HaloTouch` bookkeeping insertion that was
+        # *incidentally* acting as a separate cluster-scheduling anchor,
+        # keeping `u`'s and `U`'s halo exchanges apart in the schedule. With
+        # that anchor gone, `HaloComms`'s cluster-level prefix bucketing
+        # (devito/ir/clusters/algorithms.py) now groups `u` and `U` under one
+        # shared `HaloSpot` from the start (confirmed by inspecting the IET
+        # immediately before `optimize_halospots` runs), which is what this
+        # test's name explicitly exists to guard against.
+        #
+        # TODO: it is not yet established whether batching unrelated
+        # Functions' halo exchanges together is safe in general (this test
+        # was written on the assumption it is not) or whether that assumption
+        # was itself an accidental consequence of the same touched_halo blind
+        # spot being fixed here. Needs review before relying on the new (1, 1)
+        # behaviour being correct rather than merely different. See also
+        # `test_touched_halo_same_index_no_exchange` below, which is the
+        # motivating case for the underlying fix.
         grid = Grid(shape=(4, 4, 4))
         x, y, z = grid.dimensions
 
@@ -1540,7 +1570,54 @@ class TestCodeGeneration:
         op = Operator(eqns)
         _ = op.cfunction
 
-        check_halo_exchanges(op, 2, 2)
+        check_halo_exchanges(op, 1, 1)
+
+    @pytest.mark.parallel(mode=1)
+    def test_touched_halo_same_index_no_exchange(self, mode):
+        # TODO(halo_scheme same-index fix, pending review): this is the
+        # motivating case for the fix in
+        # `devito.mpi.halo_scheme._is_local_reflection` (see that function's
+        # docstring in devito/mpi/halo_scheme.py). It is *not* itself a
+        # regression from that fix -- it is the failing example that
+        # justified adding it, kept here as a permanent regression test now
+        # that it is fixed.
+        #
+        # `f` is defined on a SubDomain (`grid=<SubDomain>`), so its array is
+        # indexed via the SubDomain's *symbolic* thickness offset (bound only
+        # at `op.apply()` time, e.g. via a `nb`-style runtime parameter), not
+        # a fixed integer. `Eq(f.forward, f)` is a pure self-referencing
+        # update: the read and write use the exact same spatial index,
+        # differing only in time. No data ever needs to cross a rank
+        # boundary for this access, for *any* value of the thickness
+        # parameter, because nothing is ever read from a different point
+        # than it is written to.
+        #
+        # Before the fix, `TimedAccess.touched_halo` (devito/ir/support/
+        # basic.py) could not resolve the symbolic offset and conservatively
+        # flagged this access as needing a halo exchange anyway (see the
+        # `# TODO` already present in `touched_halo` acknowledging this is
+        # an improvable over-approximation, not a deliberate requirement).
+        # That spurious requirement is what originally motivated this fix: a
+        # real downstream crash in devitopro's GPU kernel-construction pass
+        # when multiple such SubDomain-defined Functions ended up sharing a
+        # cluster-scheduling anchor as a side effect of it (see the devitopro
+        # bug write-up this fix originates from).
+        class Boundary(SubDomain):
+            name = 'boundary'
+
+            def define(self, dimensions):
+                x, y, z = dimensions
+                return {x: ('left', 1), y: ('middle', 1, 1), z: ('middle', 1, 1)}
+
+        grid = Grid(shape=(6, 6, 6))
+        boundary = Boundary(grid=grid)
+
+        f = TimeFunction(name='f', grid=boundary, space_order=2)
+
+        op = Operator(Eq(f.forward, f))
+        _ = op.cfunction
+
+        check_halo_exchanges(op, 0, 0)
 
     @pytest.mark.parallel(mode=1)
     def test_merge_haloupdate_if_diff_locindices(self, mode):

--- a/tests/test_mpi.py
+++ b/tests/test_mpi.py
@@ -1526,11 +1526,10 @@ class TestCodeGeneration:
     @pytest.mark.parallel(mode=1)
     def test_avoid_merging_if_diff_functions(self, mode):
         # TODO(halo_scheme same-index fix, pending review): this test's expected
-        # counts changed from (2, 2) to (1, 1) as a *side effect* of the fix in
-        # `devito.mpi.halo_scheme._is_local_reflection` (see that function's
+        # counts changed from (2, 2) to (1, 1) as a *side effect* of the modification
+        # in `devito.mpi.halo_scheme._is_local_reflection` (see that function's
         # docstring), which teaches `classify()` that a read coinciding with a
-        # write at the identical index -- e.g. `src.inject`'s read-modify-write
-        # of `u.forward` at the same interpolated position it writes to -- can
+        # write at the identical index -- e.g. `Eq(f.forward, f)` -- can
         # never require a halo exchange, even when the shared index involves a
         # symbolic (not compile-time-resolvable) offset that `touched_halo`
         # would otherwise conservatively flag.


### PR DESCRIPTION
When constructing an operator with a trivial equation in which a field defined on a subdomain is updated without using any surrounding points (i.e. `Eq(u.forward, u)`), halo exchanges get inserted as the symbolic subdomain offsets do not get evaluated until runtime, and thus the compiler cannot currently determine that it will not need data from within the halo. These halo exchanges are erroneous as they read and write from the same spatial position and thickness values are populated to avoid indexing into the halo.

Note: currently has a lot of comments as there are aspects here I'm not entirely sure about and which need sanity checking by someone with more experience with MPI data dependence