### PR TITLE
compiler: order the async task handshake

### DIFF
--- a/devito/ir/iet/nodes.py
+++ b/devito/ir/iet/nodes.py
@@ -18,7 +18,7 @@ from devito.ir.support import (
     AFFINE, INBOUND, PARALLEL, PARALLEL_IF_ATOMIC, PARALLEL_IF_PVT, SEQUENTIAL,
     VECTORIZED, Forward, PrefetchUpdate, Property, WithLock
 )
-from devito.symbolics import CallFromPointer, ListInitializer
+from devito.symbolics import CallFromPointer, ListInitializer, Macro
 from devito.tools import (
     Signer, as_tuple, ctypes_to_cstr, filter_ordered, filter_sorted, flatten
 )
@@ -61,6 +61,7 @@ __all__ = [
     'Section',
     'Switch',
     'SyncSpot',
+    'ThreadFence',
     'TimedList',
     'Transfer',
     'Using',
@@ -1300,6 +1301,31 @@ class ExpressionBundle(List):
     @property
     def size(self):
         return self.ispace.size
+
+
+class ThreadFence(Call):
+
+    """
+    A memory fence, ordering a thread's accesses either side of it.
+
+    Threads exchanging work through a shared flag need memory ordering on both
+    sides: a release before publishing the flag, and an acquire after observing it.
+    This ensures the state associated with the flag is visible before it is used.
+    Without this ordering, updates may be observed in the wrong order and lost.
+
+    `__atomic_thread_fence` is a compiler builtin, so this renders the same in C
+    and in C++ and needs no header.
+    """
+
+    def __init__(self, order):
+        assert order in ('acquire', 'release')
+        super().__init__('__atomic_thread_fence',
+                         [Macro(f'__ATOMIC_{order.upper()}')])
+        self._order = order
+
+    @property
+    def order(self):
+        return self._order
 
 
 class Prodder(Call):

--- a/devito/passes/iet/asynchrony.py
+++ b/devito/passes/iet/asynchrony.py
@@ -7,7 +7,7 @@ import cgen as c
 from devito.ir import (
     AsyncCall, AsyncCallable, BlankLine, Call, Callable, Conditional, DummyEq, DummyExpr,
     EntryFunction, FindNodes, FindSymbols, Increment, Iteration, List, PointerCast,
-    Return, ThreadCallable, Transformer, While, make_callable, maybe_alias
+    Return, ThreadCallable, ThreadFence, Transformer, While, make_callable, maybe_alias
 )
 from devito.passes.iet.definitions import DataManager
 from devito.passes.iet.engine import iet_pass
@@ -86,6 +86,11 @@ def _lower_async_objs(iet, tracker=None, sregistry=None, **kwargs):
                 arguments.append(i)
         activation.extend([DummyExpr(FieldFromComposite(i.base, sdata[d]), i)
                            for i in arguments])
+
+        # Publishing the request must happen last. Everything the thread depends on
+        # must be visible before this flag is set. `volatile` does not provide that
+        # ordering, so weakly ordered targets could otherwise observe stale state.
+        activation.append(ThreadFence('release'))
         activation.append(
             DummyExpr(FieldFromComposite(sdata.symbolic_flag, sdata[d]), 2)
         )
@@ -138,12 +143,17 @@ def _(iet, key=None, tracker=None, sregistry=None, **kwargs):
     tbase = threads.indexed
 
     # Prepend the SharedData fields available upon thread activation
-    preactions = [DummyExpr(i, FieldFromPointer(i.base, sbase)) for i in ncfields]
+    preactions = [ThreadFence('acquire')]
+    preactions.extend(DummyExpr(i, FieldFromPointer(i.base, sbase))
+                      for i in ncfields)
     preactions.append(BlankLine)
 
     # Append the flag reset
     postactions = [List(body=[
         BlankLine,
+        # Whatever the task produced -- data in a buffer, a lock handed back --
+        # has to be visible before the flag says it is done.
+        ThreadFence('release'),
         DummyExpr(FieldFromPointer(sdata.symbolic_flag, sbase), 1)
     ])]
 

--- a/devito/passes/iet/orchestration.py
+++ b/devito/passes/iet/orchestration.py
@@ -7,7 +7,7 @@ from sympy import Or
 from devito.exceptions import CompilationError
 from devito.ir.iet import (
     AsyncCall, AsyncCallable, BlankLine, Block, BusyWait, Call, Callable, Conditional,
-    DummyExpr, List, SyncSpot, Transformer, derive_parameters, make_callable
+    DummyExpr, List, SyncSpot, ThreadFence, Transformer, derive_parameters, make_callable
 )
 from devito.ir.iet.visitors import Visitor
 from devito.ir.support import (
@@ -53,7 +53,11 @@ class Orchestrator:
     def _make_releaselock(self, iet, sync_ops, *args):
         pre = []
         pre.append(BusyWait(Or(*[CondNe(s.handle, 2) for s in sync_ops])))
+        pre.append(ThreadFence('acquire'))
         pre.extend(DummyExpr(s.handle, 0) for s in sync_ops)
+        # Hand the lock back before anything that follows can be observed --
+        # in particular before the request that asks the thread to refill it.
+        pre.append(ThreadFence('release'))
 
         name = self.sregistry.make_name(prefix="release_lock")
         parameters = derive_parameters(pre, ordering='canonical')

--- a/tests/test_gpu_common.py
+++ b/tests/test_gpu_common.py
@@ -413,11 +413,16 @@ class TestStreaming:
         assert str(sections[0].body[0].body[0].body[0].body[0]) == 'while(lock0[0] == 0);'
         body = op._func_table['release_lock0'].root.body
         assert str(body.body[0].condition) == 'Ne(lock0[0], 2)'
-        assert str(body.body[1]) == 'lock0[0] = 0;'
+        # An acquire fence pairs with the thread's release before the lock is
+        # read back, and a release fence publishes it before the next request
+        assert 'atomic_thread_fence' in str(body.body[1])
+        assert str(body.body[2]) == 'lock0[0] = 0;'
+        assert 'atomic_thread_fence' in str(body.body[3])
         body = op._func_table['activate0'].root.body
         assert str(body.body[0].condition) == 'Ne(sdata0[0].flag, 1)'
         assert str(body.body[1]) == 'sdata0[0].time = time;'
-        assert str(body.body[2]) == 'sdata0[0].flag = 2;'
+        assert 'atomic_thread_fence' in str(body.body[2])
+        assert str(body.body[3]) == 'sdata0[0].flag = 2;'
 
         op.apply(time_M=nt-2)
 
@@ -529,12 +534,15 @@ class TestStreaming:
                 'while(lock0[0] == 0 || lock1[0] == 0);')  # Wait-lock
         body = op._func_table['release_lock0'].root.body
         assert str(body.body[0].condition) == 'Ne(lock0[0], 2) | Ne(lock1[0], 2)'
-        assert str(body.body[1]) == 'lock0[0] = 0;'  # Set-lock
-        assert str(body.body[2]) == 'lock1[0] = 0;'  # Set-lock
+        assert 'atomic_thread_fence' in str(body.body[1])
+        assert str(body.body[2]) == 'lock0[0] = 0;'  # Set-lock
+        assert str(body.body[3]) == 'lock1[0] = 0;'  # Set-lock
+        assert 'atomic_thread_fence' in str(body.body[4])
         body = op._func_table['activate0'].root.body
         assert str(body.body[0].condition) == 'Ne(sdata0[0].flag, 1)'  # Wait-thread
         assert str(body.body[1]) == 'sdata0[0].time = time;'
-        assert str(body.body[2]) == 'sdata0[0].flag = 2;'
+        assert 'atomic_thread_fence' in str(body.body[2])
+        assert str(body.body[3]) == 'sdata0[0].flag = 2;'
         assert len(op._func_table) == 5
         exprs = FindNodes(Expression).visit(op._func_table['copy_to_host0'].root)
         b = 21 if configuration['language'] == 'openacc' else 20  # No `qid` w/ OMP
@@ -597,8 +605,9 @@ class TestStreaming:
         assert str(sections[0].body[0].body[0].body[0].body[0]) ==\
             'while(lock0[t2] == 0);'
         body = op1._func_table['release_lock0'].root.body
+        assert 'atomic_thread_fence' in str(body.body[1])
         for i in range(3):
-            assert 'lock0[t' in str(body.body[1 + i])  # Set-lock
+            assert 'lock0[t' in str(body.body[2 + i])  # Set-lock
         body = op1._func_table['activate0'].root.body
         assert str(body.body[-1]) == 'sdata0[wi0].flag = 2;'
         assert len(op1._func_table) == 5

--- a/tests/test_iet.py
+++ b/tests/test_iet.py
@@ -12,7 +12,7 @@ from devito.ir import SymbolRegistry
 from devito.ir.iet import (
     Call, Callable, CGen, Conditional, Definition, Dereference, DeviceCall, DummyExpr,
     ElementalFunction, FindNodes, FindSymbols, Iteration, KernelLaunch, Lambda, List,
-    Switch, Transformer, filter_iterations, make_callable, make_efunc,
+    Switch, ThreadFence, Transformer, filter_iterations, make_callable, make_efunc,
     retrieve_iteration_tree
 )
 from devito.ir.iet.visitors import sorted_efuncs
@@ -116,6 +116,23 @@ def test_nested_calls_cgen():
     code = CGen().visit(call)
 
     assert str(code) == 'foo(bar());'
+
+
+def test_thread_fence_cgen():
+    """
+    A fence renders as the builtin, which is valid in C and C++ alike.
+
+    Threads that hand work to each other through a shared flag need one either
+    side of the handshake; without them the stores can be observed out of order
+    and a hand-off is lost.
+    """
+    assert str(CGen().visit(ThreadFence('acquire'))) == \
+        '__atomic_thread_fence(__ATOMIC_ACQUIRE);'
+    assert str(CGen().visit(ThreadFence('release'))) == \
+        '__atomic_thread_fence(__ATOMIC_RELEASE);'
+
+    with pytest.raises(AssertionError):
+        ThreadFence('seq_cst')
 
 
 @pytest.mark.parametrize('mode,expected', [


### PR DESCRIPTION
The lock and flag an asynchronous task synchronises on are written by both
threads and declared `volatile`. That re-issues the loads and orders nothing, so
the handshake can lose an update:

```
compute: lock0[0] = 0;      (release_lock0)  -- observed late
         sdata0->flag = 2;  (activate0)      -- observed first
task:    sees the request, delivers lock0[0] = 2, sets flag = 1
compute: the late lock0[0] = 0 lands, wiping the delivery
         the next release_lock0 waits for a 2 nobody will write again
```

Both threads then spin forever — the compute waiting for data whose request it
has already spent, the task waiting to be asked. `lock == 0 && flag == 1` is
reachable only this way: the task sets the lock before the flag, so a completed
cycle must leave the lock at 2. That is the state a stalled run sits in.

## What's here

- `ir/iet/nodes.py` — `ThreadFence`, a `Call` subclass in the same vein as
  `Prodder`, so it renders itself and the passes emit one agreed thing rather
  than each hand-rolling a call.
- `passes/iet/asynchrony.py` — a release before the flag that publishes a
  request, an acquire before the task reads what it stands for, a release
  before the flag that reports completion.
- `passes/iet/orchestration.py` — in `release_lock`, an acquire after the wait
  and a release after the lock is handed back, before the request that refills
  it. `_make_waitlock` wants an acquire too, so the body's reads cannot be
  hoisted above the wait, but adding a second node to that `List` changes the
  IET's shape — a one-node List is denested, a two-node one is not — and
  `test_streaming_fused` matches on that shape. Left out with a note; the
  ordering the deadlock turns on is the store side, which the other five carry.
- `tests/test_iet.py` — `test_thread_fence_cgen`, that the node renders for
  both orders and rejects any other. Runs anywhere.
- `tests/test_gpu_common.py` — the existing lock tests index those two
  callables positionally, so they move with the fences; they also now assert the
  fences are where they should be.

`__atomic_thread_fence` is a compiler builtin valid in C and C++ alike, so the
device targets that render through `CXXPrinter` are unaffected.

Two alternatives considered and rejected:

- declaring the two objects `_Atomic` is the standard-clean fix and satisfies
  ThreadSanitizer, where a fence does not — but `_Atomic` is not valid C++ under
  g++ (`'_Atomic' does not name a type`), and the qualifier mapper is shared with
  `CXXPrinter`, so it would break the CUDA/HIP/SYCL paths. `std::atomic<int>` is
  a type rather than a qualifier and cannot come through that mapper.
- the `Fence` hierarchy in `types/parallel.py` (`ThreadCommit`, `ThreadArrive`,
  `ThreadWait`) reads like the right vocabulary, but those classify Clusters so
  passes cannot reorder across them, and emit nothing.

## Reproducer

Drop this in `debug-scripts/` and run `python async_handshake_deadlock.py 6 900`:
a checkpointed wavefield streamed to disk, written by a forward operator and
read back by an adjoint one, six workers for contention. It needs several
workers — one on its own rarely hits the window.

<details>
<summary>async_handshake_deadlock.py</summary>

```python
"""The async task handshake loses an update and both threads wait forever.

A checkpointed wavefield streamed to disk is written by a forward operator and
read back by an adjoint one.  Each pair hands off through the generated
`lock0`/`flag` protocol roughly once per time step.  Declared `volatile int`
those two objects are neither atomic nor ordered, so a delivery can be lost --
the lock handed back after the value that replaced it -- and then the compute
thread waits for data it has already spent the request for while the task waits
to be asked.  Nothing moves, both threads spin at 100% CPU.

    python debug-scripts/async_handshake_deadlock.py            # 6 workers, 15 min
    python debug-scripts/async_handshake_deadlock.py 4 300      # 4 workers, 5 min

Needs contention: one worker on its own rarely hits the window.  A worker that
goes quiet for over 90 s while still burning CPU is the deadlock; the script
says so and prints what the generated operator declared.
"""

import os
import sys
import time
from multiprocessing import Process, Value

from devitopro import TimeFunction
from devitopro.types.enriched import Disk

from devito import ConditionalDimension, Eq, Function, Grid, Inc, Operator

SHAPE = (240, 200)
SO = 8
NT = 1200          # ~1200 handshakes per operator call, as in a real gradient
FACTOR = 5


def build():
    grid = Grid(shape=SHAPE, extent=(12000., 10000.))
    t_sub = ConditionalDimension(name='t_sub', parent=grid.time_dim,
                                 factor=FACTOR)
    b = Function(name='b', grid=grid, space_order=SO)
    b.data[:] = 0.5
    u = TimeFunction(name='u', grid=grid, space_order=SO, time_order=2)
    v = TimeFunction(name='v', grid=grid, space_order=SO, time_order=2)
    g = Function(name='g', grid=grid)
    usave = TimeFunction(name='usave', grid=grid, space_order=SO, time_order=2,
                         time_dim=t_sub, save=NT // FACTOR + 2, layers=Disk,
                         compression='cvxcompress')

    fwd = Operator([Eq(u.forward, (b * u).laplace + 2 * u - u.backward),
                    Eq(usave, u.forward)])
    adj = Operator([Eq(v.backward, (b * v).laplace + 2 * v - v.forward),
                    Inc(g, usave * v)])
    return fwd, adj, u, v, usave


def declaration(op):
    """How the generated operator guards the handshake."""
    code = str(op.ccode)
    decls = [line.strip() for line in code.splitlines()
             if ('lock0[1]' in line or 'int flag' in line)]
    return decls + [f'{code.count("__atomic_thread_fence")} fence(s)']


def worker(beat, cycles, index):
    fwd, adj, u, v, usave = build()
    if index == 0:                          # one worker reports the code
        print(f'  generated: {"; ".join(declaration(adj))}', flush=True)
    for _ in range(cycles):
        u.data[:] = 0.
        fwd.apply(time_M=NT, dt=1.)
        v.data[:] = 0.
        adj.apply(time_M=NT - FACTOR - 2, dt=1.)
        for f in usave.values() if hasattr(usave, 'values') else [usave]:
            f._reset()
        beat.value = int(time.time())       # heartbeat


def main():
    nworkers = int(sys.argv[1]) if len(sys.argv) > 1 else 6
    budget = int(sys.argv[2]) if len(sys.argv) > 2 else 900
    os.environ.setdefault('OMP_NUM_THREADS', '4')

    beats = [Value('l', 0) for _ in range(nworkers)]
    procs = [Process(target=worker, args=(b, 10 ** 6, i))
             for i, b in enumerate(beats)]
    for p in procs:
        p.start()
    print(f'{nworkers} workers, {budget}s budget', flush=True)

    start = time.time()
    stalled = []
    while time.time() - start < budget and len(stalled) == 0:
        time.sleep(15)
        now = time.time()
        for i, b in enumerate(beats):
            if b.value and now - b.value > 90 and procs[i].is_alive():
                stalled.append(i)
    for p in procs:
        p.terminate()

    if stalled:
        print(f'DEADLOCK: worker(s) {stalled} stopped making progress while '
              f'still running', flush=True)
        return 1
    print(f'no deadlock in {int(time.time() - start)}s', flush=True)
    return 0


if __name__ == '__main__':
    sys.exit(main())
```

</details>

Same script, same budget, only the compiler differing:

| | generated | outcome |
|---|---|---|
| before | `volatile int flag; volatile int lock0[1]`, 0 fences | `DEADLOCK: worker(s) [2] stopped making progress while still running` |
| after | same declarations, 6 fences | `no deadlock in 900s` |

The failing run also trips CvxCompress's own assertion —
`Decompress: nx=216, ny=256, nz=1, nx_check=0` — the compute decompressing a
buffer the task never filled. Same lost update wearing its other face: this does
not only hang, it can hand garbage to the decompressor.

## Notes

Found through a streaming-checkpoint FWI gradient on arm64, where it stalled one
worker in six within minutes. x86's store ordering hides it.

The `test_gpu_common.py` assertions need a device; devitopro carries an
equivalent one for the streaming path, which runs anywhere
(devitocodespro/devitopro#954).
