### PR TITLE
compiler: Avoid CSE capture of opaque DefFunction calls

### DIFF
--- a/devito/passes/clusters/cse.py
+++ b/devito/passes/clusters/cse.py
@@ -13,7 +13,9 @@ except ImportError:
 
 from devito.finite_differences.differentiable import IndexDerivative
 from devito.ir import Cluster, Scope, cluster_pass
-from devito.symbolics import Reserved, estimate_cost, q_leaf, q_terminal, search
+from devito.symbolics import (
+    DefFunction, Reserved, estimate_cost, q_leaf, q_terminal, search
+)
 from devito.symbolics.manipulation import _uxreplace
 from devito.tools import DAG, as_list, as_tuple, extract_dtype, frozendict
 from devito.types import Eq, Symbol, Temp
@@ -462,3 +464,14 @@ def _(expr):
     mapper[Candidate(expr)].append(expr)
 
     return mapper
+
+
+@_catch.register(DefFunction)
+def _(expr):
+    """
+    Handler for opaque C-level calls (e.g. `make_float4(...)`). Their return
+    dtype is invisible to `extract_dtype` -- capturing one would bind it to a
+    temporary of the wrong type (`float r0 = make_float4(...)`) -- and they
+    are not guaranteed to be pure, so they are left untouched.
+    """
+    return {}

--- a/tests/test_cse.py
+++ b/tests/test_cse.py
@@ -11,7 +11,7 @@ from devito.finite_differences.differentiable import diffify
 from devito.ir import Conditional, DummyEq, FindNodes, FindSymbols
 from devito.ir.support import generator
 from devito.passes.clusters.cse import CTemp, _cse
-from devito.symbolics import indexify
+from devito.symbolics import DefFunction, indexify
 from devito.types import Array, Symbol, Temp
 
 
@@ -129,6 +129,29 @@ def test_temp_order():
     assert type(args[0]) is Symbol
     assert type(args[1]) is Temp
     assert type(args[2]) is CTemp
+
+
+def test_deffunction_not_captured():
+    """
+    Opaque C-level calls (DefFunction) must not be CSE-captured: their return
+    dtype is invisible to the type inference (e.g. `make_float4` returns a
+    `float4`, but `extract_dtype` only sees the `float` arguments), so binding
+    one to a temporary declares it with the wrong type and the generated code
+    does not compile.
+    """
+    t0 = Symbol(name='t0', dtype=np.float32)
+    t1 = Symbol(name='t1', dtype=np.float32)
+    a = CTemp(name='a', dtype=np.float32)
+    b = CTemp(name='b', dtype=np.float32)
+    call = DefFunction('make_float4', (t0 + t1, t0 + t1, t0, t1))
+    exprs = [DummyEq(a, call), DummyEq(b, call)]
+
+    counter = generator()
+    make = lambda _: CTemp(name=f'r{counter()}')
+    processed = _cse(exprs, make)
+
+    # The two calls are left in place, uncaptured
+    assert processed == exprs
 
 
 def test_w_conditionals():


### PR DESCRIPTION
CSE registers `sympy.Function` applications as candidates, so an opaque C-level call (`DefFunction`) appearing verbatim on several right-hand sides gets captured into a `CTemp`. The temporary's dtype comes from `extract_dtype`, which only sees the call's free symbols — for a call like `make_float4(r1, r1, r1, r1)` (emitted downstream when vector types are in play) that is `float32`, so the generated code declares

```c
float r0 = make_float4(r1, r1, r1, r1);
```

which nvcc rejects (`no operator "=" matches these operands: float4 = float`; observed as `codepy.CompileError` on staggered/TTI elastic adjoint operators on GPU with vector types enabled).

This adds a `_catch` handler that leaves `DefFunction`s uncaptured: their return dtype is invisible to the type inference, and, being opaque calls, they are not guaranteed to be pure either.