### PR TITLE
misc: Snapshot the environment when a switchenv is entered

### DIFF
--- a/devito/parameters.py
+++ b/devito/parameters.py
@@ -295,10 +295,14 @@ class switchenv(SwitchDecorator):
     the context manager, so should be used cautiously.
     """
     def __init__(self, params):
-        self.previous = dict(os.environ)
         self.params = params
+        self.previous = {}
 
     def __enter__(self):
+        # Snapshot the environment upon entering, not upon construction, since the
+        # same object is reused across entries, most notably as a decorator
+        self.previous = dict(os.environ)
+
         # Prevent having multiple conflicting device vars, e.g
         # switching CUDA_VISIBLE_DEVICES but having NVIDIA_VISIBLE_DEVICES set.
         from devito.arch.archinfo import device_vars

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -344,3 +344,33 @@ def test_switchenv():
 
     # Make sure the switchenv does not persist to verify switchenv works as intended
     assert dict(os.environ) == previous_environ
+
+
+def test_switchenv_reuse():
+    # Save previous environment
+    previous_environ = dict(os.environ)
+
+    try:
+        # A switchenv is constructed once, when the decorator is applied, and then
+        # reused on every call of the decorated function
+        @switchenv({'TEST_VAR': 'foo'})
+        def foo():
+            return os.environ['TEST_VAR']
+
+        # Set after the decorator has been applied, so it is not visible to an
+        # environment snapshot taken at construction time
+        os.environ['TEST_VAR_LATE'] = 'bar'
+
+        assert foo() == 'foo'
+        assert os.environ.get('TEST_VAR') is None
+        assert os.environ['TEST_VAR_LATE'] == 'bar'
+
+        # Same story for a switchenv reused as a context manager
+        cm = switchenv({'TEST_VAR': 'foo'})
+        os.environ['TEST_VAR_LATER'] = 'baz'
+        with cm:
+            assert os.environ['TEST_VAR'] == 'foo'
+        assert os.environ['TEST_VAR_LATER'] == 'baz'
+    finally:
+        os.environ.clear()
+        os.environ.update(previous_environ)


### PR DESCRIPTION
`switchenv.__exit__` restores the environment with `os.environ.clear()` followed by `os.environ.update(self.previous)`, but `self.previous` is captured in `switchenv.__init__` (devito/parameters.py), so it dates from construction rather than from entry. `SwitchDecorator.__call__` wraps the decorated function in `with self`, so a `switchenv` used as a decorator is built once, when the decorator is applied, and entered on every call. The first call therefore rewinds the environment to how it looked at decoration time, deleting every variable set since. Same story for a `switchenv` object kept around and reused as a context manager.

On main:

```python
import os
from devito import switchenv

@switchenv({'FOO': 'inside'})
def f():
    return os.environ['FOO']

os.environ['SET_LATER'] = 'keepme'
f()
print(os.environ.get('SET_LATER'))  # None, was 'keepme'
```

The sibling `switchconfig` already rebuilds `self.previous` at the top of `__enter__`. This does the same in `switchenv`, taking the snapshot before the device vars are popped so that a single use restores exactly what it restored before. Every existing call site builds the object inline in a `with` statement, where construction and entry are adjacent, so none of them change behaviour.

Verified on macOS with `DEVITO_ARCH=clang`. The new `tests/test_tools.py::test_switchenv_reuse` fails on unmodified main with `KeyError: 'TEST_VAR_LATE'` and passes with the fix. `pytest tests/test_tools.py` gives 32 passed and `pytest tests/test_environment.py` gives 1 passed. `isort --check-only .`, `ruff check --preview`, `flake8 --builtins=ArgumentError .` and `typos` are all clean.
